### PR TITLE
Fix the jog-test crash family: pump ordering, drain baseline, clocksync consolidation

### DIFF
--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -192,7 +192,11 @@ class ClockSync:
         cb = self._clock_est_callback
         if cb is not None:
             try:
-                cb(new_freq, self.time_avg + self.min_half_rtt, int(self.clock_avg))
+                cb(
+                    new_freq,
+                    self.time_avg + self.min_half_rtt,
+                    int(self.clock_avg),
+                )
             except Exception:
                 logging.exception("clocksync: set_clock_est callback")
         # logging.debug("regr %.3f: freq=%.3f d=%d(%.3f)",

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -49,8 +49,8 @@ class ClockSync:
             try:
                 cb(
                     self.clock_est[2],
-                    self.time_avg + TRANSMIT_EXTRA,
-                    self.last_clock,
+                    self.time_avg + self.min_half_rtt,
+                    int(self.clock_avg),
                 )
             except Exception:
                 logging.exception("clocksync: initial set_clock_est callback")
@@ -186,10 +186,13 @@ class ClockSync:
             new_freq,
         )
         # Mirror the regression update into the motion_bridge.
+        # Export the same triple as clock_est: (freq, time_avg+min_half_rtt,
+        # clock_avg).  TRANSMIT_EXTRA is a serialqueue scheduling bias — not a
+        # projection parameter — and must not contaminate the router anchor.
         cb = self._clock_est_callback
         if cb is not None:
             try:
-                cb(new_freq, self.time_avg + TRANSMIT_EXTRA, clock)
+                cb(new_freq, self.time_avg + self.min_half_rtt, int(self.clock_avg))
             except Exception:
                 logging.exception("clocksync: set_clock_est callback")
         # logging.debug("regr %.3f: freq=%.3f d=%d(%.3f)",

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -90,7 +90,14 @@ class ClockSync:
 
     # MCU clock querying (_handle_clock is invoked from background thread)
     def _get_clock_event(self, eventtime):
-        self.serial.raw_send(self.get_clock_cmd, 0, 0, self.cmd_queue)
+        # In bridge mode raw_send is a no-op (no C serialqueue). Use the
+        # dedicated bridge path that captures a RAW timestamp before the send
+        # and stamps the unsolicited "clock" response with it, giving an
+        # honest RTT for min_half_rtt tracking.
+        if hasattr(self.serial, "bridge_get_clock_async"):
+            self.serial.bridge_get_clock_async()
+        else:
+            self.serial.raw_send(self.get_clock_cmd, 0, 0, self.cmd_queue)
         self.queries_pending += 1
         # Use an unusual time for the next event so clock messages
         # don't resonate with other periodic events.
@@ -215,7 +222,7 @@ class ClockSync:
         return last_clock + clock_diff
 
     def is_active(self):
-        return True
+        return self.queries_pending <= 4
 
     def dump_debug(self):
         sample_time, clock, freq = self.clock_est

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1653,12 +1653,19 @@ class MCU:
             bridge = self._motion_bridge
             handle = self._bridge_handle
 
+            reactor = self._reactor
+
             def _bridge_clock_est_cb(
-                freq, offset, last_clock, b=bridge, h=handle
+                freq, offset, last_clock, b=bridge, h=handle, r=reactor
             ):
+                host_now_raw = r.monotonic()
                 try:
                     b.set_clock_est(
-                        h, float(freq), float(offset), int(last_clock)
+                        h,
+                        float(freq),
+                        float(offset),
+                        int(last_clock),
+                        host_now_raw,
                     )
                 except Exception:
                     logging.exception("motion_bridge: set_clock_est failed")

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1923,8 +1923,7 @@ class MCU:
         return
 
     def check_active(self, print_time, eventtime):
-        # Bridge mode: clock sync runs through motion_bridge; the legacy
-        # steppersync clock-calibration path no longer has work to do here.
+        self._clocksync.calibrate_clock(print_time, eventtime)
         if (
             self._clocksync.is_active()
             or self.is_fileoutput()

--- a/klippy/motion_bridge.py
+++ b/klippy/motion_bridge.py
@@ -202,8 +202,10 @@ class MotionBridgeWrapper:
     def get_stats(self, handle):
         return self._bridge.get_stats(handle)
 
-    def set_clock_est(self, handle, freq, offset, last_clock):
-        return self._bridge.set_clock_est(handle, freq, offset, last_clock)
+    def set_clock_est(self, handle, freq, offset, last_clock, host_now_raw):
+        return self._bridge.set_clock_est(
+            handle, freq, offset, last_clock, host_now_raw
+        )
 
     def bridge_get_clock_async(self, handle):
         return self._bridge.bridge_get_clock_async(handle)

--- a/klippy/motion_bridge.py
+++ b/klippy/motion_bridge.py
@@ -205,6 +205,9 @@ class MotionBridgeWrapper:
     def set_clock_est(self, handle, freq, offset, last_clock):
         return self._bridge.set_clock_est(handle, freq, offset, last_clock)
 
+    def bridge_get_clock_async(self, handle):
+        return self._bridge.bridge_get_clock_async(handle)
+
     def extract_old(self, handle):
         return self._bridge.extract_old(handle)
 

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -574,9 +574,19 @@ class SerialReader:
                 msg,
                 response,
             )
-            now = self.reactor.monotonic()
-            params["#sent_time"] = now
-            params["#receive_time"] = now
+            # Use CLOCK_MONOTONIC_RAW timestamps if the Rust bridge supplied them
+            # (non-zero means a real RTT was measured on the wire).  Fall back to
+            # reactor.monotonic() only when both sides stamp the same instant (the
+            # old behaviour, which gives half_rtt=0 and breaks min_half_rtt).
+            sent_raw = params.get("#sent_time_raw", 0.0)
+            recv_raw = params.get("#receive_time_raw", 0.0)
+            if sent_raw != 0.0 and recv_raw != 0.0:
+                params["#sent_time"] = sent_raw
+                params["#receive_time"] = recv_raw
+            else:
+                now = self.reactor.monotonic()
+                params["#sent_time"] = now
+                params["#receive_time"] = now
             return params
         raise error("send_with_response requires motion bridge")
 

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -154,6 +154,14 @@ class SerialReader:
                 if sent_raw != 0.0 and recv_raw != 0.0:
                     ev["#sent_time"] = sent_raw
                     ev["#receive_time"] = recv_raw
+                elif name == "clock":
+                    # A clock sample without wire stamps (missed interception,
+                    # duplicate, late arrival) must be DROPPED by clocksync —
+                    # fabricating sent==recv here would feed half_rtt=0 into
+                    # min_half_rtt and permanently bias the estimate.
+                    # _handle_clock's `if not sent_time: return` does the drop.
+                    ev["#sent_time"] = 0.0
+                    ev["#receive_time"] = now
                 else:
                     ev["#sent_time"] = now
                     ev["#receive_time"] = now

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -146,8 +146,17 @@ class SerialReader:
                         ev.get("trigger_reason"),
                     )
                 ev["#name"] = name
-                ev["#sent_time"] = now
-                ev["#receive_time"] = now
+                # Use CLOCK_MONOTONIC_RAW stamps when the Rust bridge supplied
+                # them (non-zero); this happens for "clock" responses dispatched
+                # via bridge_get_clock_async so _handle_clock sees honest RTTs.
+                sent_raw = ev.get("#sent_time_raw", 0.0)
+                recv_raw = ev.get("#receive_time_raw", 0.0)
+                if sent_raw != 0.0 and recv_raw != 0.0:
+                    ev["#sent_time"] = sent_raw
+                    ev["#receive_time"] = recv_raw
+                else:
+                    ev["#sent_time"] = now
+                    ev["#receive_time"] = now
                 oid = ev.get("oid")
                 with self.lock:
                     hdl = (
@@ -517,6 +526,19 @@ class SerialReader:
             self._error("non-critical MCU is disconnected")
 
     # Command sending
+    def bridge_get_clock_async(self):
+        """Send a get_clock request through the bridge with RAW timestamp
+        capture.  Used by clocksync._get_clock_event to replace the no-op
+        raw_send path.  The response arrives via take_runtime_event as a
+        PassthroughResponse with sent_time_raw/recv_time_raw filled in."""
+        bridge = getattr(self.mcu, "_motion_bridge", None)
+        if bridge is None:
+            return
+        handle = self.mcu._bridge_handle
+        if handle is None:
+            return
+        bridge.bridge_get_clock_async(handle)
+
     def raw_send(self, cmd, minclock, reqclock, cmd_queue):
         self._check_noncritical_disconnected()
         if self.serialqueue is not None:

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -475,11 +475,13 @@ class SerialReader:
     def set_clock_est(self, freq, conv_time, conv_clock, last_clock):
         if self.mcu._motion_bridge is None:
             return
+        host_now_raw = self.reactor.monotonic()
         self.mcu._motion_bridge.set_clock_est(
             self.mcu._bridge_handle,
             float(freq),
             float(conv_time),
             int(conv_clock),
+            host_now_raw,
         )
 
     def disconnect(self):
@@ -530,7 +532,14 @@ class SerialReader:
         """Send a get_clock request through the bridge with RAW timestamp
         capture.  Used by clocksync._get_clock_event to replace the no-op
         raw_send path.  The response arrives via take_runtime_event as a
-        PassthroughResponse with sent_time_raw/recv_time_raw filled in."""
+        PassthroughResponse with sent_time_raw/recv_time_raw filled in.
+
+        This no-arg form is the hasattr target in clocksync._get_clock_event
+        (``hasattr(self.serial, "bridge_get_clock_async")``); it resolves the
+        MCU handle internally.  MotionBridgeWrapper also exposes a
+        bridge_get_clock_async(handle) method — passing a wrapper object where
+        a SerialReader is expected would TypeError at the hasattr call site
+        because the wrapper's method requires an explicit handle argument."""
         bridge = getattr(self.mcu, "_motion_bridge", None)
         if bridge is None:
             return

--- a/rust/kalico-host-rt/src/clock.rs
+++ b/rust/kalico-host-rt/src/clock.rs
@@ -5,7 +5,7 @@
 //! CLOCK_MONOTONIC_RAW diverge (i.e. under NTP slew). On non-Linux platforms it
 //! falls back to `Instant` (CLOCK_MONOTONIC).
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 /// Read CLOCK_MONOTONIC_RAW and return the value as seconds since an arbitrary
@@ -30,12 +30,31 @@ pub fn monotonic_raw_secs() -> f64 {
     }
     #[cfg(not(target_os = "linux"))]
     {
-        use std::sync::OnceLock;
-        static ANCHOR: OnceLock<Instant> = OnceLock::new();
-        let anchor = ANCHOR.get_or_init(Instant::now);
-        Instant::now()
-            .saturating_duration_since(*anchor)
-            .as_secs_f64()
+        // `instant_to_f64` is signed; clamp to 0.0 here to preserve the
+        // non-negative contract (the shared anchor may be seeded slightly after
+        // the current instant under parallel test initialisation).
+        instant_to_f64(Instant::now()).max(0.0)
+    }
+}
+
+/// Convert an `Instant` to seconds relative to a stable process-lifetime anchor.
+///
+/// The anchor is initialised on first call and shared across all callers in the
+/// same process, so `instant_to_f64(a) - instant_to_f64(b)` equals
+/// `a.duration_since(b)` for any two `Instant`s — including values produced by
+/// `monotonic_raw_secs`'s non-Linux fallback, which uses the same anchor.
+///
+/// On Linux this is the companion to `monotonic_raw_secs`: use
+/// `monotonic_raw_secs()` for wire-stamp deltas and `instant_to_f64` for
+/// `Instant`-based durations; both share the same zero-point off-Linux so
+/// mixed arithmetic in `set_clock_est_rebased` is correct on all platforms.
+pub fn instant_to_f64(instant: Instant) -> f64 {
+    static ANCHOR: OnceLock<Instant> = OnceLock::new();
+    let anchor = ANCHOR.get_or_init(Instant::now);
+    if instant >= *anchor {
+        instant.duration_since(*anchor).as_secs_f64()
+    } else {
+        -(anchor.duration_since(instant).as_secs_f64())
     }
 }
 

--- a/rust/kalico-host-rt/src/clock.rs
+++ b/rust/kalico-host-rt/src/clock.rs
@@ -1,7 +1,43 @@
 //! Time abstraction. Production wires `RealClock`; tests wire `MockClock`.
+//!
+//! `monotonic_raw_secs` gives a CLOCK_MONOTONIC_RAW reading as seconds since an
+//! arbitrary epoch, used for RTT measurement wherever CLOCK_MONOTONIC and
+//! CLOCK_MONOTONIC_RAW diverge (i.e. under NTP slew). On non-Linux platforms it
+//! falls back to `Instant` (CLOCK_MONOTONIC).
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// Read CLOCK_MONOTONIC_RAW and return the value as seconds since an arbitrary
+/// but stable epoch.
+///
+/// The returned value is only meaningful when compared to other values from the
+/// same call — it is not wall time. On platforms that do not support
+/// CLOCK_MONOTONIC_RAW (anything other than Linux) it falls back to
+/// `Instant::now()` measured against a process-lifetime anchor.
+///
+/// The unit is seconds (f64) to match klippy's reactor.monotonic() convention.
+pub fn monotonic_raw_secs() -> f64 {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: clock_gettime is a safe POSIX syscall; we only read the result.
+        #[allow(unsafe_code)]
+        unsafe {
+            let mut ts: libc::timespec = std::mem::zeroed();
+            libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut ts);
+            ts.tv_sec as f64 + ts.tv_nsec as f64 * 1e-9
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        use std::sync::OnceLock;
+        static ANCHOR: OnceLock<Instant> = OnceLock::new();
+        let anchor = ANCHOR.get_or_init(Instant::now);
+        Instant::now()
+            .saturating_duration_since(*anchor)
+            .as_secs_f64()
+    }
+}
 
 pub trait Clock: Send + Sync {
     fn now(&self) -> Instant;

--- a/rust/kalico-host-rt/src/clock/tests.rs
+++ b/rust/kalico-host-rt/src/clock/tests.rs
@@ -23,3 +23,20 @@ fn real_clock_increases() {
     let t1 = c.now();
     assert!(t1 > t0);
 }
+
+#[test]
+fn monotonic_raw_secs_is_non_negative() {
+    let t = monotonic_raw_secs();
+    assert!(t >= 0.0, "monotonic_raw_secs must be non-negative, got {t}");
+}
+
+#[test]
+fn monotonic_raw_secs_advances() {
+    let t0 = monotonic_raw_secs();
+    std::thread::sleep(Duration::from_millis(2));
+    let t1 = monotonic_raw_secs();
+    assert!(
+        t1 > t0,
+        "monotonic_raw_secs must increase over time: t0={t0} t1={t1}"
+    );
+}

--- a/rust/kalico-host-rt/src/clock_sync.rs
+++ b/rust/kalico-host-rt/src/clock_sync.rs
@@ -79,7 +79,7 @@ pub struct ClockSyncEstimator {
     anchor_mcu_clock: u64,
 
     // Diagnostics.
-    pub residual_max_in_window: f64,
+    pub residual_ewma_us: f64,
     pub last_dedicated_sample: Option<Instant>,
 
     // For `add_dedicated_sample` age gate (same role as the old window).
@@ -105,7 +105,7 @@ impl std::fmt::Debug for ClockSyncEstimator {
             .field("prediction_variance", &self.prediction_variance)
             .field("min_half_rtt", &self.min_half_rtt)
             .field("sample_count", &self.sample_count)
-            .field("residual_max_in_window", &self.residual_max_in_window)
+            .field("residual_ewma_us", &self.residual_ewma_us)
             .field("last_dedicated_sample", &self.last_dedicated_sample)
             .finish_non_exhaustive()
     }
@@ -133,7 +133,7 @@ impl ClockSyncEstimator {
             clock_freq_estimate: initial_freq_estimate,
             anchor_host_time: 0.0,
             anchor_mcu_clock: 0,
-            residual_max_in_window: 0.0,
+            residual_ewma_us: 0.0,
             last_dedicated_sample: None,
             last_sample_recorded_at: None,
             sample_count: 0,
@@ -318,10 +318,10 @@ impl ClockSyncEstimator {
 
         // Residual quality metric: EWMA of |clock_diff| in µs.  This is the
         // per-sample prediction error, directly comparable to the old window
-        // regression's `residual_max_in_window`.
+        // regression's `residual_ewma_us`.
         if self.clock_freq_estimate > 1.0 {
             let abs_resid_us = clock_diff.abs() / self.clock_freq_estimate * 1e6;
-            self.residual_max_in_window = (1.0 - DECAY) * self.residual_max_in_window
+            self.residual_ewma_us = (1.0 - DECAY) * self.residual_ewma_us
                 + DECAY * abs_resid_us;
         }
 
@@ -407,9 +407,9 @@ impl ClockSyncEstimator {
                 required: MIN_WARMUP_SAMPLES as usize,
             });
         }
-        if self.residual_max_in_window > MAX_RESIDUAL_US_DEFAULT {
+        if self.residual_ewma_us > MAX_RESIDUAL_US_DEFAULT {
             return Err(QualityGateFailure::ResidualExceeded {
-                observed_us: self.residual_max_in_window,
+                observed_us: self.residual_ewma_us,
                 max_us: MAX_RESIDUAL_US_DEFAULT,
             });
         }

--- a/rust/kalico-host-rt/src/clock_sync.rs
+++ b/rust/kalico-host-rt/src/clock_sync.rs
@@ -1,10 +1,30 @@
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::clock::{Clock, RealClock};
 
-pub const WINDOW: usize = 30;
+/// EWMA decay factor — mirrors klippy's `DECAY = 1/30`.
+const DECAY: f64 = 1.0 / 30.0;
+
+/// Half-RTT age coefficient — mirrors klippy's `RTT_AGE = 10µs / 3600s`.
+const RTT_AGE: f64 = 0.000_010 / (60.0 * 60.0);
+
+/// Prediction-variance is reset to `(1ms * freq)²` on a variance reset; the
+/// same formula klippy uses.
+const PREDICTION_RESET_MS: f64 = 0.001;
+
+/// Outlier gate: residual² must exceed this multiple of prediction_variance AND
+/// the absolute floor below to be considered an outlier.  Matches klippy's 25×.
+const OUTLIER_VARIANCE_MULT: f64 = 25.0;
+
+/// Absolute outlier floor: residual must also exceed 500µs × freq to gate.
+/// Matches klippy's `(0.000500 * self.mcu_freq)²`.
+const OUTLIER_ABS_FLOOR_SECS: f64 = 0.000_500;
+
+/// After how long without a progressive prediction update do we allow an
+/// "upward" outlier through (klippy: `sent_time < last_prediction_time + 10`).
+const OUTLIER_RESET_WINDOW_SECS: f64 = 10.0;
+
 pub const MIN_WARMUP_SAMPLES: u32 = 30;
 pub const MAX_RESIDUAL_US_DEFAULT: f64 = 100.0;
 pub const MAX_DRIFT_PPM_DEFAULT: f64 = 100.0;
@@ -17,6 +37,7 @@ pub enum SampleSource {
     Piggyback,
 }
 
+/// A single RTT-qualified sample fed into the estimator.
 #[derive(Debug, Clone, Copy)]
 pub struct Sample {
     pub host_time_secs: f64,
@@ -26,31 +47,66 @@ pub struct Sample {
     pub recorded_at: Instant,
 }
 
+/// EWMA-based clock frequency / offset estimator.
+///
+/// Mirrors klippy's `ClockSync._handle_clock` algorithm:
+/// - Decayed accumulators (`time_avg`, `clock_avg`, `time_variance`,
+///   `clock_covariance`) with `DECAY = 1/30`.
+/// - Prediction-variance outlier gate (25× + 500µs absolute floor).
+/// - `min_half_rtt` / `RTT_AGE` logic for minimal-RTT sample selection.
+///
+/// Public API is unchanged from the window-regression version so `bridge.rs`
+/// callers need no changes.
 pub struct ClockSyncEstimator {
     epoch: Instant,
     wall_epoch: SystemTime,
-    samples: VecDeque<Sample>,
+
+    // EWMA accumulators (klippy naming kept for auditability).
+    time_avg: f64,
+    time_variance: f64,
+    clock_avg: f64,
+    clock_covariance: f64,
+    prediction_variance: f64,
+    last_prediction_time: f64,
+
+    // min-RTT tracking.
+    min_half_rtt: f64,
+    min_rtt_time: f64,
+
+    // Derived fit exported to callers.
     pub clock_freq_estimate: f64,
     anchor_host_time: f64,
     anchor_mcu_clock: u64,
+
+    // Diagnostics.
     pub residual_max_in_window: f64,
     pub last_dedicated_sample: Option<Instant>,
+
+    // For `add_dedicated_sample` age gate (same role as the old window).
+    last_sample_recorded_at: Option<Instant>,
+
+    sample_count: u32,
     clock_sync_request_id: u32,
     clock: Arc<dyn Clock>,
+
+    /// Initial freq kept for the prediction-variance reset formula.
+    mcu_freq: f64,
 }
 
 impl std::fmt::Debug for ClockSyncEstimator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClockSyncEstimator")
             .field("epoch", &self.epoch)
-            .field("wall_epoch", &self.wall_epoch)
-            .field("samples", &self.samples)
             .field("clock_freq_estimate", &self.clock_freq_estimate)
             .field("anchor_host_time", &self.anchor_host_time)
             .field("anchor_mcu_clock", &self.anchor_mcu_clock)
+            .field("time_avg", &self.time_avg)
+            .field("clock_avg", &self.clock_avg)
+            .field("prediction_variance", &self.prediction_variance)
+            .field("min_half_rtt", &self.min_half_rtt)
+            .field("sample_count", &self.sample_count)
             .field("residual_max_in_window", &self.residual_max_in_window)
             .field("last_dedicated_sample", &self.last_dedicated_sample)
-            .field("clock_sync_request_id", &self.clock_sync_request_id)
             .finish_non_exhaustive()
     }
 }
@@ -66,14 +122,24 @@ impl ClockSyncEstimator {
         Self {
             epoch,
             wall_epoch,
-            samples: VecDeque::with_capacity(WINDOW),
+            time_avg: 0.0,
+            time_variance: 0.0,
+            clock_avg: 0.0,
+            clock_covariance: 0.0,
+            prediction_variance: (PREDICTION_RESET_MS * initial_freq_estimate).powi(2),
+            last_prediction_time: -9999.0,
+            min_half_rtt: 999_999_999.9,
+            min_rtt_time: 0.0,
             clock_freq_estimate: initial_freq_estimate,
             anchor_host_time: 0.0,
             anchor_mcu_clock: 0,
             residual_max_in_window: 0.0,
             last_dedicated_sample: None,
+            last_sample_recorded_at: None,
+            sample_count: 0,
             clock_sync_request_id: 0,
             clock,
+            mcu_freq: initial_freq_estimate,
         }
     }
 
@@ -95,6 +161,7 @@ impl ClockSyncEstimator {
         self.epoch
     }
 
+    /// Project a host-time to MCU clock using the current fit.
     pub fn mcu_time_at_host(&self, host_time_secs: f64) -> u64 {
         let delta_secs = host_time_secs - self.anchor_host_time;
         #[allow(
@@ -109,14 +176,13 @@ impl ClockSyncEstimator {
         }
     }
 
+    /// Convert an MCU tick count to a wall-clock `OffsetDateTime`.
+    /// Returns `None` before the first sample, `(time, estimated)` where
+    /// `estimated=true` means the tick is outside the observed range.
     pub fn wall_time_at_mcu(&self, mcu_ticks: u64) -> Option<(time::OffsetDateTime, bool)> {
-        if self.samples.is_empty() {
+        if self.sample_count == 0 {
             return None;
         }
-
-        let min_mcu = self.samples.iter().map(|s| s.mcu_clock).min().unwrap_or(0);
-        let max_mcu = self.samples.iter().map(|s| s.mcu_clock).max().unwrap_or(0);
-        let estimated = mcu_ticks < min_mcu || mcu_ticks > max_mcu;
 
         let freq = self.clock_freq_estimate;
         if freq.abs() < 1e-6 {
@@ -124,9 +190,13 @@ impl ClockSyncEstimator {
             return Some((dt, true));
         }
 
+        // "estimated" = extrapolation (we have no window bounds anymore, so we
+        // treat any tick that is farther than 1 freq-second from the anchor as
+        // estimated, which is a conservative proxy).
         #[allow(clippy::cast_precision_loss)]
         let delta_ticks = (mcu_ticks as f64) - (self.anchor_mcu_clock as f64);
         let host_secs = self.anchor_host_time + delta_ticks / freq;
+        let estimated = delta_ticks.abs() / freq > 1.0;
 
         let wall_time = if host_secs >= 0.0 {
             self.wall_epoch
@@ -141,6 +211,18 @@ impl ClockSyncEstimator {
         Some((time::OffsetDateTime::from(wall_time), estimated))
     }
 
+    /// Feed one RTT-qualified dedicated sample.
+    ///
+    /// `mcu_at_response` is the MCU clock value echoed in the response (i.e.
+    /// the MCU clock at the instant the firmware generated its reply, which is
+    /// approximately `send_time + half_rtt` in host time).  The one-way delay
+    /// is subtracted so the regression maps `send_time → mcu_at_send`, keeping
+    /// the y-axis consistent with piggyback samples (which also carry the
+    /// instantaneous MCU clock at the observed host time).
+    ///
+    /// The `min_half_rtt` tracker selects the best-observed RTT; both the
+    /// subtraction and the projection anchor use it so that high-RTT samples
+    /// do not distort the slope estimate.
     pub fn add_dedicated_sample(
         &mut self,
         host_send: Instant,
@@ -148,85 +230,151 @@ impl ClockSyncEstimator {
         mcu_at_response: u64,
     ) {
         let rtt = host_recv.saturating_duration_since(host_send);
-        let rtt_us = rtt.as_micros().min(u128::from(u32::MAX)) as u32;
-        let one_way_secs = rtt.as_secs_f64() / 2.0;
-        let host_time_at_send = self.host_time_at(host_send);
+        let half_rtt = rtt.as_secs_f64() / 2.0;
+        let sent_time = self.host_time_at(host_send);
+
+        // min-RTT gate (klippy: `if half_rtt < self.min_half_rtt + aged_rtt`).
+        let aged_rtt = (sent_time - self.min_rtt_time) * RTT_AGE;
+        if half_rtt < self.min_half_rtt + aged_rtt {
+            self.min_half_rtt = half_rtt;
+            self.min_rtt_time = sent_time;
+        }
+
+        // Back-correct MCU clock to the send instant using current freq estimate.
+        // Using `min_half_rtt` (not the raw `half_rtt`) mirrors klippy's approach
+        // of anchoring projections at the minimum-RTT estimate.
+        let effective_half_rtt = if self.min_half_rtt < 1.0 {
+            self.min_half_rtt
+        } else {
+            half_rtt
+        };
         #[allow(clippy::cast_sign_loss)]
-        let one_way_cycles = (one_way_secs * self.clock_freq_estimate) as u64;
+        let one_way_cycles =
+            (effective_half_rtt * self.clock_freq_estimate).max(0.0) as u64;
         let mcu_at_send = mcu_at_response.saturating_sub(one_way_cycles);
+
+        #[allow(clippy::cast_precision_loss)]
+        let feed_clock = mcu_at_send as f64;
+        self.ingest(sent_time, feed_clock, sent_time);
+
         let now = self.clock.now();
-        self.add_sample(Sample {
-            host_time_secs: host_time_at_send,
-            mcu_clock: mcu_at_send,
-            rtt_us,
-            source: SampleSource::Dedicated,
-            recorded_at: now,
-        });
         self.last_dedicated_sample = Some(now);
+        self.last_sample_recorded_at = Some(now);
     }
 
     pub fn add_piggyback_sample(&mut self, host_recv: Instant, mcu_clock_now: u64) {
-        let host_time_secs = self.host_time_at(host_recv);
-        self.add_sample(Sample {
-            host_time_secs,
-            mcu_clock: mcu_clock_now,
-            rtt_us: 0,
-            source: SampleSource::Piggyback,
-            recorded_at: self.clock.now(),
-        });
+        let sent_time = self.host_time_at(host_recv);
+        #[allow(clippy::cast_precision_loss)]
+        let feed_clock = mcu_clock_now as f64;
+        let now = self.clock.now();
+        self.ingest(sent_time, feed_clock, sent_time);
+        self.last_sample_recorded_at = Some(now);
     }
 
-    fn add_sample(&mut self, sample: Sample) {
-        if self.samples.len() == WINDOW {
-            self.samples.pop_front();
+    /// Core EWMA update — port of klippy's `_handle_clock` accumulator logic.
+    ///
+    /// `sent_time`  — host time of the send (used for outlier gating).
+    /// `feed_time`  — the x-value fed into the regression (identical to
+    ///                `sent_time` for both dedicated and piggyback callers).
+    /// `clock`      — the y-value (MCU clock ticks at `feed_time`).
+    fn ingest(&mut self, feed_time: f64, clock: f64, sent_time: f64) {
+        // First sample: seed the EWMA accumulators directly (mirrors klippy's
+        // `connect()` which initialises `time_avg` and `clock_avg` from the
+        // first `get_uptime` response before entering the EWMA loop).
+        if self.sample_count == 0 {
+            self.time_avg = feed_time;
+            self.clock_avg = clock;
+            self.prediction_variance = (PREDICTION_RESET_MS * self.mcu_freq).powi(2);
+            self.last_prediction_time = sent_time;
+            self.sample_count = 1;
+            // No variance/covariance update; need at least two points for a slope.
+            return;
         }
-        self.samples.push_back(sample);
-        self.recompute_regression();
+
+        // --- outlier gate (klippy lines ~122-155) ---
+        let exp_clock =
+            (sent_time - self.time_avg) * self.clock_freq_estimate + self.clock_avg;
+        let clock_diff = clock - exp_clock;
+        let clock_diff2 = clock_diff * clock_diff;
+        let abs_floor = (OUTLIER_ABS_FLOOR_SECS * self.mcu_freq).powi(2);
+
+        if clock_diff2 > OUTLIER_VARIANCE_MULT * self.prediction_variance
+            && clock_diff2 > abs_floor
+        {
+            if clock > exp_clock
+                && sent_time < self.last_prediction_time + OUTLIER_RESET_WINDOW_SECS
+            {
+                // High-side outlier within the reset window: skip entirely.
+                return;
+            }
+            // Reset prediction variance (klippy: variance reset path).
+            self.prediction_variance =
+                (PREDICTION_RESET_MS * self.mcu_freq).powi(2);
+        } else {
+            self.last_prediction_time = sent_time;
+            self.prediction_variance = (1.0 - DECAY)
+                * (self.prediction_variance + clock_diff2 * DECAY);
+        }
+
+        // Residual quality metric: EWMA of |clock_diff| in µs.  This is the
+        // per-sample prediction error, directly comparable to the old window
+        // regression's `residual_max_in_window`.
+        if self.clock_freq_estimate > 1.0 {
+            let abs_resid_us = clock_diff.abs() / self.clock_freq_estimate * 1e6;
+            self.residual_max_in_window = (1.0 - DECAY) * self.residual_max_in_window
+                + DECAY * abs_resid_us;
+        }
+
+        // --- EWMA accumulators (klippy lines ~157-165) ---
+        let diff_sent = feed_time - self.time_avg;
+        self.time_avg += DECAY * diff_sent;
+        self.time_variance =
+            (1.0 - DECAY) * (self.time_variance + diff_sent * diff_sent * DECAY);
+
+        let diff_clock = clock - self.clock_avg;
+        self.clock_avg += DECAY * diff_clock;
+        self.clock_covariance =
+            (1.0 - DECAY) * (self.clock_covariance + diff_sent * diff_clock * DECAY);
+
+        self.sample_count = self.sample_count.saturating_add(1);
+
+        // --- derive slope + anchor ---
+        self.update_fit();
     }
 
-    fn recompute_regression(&mut self) {
-        if self.samples.len() < 2 {
+    /// Recompute `clock_freq_estimate` and the projection anchor from the
+    /// current EWMA accumulators.  Called after every accepted sample.
+    fn update_fit(&mut self) {
+        if self.time_variance.abs() < 1e-12 {
             return;
         }
-        let n = self.samples.len() as f64;
-        let mut sum_x = 0.0_f64;
-        let mut sum_y = 0.0_f64;
-        let mut sum_xx = 0.0_f64;
-        let mut sum_xy = 0.0_f64;
-        for s in &self.samples {
-            let x = s.host_time_secs;
-            let y = s.mcu_clock as f64;
-            sum_x += x;
-            sum_y += y;
-            sum_xx += x * x;
-            sum_xy += x * y;
-        }
-        let mean_x = sum_x / n;
-        let mean_y = sum_y / n;
-        let denom = sum_xx - n * mean_x * mean_x;
-        if denom.abs() < 1e-12 {
+        let new_freq = self.clock_covariance / self.time_variance;
+        if new_freq < 1.0 {
+            // Guard against degenerate state on cold start.
             return;
         }
-        let slope = (sum_xy - n * mean_x * mean_y) / denom;
-        let offset = mean_y - slope * mean_x;
-        self.clock_freq_estimate = slope;
-        self.anchor_host_time = mean_x;
+        self.clock_freq_estimate = new_freq;
+
+        // Anchor at `time_avg + min_half_rtt` (mirrors klippy's
+        // `clock_est = (time_avg + min_half_rtt, clock_avg, new_freq)`).
+        // Use `min_half_rtt` only when it has been updated from an actual RTT
+        // measurement; the initial sentinel (999_999_999.9) must not shift the
+        // anchor.
+        let effective_min_half_rtt = if self.min_half_rtt < 1.0 {
+            self.min_half_rtt
+        } else {
+            0.0
+        };
+        self.anchor_host_time = self.time_avg + effective_min_half_rtt;
         #[allow(clippy::cast_sign_loss)]
         {
-            self.anchor_mcu_clock = if mean_y < 0.0 { 0 } else { mean_y as u64 };
+            self.anchor_mcu_clock = if self.clock_avg < 0.0 {
+                0
+            } else {
+                self.clock_avg as u64
+            };
         }
 
-        let mut max_resid_us = 0.0_f64;
-        for s in &self.samples {
-            let predicted = slope * s.host_time_secs + offset;
-            // Convert residual cycles to seconds via slope, then µs.
-            let resid_seconds = ((s.mcu_clock as f64) - predicted) / slope;
-            let resid_us = (resid_seconds * 1e6).abs();
-            if resid_us > max_resid_us {
-                max_resid_us = resid_us;
-            }
-        }
-        self.residual_max_in_window = max_resid_us;
     }
 
     pub fn drift_ppm(&self, baseline_freq: f64) -> f64 {
@@ -238,9 +386,8 @@ impl ClockSyncEstimator {
 
     pub fn last_sample_age(&self) -> Option<Duration> {
         let now = self.clock.now();
-        self.samples
-            .back()
-            .map(|s| now.saturating_duration_since(s.recorded_at))
+        self.last_sample_recorded_at
+            .map(|t| now.saturating_duration_since(t))
     }
 
     pub fn last_dedicated_sample_age(&self) -> Option<Duration> {
@@ -250,7 +397,7 @@ impl ClockSyncEstimator {
     }
 
     pub fn sample_count(&self) -> u32 {
-        self.samples.len() as u32
+        self.sample_count
     }
 
     pub fn is_quality_gate_passed(&self, baseline_freq: f64) -> Result<(), QualityGateFailure> {

--- a/rust/kalico-host-rt/src/clock_sync.rs
+++ b/rust/kalico-host-rt/src/clock_sync.rs
@@ -249,8 +249,7 @@ impl ClockSyncEstimator {
             half_rtt
         };
         #[allow(clippy::cast_sign_loss)]
-        let one_way_cycles =
-            (effective_half_rtt * self.clock_freq_estimate).max(0.0) as u64;
+        let one_way_cycles = (effective_half_rtt * self.clock_freq_estimate).max(0.0) as u64;
         let mcu_at_send = mcu_at_response.saturating_sub(one_way_cycles);
 
         #[allow(clippy::cast_precision_loss)]
@@ -292,14 +291,12 @@ impl ClockSyncEstimator {
         }
 
         // --- outlier gate (klippy lines ~122-155) ---
-        let exp_clock =
-            (sent_time - self.time_avg) * self.clock_freq_estimate + self.clock_avg;
+        let exp_clock = (sent_time - self.time_avg) * self.clock_freq_estimate + self.clock_avg;
         let clock_diff = clock - exp_clock;
         let clock_diff2 = clock_diff * clock_diff;
         let abs_floor = (OUTLIER_ABS_FLOOR_SECS * self.mcu_freq).powi(2);
 
-        if clock_diff2 > OUTLIER_VARIANCE_MULT * self.prediction_variance
-            && clock_diff2 > abs_floor
+        if clock_diff2 > OUTLIER_VARIANCE_MULT * self.prediction_variance && clock_diff2 > abs_floor
         {
             if clock > exp_clock
                 && sent_time < self.last_prediction_time + OUTLIER_RESET_WINDOW_SECS
@@ -308,12 +305,11 @@ impl ClockSyncEstimator {
                 return;
             }
             // Reset prediction variance (klippy: variance reset path).
-            self.prediction_variance =
-                (PREDICTION_RESET_MS * self.mcu_freq).powi(2);
+            self.prediction_variance = (PREDICTION_RESET_MS * self.mcu_freq).powi(2);
         } else {
             self.last_prediction_time = sent_time;
-            self.prediction_variance = (1.0 - DECAY)
-                * (self.prediction_variance + clock_diff2 * DECAY);
+            self.prediction_variance =
+                (1.0 - DECAY) * (self.prediction_variance + clock_diff2 * DECAY);
         }
 
         // Residual quality metric: EWMA of |clock_diff| in µs.  This is the
@@ -321,15 +317,13 @@ impl ClockSyncEstimator {
         // regression's `residual_ewma_us`.
         if self.clock_freq_estimate > 1.0 {
             let abs_resid_us = clock_diff.abs() / self.clock_freq_estimate * 1e6;
-            self.residual_ewma_us = (1.0 - DECAY) * self.residual_ewma_us
-                + DECAY * abs_resid_us;
+            self.residual_ewma_us = (1.0 - DECAY) * self.residual_ewma_us + DECAY * abs_resid_us;
         }
 
         // --- EWMA accumulators (klippy lines ~157-165) ---
         let diff_sent = feed_time - self.time_avg;
         self.time_avg += DECAY * diff_sent;
-        self.time_variance =
-            (1.0 - DECAY) * (self.time_variance + diff_sent * diff_sent * DECAY);
+        self.time_variance = (1.0 - DECAY) * (self.time_variance + diff_sent * diff_sent * DECAY);
 
         let diff_clock = clock - self.clock_avg;
         self.clock_avg += DECAY * diff_clock;
@@ -374,7 +368,6 @@ impl ClockSyncEstimator {
                 self.clock_avg as u64
             };
         }
-
     }
 
     pub fn drift_ppm(&self, baseline_freq: f64) -> f64 {

--- a/rust/kalico-host-rt/src/clock_sync/clock_seam_tests.rs
+++ b/rust/kalico-host-rt/src/clock_sync/clock_seam_tests.rs
@@ -2,6 +2,10 @@ use super::*;
 use crate::clock::MockClock;
 use std::time::Duration;
 
+// ---------------------------------------------------------------------------
+// Seam / infrastructure tests (unchanged behaviour)
+// ---------------------------------------------------------------------------
+
 #[test]
 fn last_sample_age_uses_injected_clock() {
     let clock = MockClock::new();
@@ -33,50 +37,30 @@ fn wall_time_at_mcu_returns_none_with_zero_samples() {
 }
 
 #[test]
-fn wall_time_at_mcu_inside_window_returns_some_false() {
+fn wall_time_at_mcu_inside_window_returns_some() {
     let clock = MockClock::new();
     let mut est = ClockSyncEstimator::new_with_clock(100_000_000.0, clock.clone());
 
-    for i in 0..30u64 {
+    // Feed 30 dedicated samples with 1ms constant RTT so min_half_rtt is set.
+    let t0 = clock.now();
+    for i in 1..=30u64 {
+        let send = t0 + Duration::from_secs(i);
+        let recv = send + Duration::from_millis(1);
+        // mcu_at_response: MCU clock at the response instant (send + 0.5ms).
+        let mcu_resp = i * 100_000_000 + 50_000;
+        est.add_dedicated_sample(send, recv, mcu_resp);
         clock.advance(Duration::from_secs(1));
-        let mcu_clock = (i + 1) * 100_000_000;
-        est.add_piggyback_sample_at_now(mcu_clock);
     }
 
     let result = est.wall_time_at_mcu(15 * 100_000_000);
     assert!(result.is_some(), "expected Some after 30 samples");
-    let (dt, estimated) = result.unwrap();
-
-    assert!(
-        !estimated,
-        "tick inside window must not be estimated; got estimated={estimated}"
-    );
+    let (dt, _estimated) = result.unwrap();
 
     let now_dt = time::OffsetDateTime::now_utc();
     let diff_secs = (now_dt - dt).whole_seconds().abs();
     assert!(
-        diff_secs < 60,
+        diff_secs < 120,
         "returned time {dt} is {diff_secs}s from now_utc {now_dt}",
-    );
-}
-
-#[test]
-fn wall_time_at_mcu_extrapolate_returns_some_true() {
-    let clock = MockClock::new();
-    let mut est = ClockSyncEstimator::new_with_clock(100_000_000.0, clock.clone());
-
-    for i in 0..30u64 {
-        clock.advance(Duration::from_secs(1));
-        est.add_piggyback_sample_at_now((i + 1) * 100_000_000);
-    }
-
-    let far_future = 90 * 100_000_000u64;
-    let result = est.wall_time_at_mcu(far_future);
-    assert!(result.is_some(), "expected Some after 30 samples");
-    let (_dt, estimated) = result.unwrap();
-    assert!(
-        estimated,
-        "extrapolation outside window must set estimated=true",
     );
 }
 
@@ -93,12 +77,7 @@ fn wall_time_at_mcu_one_sample_returns_some_estimated() {
     let result = est.wall_time_at_mcu(query_tick);
 
     assert!(result.is_some(), "expected Some with one sample, got None");
-    let (dt, estimated) = result.unwrap();
-
-    assert!(
-        estimated,
-        "one-sample path must set estimated=true for a tick != the sample"
-    );
+    let (dt, _estimated) = result.unwrap();
 
     let unix_epoch = time::OffsetDateTime::UNIX_EPOCH;
     assert_ne!(
@@ -109,7 +88,216 @@ fn wall_time_at_mcu_one_sample_returns_some_estimated() {
     let now_dt = time::OffsetDateTime::now_utc();
     let diff_secs = (now_dt - dt).whole_seconds().abs();
     assert!(
-        diff_secs < 60,
-        "one-sample result {dt} is {diff_secs}s from now_utc {now_dt} — expected < 60 s"
+        diff_secs < 120,
+        "one-sample result {dt} is {diff_secs}s from now_utc {now_dt} — expected < 120 s"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-task B unit tests
+//
+// All timestamps are deterministic: fixed arrays or seeded LCG.
+// No Instant::now() / SystemTime::now() used inside the test logic —
+// MockClock provides a controlled time base.
+// ---------------------------------------------------------------------------
+
+/// Seeded LCG for deterministic bounded noise (no external crate needed).
+struct Lcg(u64);
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+
+    /// Returns a value in [0, modulus).
+    fn bounded(&mut self, modulus: u64) -> u64 {
+        (self.next_u64() >> 17) % modulus
+    }
+
+    /// Returns a signed offset in [-half_us, +half_us] expressed in seconds.
+    fn noise_secs(&mut self, half_us: u64) -> f64 {
+        let raw = self.bounded(2 * half_us + 1);
+        (raw as i64 - half_us as i64) as f64 * 1e-6
+    }
+}
+
+/// (a) Stationary clock + bounded noise → fitted freq within ±5ppm after warmup.
+///
+/// Stream: 120 dedicated samples at ~500ms spacing with constant 300µs RTT
+/// and ±5µs host-timing jitter.  After warmup the EWMA should track
+/// `true_freq` within 5ppm.  The tolerance is intentionally looser than the
+/// bench ±18ppm worst-case; this test guards against algorithmic regression,
+/// not hardware accuracy.
+#[test]
+fn stationary_clock_converges_within_5ppm() {
+    let true_freq = 168_000_000.0_f64;
+    let clock = MockClock::new();
+    let mut est = ClockSyncEstimator::new_with_clock(true_freq, clock.clone());
+    let mut lcg = Lcg::new(0xDEAD_BEEF_CAFE_1234);
+
+    let epoch = clock.now();
+    let rtt_us = 300u64; // constant 300µs RTT
+    let half_rtt = rtt_us as f64 * 1e-6 / 2.0;
+
+    for i in 1u64..=120 {
+        // ±5µs timing jitter on the send instant (host-side noise).
+        let t_secs = i as f64 * 0.5 + lcg.noise_secs(5);
+        let t_secs = t_secs.max(0.001);
+
+        // MCU clock at the response instant (send + one-way delay).
+        let mcu_resp = ((t_secs + half_rtt) * true_freq) as u64;
+
+        let send = epoch + Duration::from_secs_f64(t_secs);
+        let recv = send + Duration::from_micros(rtt_us);
+        est.add_dedicated_sample(send, recv, mcu_resp);
+        clock.advance(Duration::from_millis(500));
+    }
+
+    let fitted = est.clock_freq_estimate;
+    let err_ppm = ((fitted - true_freq) / true_freq * 1e6).abs();
+    assert!(
+        err_ppm < 5.0,
+        "fitted freq {fitted:.1} Hz is {err_ppm:.3}ppm from truth {true_freq:.1} Hz — expected < 5ppm"
+    );
+}
+
+/// (b) Klippy-parity outlier rejection: a high-side clock glitch within the
+///     10-second prediction reset window is silently dropped and does NOT move
+///     the projected MCU clock by more than ~1µs.
+///
+/// Klippy's gate: `clock > exp_clock && sent_time < last_prediction_time + 10`
+/// → sample is returned early (skipped).  We inject an outlier with a +5ms
+/// clock advance (840_000 ticks at 168 MHz) while the prediction window is
+/// still fresh.
+#[test]
+fn high_side_outlier_within_window_is_dropped() {
+    let true_freq = 168_000_000.0_f64;
+    let clock = MockClock::new();
+    let mut est = ClockSyncEstimator::new_with_clock(true_freq, clock.clone());
+
+    let epoch = clock.now();
+    let rtt_dur = Duration::from_micros(300); // constant 300µs RTT
+    let half_rtt = 0.000_150; // 150µs
+
+    // Warmup: 60 honest samples at 500ms spacing.
+    for i in 1u64..=60 {
+        let t = i as f64 * 0.5;
+        let send = epoch + Duration::from_secs_f64(t);
+        let mcu_resp = ((t + half_rtt) * true_freq) as u64;
+        est.add_dedicated_sample(send, send + rtt_dur, mcu_resp);
+        clock.advance(Duration::from_millis(500));
+    }
+
+    // Probe before outlier.
+    let probe_secs = 70.0_f64;
+    let before = est.mcu_time_at_host(probe_secs);
+
+    // Inject a high-side outlier: MCU clock is +5ms (840_000 ticks) ahead of
+    // prediction.  `sent_time = 30.5`, `last_prediction_time ≈ 30.0` → within
+    // the 10-second window → klippy (and our port) silently drop it.
+    let outlier_t = 30.5_f64;
+    let send = epoch + Duration::from_secs_f64(outlier_t);
+    // Expected MCU at send ≈ 30.5 * true_freq + offset_from_regression.
+    // We add +840_000 (≈ 5ms) to make it a clear high-side outlier.
+    let mcu_resp_outlier = ((outlier_t + half_rtt) * true_freq) as u64 + 840_000;
+    est.add_dedicated_sample(send, send + rtt_dur, mcu_resp_outlier);
+
+    let after = est.mcu_time_at_host(probe_secs);
+
+    let shift_ticks = (after as i64) - (before as i64);
+    let shift_us = (shift_ticks as f64 / true_freq * 1e6).abs();
+    assert!(
+        shift_us < 1.0,
+        "high-side outlier shifted projected offset by {shift_us:.3}µs — must be < 1µs \
+         (klippy silently drops this class of outlier)"
+    );
+}
+
+/// (c) Cold-start: first 5 samples should yield a usable fit within 50ppm.
+///
+/// We use a constant RTT of 500µs so there is no ambiguity in what the MCU
+/// clock should be at send time.
+#[test]
+fn cold_start_within_50ppm_after_handful() {
+    let true_freq = 100_000_000.0_f64;
+    let clock = MockClock::new();
+    let mut est = ClockSyncEstimator::new_with_clock(true_freq, clock.clone());
+
+    let epoch = clock.now();
+    let rtt_dur = Duration::from_micros(500);
+    let half_rtt = 0.000_250;
+
+    for i in 1u64..=5 {
+        let t = i as f64 * 0.5;
+        let send = epoch + Duration::from_secs_f64(t);
+        let mcu_resp = ((t + half_rtt) * true_freq) as u64;
+        est.add_dedicated_sample(send, send + rtt_dur, mcu_resp);
+        clock.advance(Duration::from_millis(500));
+    }
+
+    let fitted = est.clock_freq_estimate;
+    let err_ppm = ((fitted - true_freq) / true_freq * 1e6).abs();
+    assert!(
+        err_ppm < 50.0,
+        "cold-start fitted freq {fitted:.1} Hz is {err_ppm:.3}ppm from truth after 5 samples"
+    );
+}
+
+/// (d) A genuine frequency step (temperature-ramp analog) is tracked within
+///     the decay time constant.
+///
+/// After 60 samples at `freq_before`, we switch to `freq_after` (+18ppm) and
+/// feed another 60 samples.  After one full decay window the fit should have
+/// converged to within 5ppm of `freq_after`.
+#[test]
+fn genuine_freq_step_tracked_within_decay_constant() {
+    let freq_before = 100_000_000.0_f64;
+    let freq_after = 100_001_800.0_f64; // +18ppm
+
+    let clock = MockClock::new();
+    let mut est = ClockSyncEstimator::new_with_clock(freq_before, clock.clone());
+
+    let epoch = clock.now();
+    let rtt_dur = Duration::from_micros(300);
+    let half_rtt = 0.000_150;
+
+    let mut mcu_clock_acc = 0.0_f64; // simulate accumulating ticks
+
+    // Phase 1: 60 samples at freq_before.
+    for i in 0u64..60 {
+        let t = i as f64 * 0.5;
+        mcu_clock_acc += 0.5 * freq_before;
+        let send = epoch + Duration::from_secs_f64(t);
+        // mcu_resp is the MCU clock at the response instant (send + half_rtt).
+        let mcu_resp = (mcu_clock_acc + half_rtt * freq_before) as u64;
+        est.add_dedicated_sample(send, send + rtt_dur, mcu_resp);
+        clock.advance(Duration::from_millis(500));
+    }
+
+    // Phase 2: 60 samples at freq_after.
+    let phase2_start = 60.0_f64 * 0.5;
+    for i in 0u64..60 {
+        let t = phase2_start + i as f64 * 0.5;
+        mcu_clock_acc += 0.5 * freq_after;
+        let send = epoch + Duration::from_secs_f64(t);
+        let mcu_resp = (mcu_clock_acc + half_rtt * freq_after) as u64;
+        est.add_dedicated_sample(send, send + rtt_dur, mcu_resp);
+        clock.advance(Duration::from_millis(500));
+    }
+
+    let fitted = est.clock_freq_estimate;
+    let err_ppm = ((fitted - freq_after) / freq_after * 1e6).abs();
+    // After one full decay window (60 samples × 500ms) the EWMA should have
+    // converged to within ~10ppm of the new frequency.  The tolerance accounts
+    // for EWMA lag: at DECAY=1/30, 60 samples give ~86% tracking of a step.
+    assert!(
+        err_ppm < 10.0,
+        "after freq step + 60 samples, fitted {fitted:.1} Hz still {err_ppm:.3}ppm \
+         from new truth {freq_after:.1} Hz"
     );
 }

--- a/rust/kalico-host-rt/src/clock_sync/clock_seam_tests.rs
+++ b/rust/kalico-host-rt/src/clock_sync/clock_seam_tests.rs
@@ -181,7 +181,10 @@ impl Lcg {
     }
 
     fn next_u64(&mut self) -> u64 {
-        self.0 = self.0.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1_442_695_040_888_963_407);
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
         self.0
     }
 

--- a/rust/kalico-host-rt/src/clock_sync/clock_seam_tests.rs
+++ b/rust/kalico-host-rt/src/clock_sync/clock_seam_tests.rs
@@ -93,6 +93,77 @@ fn wall_time_at_mcu_one_sample_returns_some_estimated() {
     );
 }
 
+/// Anchor-proximal tick → `estimated == false`.
+///
+/// We feed two dedicated samples 1 s apart with a 300µs constant RTT so that
+/// `update_fit` runs and `anchor_mcu_clock` is set to approximately
+/// `100_000_000` ticks.  Querying that exact tick must return
+/// `estimated=false` (delta_ticks ≈ 0, well within the 1 s threshold).
+#[test]
+fn wall_time_at_mcu_anchor_tick_not_estimated() {
+    let clock = MockClock::new();
+    let freq = 100_000_000.0_f64;
+    let mut est = ClockSyncEstimator::new_with_clock(freq, clock.clone());
+
+    let t0 = clock.now();
+    let rtt = Duration::from_micros(300);
+    let half_rtt_s = 0.000_150_f64;
+
+    // Two samples so update_fit runs.
+    for i in 1u64..=2 {
+        let t = i as f64;
+        let send = t0 + Duration::from_secs_f64(t);
+        let mcu_resp = ((t + half_rtt_s) * freq) as u64;
+        est.add_dedicated_sample(send, send + rtt, mcu_resp);
+        clock.advance(Duration::from_secs(1));
+    }
+
+    // The anchor sits near clock_avg ≈ 1.5 * freq + adjustment.
+    // Query the anchor tick itself (anchor_mcu_clock from the estimator).
+    let anchor = est.anchor_mcu_clock;
+    let (_, estimated) = est
+        .wall_time_at_mcu(anchor)
+        .expect("must return Some after samples");
+    assert!(
+        !estimated,
+        "tick at exact anchor_mcu_clock should not be estimated (delta_ticks=0)"
+    );
+}
+
+/// Tick more than 1 MCU-second from anchor → `estimated == true`.
+///
+/// At 100 MHz, an offset of 200_000_000 ticks = 2.0 s from the anchor;
+/// that exceeds the 1.0 s threshold so `estimated` must be true.
+#[test]
+fn wall_time_at_mcu_far_tick_is_estimated() {
+    let clock = MockClock::new();
+    let freq = 100_000_000.0_f64;
+    let mut est = ClockSyncEstimator::new_with_clock(freq, clock.clone());
+
+    let t0 = clock.now();
+    let rtt = Duration::from_micros(300);
+    let half_rtt_s = 0.000_150_f64;
+
+    for i in 1u64..=2 {
+        let t = i as f64;
+        let send = t0 + Duration::from_secs_f64(t);
+        let mcu_resp = ((t + half_rtt_s) * freq) as u64;
+        est.add_dedicated_sample(send, send + rtt, mcu_resp);
+        clock.advance(Duration::from_secs(1));
+    }
+
+    let anchor = est.anchor_mcu_clock;
+    // 2 s of ticks away from anchor.
+    let far_tick = anchor + 200_000_000;
+    let (_, estimated) = est
+        .wall_time_at_mcu(far_tick)
+        .expect("must return Some after samples");
+    assert!(
+        estimated,
+        "tick 2 MCU-seconds from anchor must be estimated (delta=2.0 > 1.0)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Sub-task B unit tests
 //

--- a/rust/kalico-host-rt/src/host_io/mod.rs
+++ b/rust/kalico-host-rt/src/host_io/mod.rs
@@ -142,6 +142,14 @@ pub enum ReactorCommand {
             SyncSender<Result<crate::host_io::kalico_native::KalicoCallOutcome, TransportError>>,
         deadline: std::time::Instant,
     },
+    /// Send pre-encoded get_clock bytes as fire-and-forget and record
+    /// `sent_time_raw` so that when the "clock" response arrives as an
+    /// unsolicited frame the reactor can inject honest RAW timestamps and
+    /// deliver it as a PassthroughResponse runtime event.
+    GetClockAndDeliver {
+        get_clock_bytes: Vec<u8>,
+        sent_time_raw: f64,
+    },
     Shutdown,
     Noop,
     RegisterInterceptor {
@@ -597,6 +605,28 @@ impl KalicoHostIo {
         self.submission_tx
             .send(ReactorCommand::FireAndForget {
                 cmd: cmd.to_owned(),
+            })
+            .map_err(|_| TransportError::Closed)
+    }
+
+    /// Send a pre-encoded get_clock frame and tell the reactor to stamp the
+    /// matching "clock" response with CLOCK_MONOTONIC_RAW timestamps.
+    ///
+    /// `sent_time_raw` must have been captured with `monotonic_raw_secs()`
+    /// immediately before calling this method.  The reactor delivers the
+    /// response as a `PassthroughResponse { name: "clock", .. }` runtime event
+    /// with `MessageParams::sent_time_raw` and `recv_time_raw` filled in, so
+    /// the Python `_bridge_event_poller` can inject them into `#sent_time` /
+    /// `#receive_time` before dispatching to `_handle_clock`.
+    pub fn get_clock_async(
+        &self,
+        get_clock_bytes: Vec<u8>,
+        sent_time_raw: f64,
+    ) -> Result<(), TransportError> {
+        self.submission_tx
+            .send(ReactorCommand::GetClockAndDeliver {
+                get_clock_bytes,
+                sent_time_raw,
             })
             .map_err(|_| TransportError::Closed)
     }

--- a/rust/kalico-host-rt/src/host_io/mod.rs
+++ b/rust/kalico-host-rt/src/host_io/mod.rs
@@ -142,14 +142,14 @@ pub enum ReactorCommand {
             SyncSender<Result<crate::host_io::kalico_native::KalicoCallOutcome, TransportError>>,
         deadline: std::time::Instant,
     },
-    /// Send pre-encoded get_clock bytes as fire-and-forget and record
-    /// `sent_time_raw` so that when the "clock" response arrives as an
-    /// unsolicited frame the reactor can inject honest RAW timestamps and
-    /// deliver it as a PassthroughResponse runtime event.
-    GetClockAndDeliver {
-        get_clock_bytes: Vec<u8>,
-        sent_time_raw: f64,
-    },
+    /// Encode and send `get_clock` (with the reactor's own per-MCU parser —
+    /// the bridge-level parser carries whichever MCU's dictionary was set
+    /// last and must never encode for a specific MCU). The send timestamp is
+    /// captured in the reactor immediately before the wire write; when the
+    /// "clock" response arrives as an unsolicited frame the reactor injects
+    /// honest RAW timestamps and delivers it as a PassthroughResponse
+    /// runtime event.
+    GetClockAndDeliver,
     Shutdown,
     Noop,
     RegisterInterceptor {
@@ -609,25 +609,16 @@ impl KalicoHostIo {
             .map_err(|_| TransportError::Closed)
     }
 
-    /// Send a pre-encoded get_clock frame and tell the reactor to stamp the
-    /// matching "clock" response with CLOCK_MONOTONIC_RAW timestamps.
-    ///
-    /// `sent_time_raw` must have been captured with `monotonic_raw_secs()`
-    /// immediately before calling this method.  The reactor delivers the
-    /// response as a `PassthroughResponse { name: "clock", .. }` runtime event
-    /// with `MessageParams::sent_time_raw` and `recv_time_raw` filled in, so
-    /// the Python `_bridge_event_poller` can inject them into `#sent_time` /
-    /// `#receive_time` before dispatching to `_handle_clock`.
-    pub fn get_clock_async(
-        &self,
-        get_clock_bytes: Vec<u8>,
-        sent_time_raw: f64,
-    ) -> Result<(), TransportError> {
+    /// Ask the reactor to encode+send `get_clock` and stamp the matching
+    /// "clock" response with CLOCK_MONOTONIC_RAW timestamps (send stamp
+    /// captured in the reactor immediately before the wire write). The
+    /// response is delivered as a `PassthroughResponse { name: "clock", .. }`
+    /// runtime event with `MessageParams::sent_time_raw` / `recv_time_raw`
+    /// filled in, so the Python `_bridge_event_poller` can inject them into
+    /// `#sent_time` / `#receive_time` before dispatching to `_handle_clock`.
+    pub fn get_clock_async(&self) -> Result<(), TransportError> {
         self.submission_tx
-            .send(ReactorCommand::GetClockAndDeliver {
-                get_clock_bytes,
-                sent_time_raw,
-            })
+            .send(ReactorCommand::GetClockAndDeliver)
             .map_err(|_| TransportError::Closed)
     }
 

--- a/rust/kalico-host-rt/src/host_io/reactor.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor.rs
@@ -274,6 +274,7 @@ impl Reactor {
         let wire_seq = (seq & 0x0F) as u8;
         let frame = crate::host_io::wire::build_frame(&payload, wire_seq);
 
+        let sent_time_raw = crate::clock::monotonic_raw_secs();
         self.write_frame(&frame)?;
 
         let now = self.clock.now();
@@ -294,6 +295,7 @@ impl Reactor {
                 submitted_at: now,
                 deadline,
                 abandoned: false,
+                sent_time_raw,
             })?;
         tracing::trace!(
             subsystem = "mcu-comms",
@@ -642,6 +644,9 @@ impl Reactor {
                         matched_seq = entry.seq,
                         "solicited response matched"
                     );
+                    let mut params = params;
+                    params.sent_time_raw = entry.sent_time_raw;
+                    params.recv_time_raw = crate::clock::monotonic_raw_secs();
                     let _ = entry.completion.send(Ok(params));
                 } else {
                     let oid = params.fields.get("oid").and_then(|v| match v {

--- a/rust/kalico-host-rt/src/host_io/reactor.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor.rs
@@ -57,7 +57,9 @@ pub struct Reactor {
     /// with RAW RTT stamps rather than going through the generic path.
     pub(crate) pending_clock_sent_raw: Option<f64>,
 
-    pub(crate) pending_fire_and_forget: VecDeque<Vec<u8>>,
+    /// Queued fire-and-forget payloads; the bool marks a `get_clock` frame
+    /// whose RAW send stamp is captured at the actual wire write.
+    pub(crate) pending_fire_and_forget: VecDeque<(Vec<u8>, bool)>,
     pub(crate) pending_outbound_order: VecDeque<PendingOutboundKind>,
     pub(crate) zero_byte_first_seen: Option<Instant>,
     pub(crate) last_recv_time: Instant,
@@ -325,6 +327,7 @@ impl Reactor {
     pub(crate) fn dispatch_fire_and_forget(
         &mut self,
         payload: Vec<u8>,
+        is_get_clock: bool,
     ) -> Result<(), TransportError> {
         if self.unacked_window.is_full() {
             if self.pending_fire_and_forget.len() >= PENDING_FIRE_AND_FORGET_CEILING {
@@ -334,7 +337,8 @@ impl Reactor {
                 );
                 return Err(TransportError::Backpressure);
             }
-            self.pending_fire_and_forget.push_back(payload);
+            self.pending_fire_and_forget
+                .push_back((payload, is_get_clock));
             self.pending_outbound_order
                 .push_back(PendingOutboundKind::FireAndForget);
             return Ok(());
@@ -343,7 +347,20 @@ impl Reactor {
         self.send_seq += 1;
         let wire_seq = (seq & 0x0F) as u8;
         let frame = crate::host_io::wire::build_frame(&payload, wire_seq);
-        self.write_frame(&frame)?;
+        // get_clock send stamps MUST be captured at the wire write, not at
+        // command processing: on a busy link (beacon's status stream) the
+        // frame can queue for multiple ms, and an early stamp pairs the
+        // response clock with a fictitious send time — observed as a
+        // constant +5.6ms outlier on every beacon clocksync sample.
+        if is_get_clock {
+            self.pending_clock_sent_raw = Some(crate::clock::monotonic_raw_secs());
+        }
+        if let Err(e) = self.write_frame(&frame) {
+            if is_get_clock {
+                self.pending_clock_sent_raw = None;
+            }
+            return Err(e);
+        }
         let now = self.clock.now();
         self.unacked_window
             .push(crate::host_io::window::UnackedEntry {
@@ -394,11 +411,12 @@ impl Reactor {
                     }
                 }
                 PendingOutboundKind::FireAndForget => {
-                    let Some(payload) = self.pending_fire_and_forget.pop_front() else {
+                    let Some((payload, is_get_clock)) = self.pending_fire_and_forget.pop_front()
+                    else {
                         log::error!("pending outbound order referenced missing fire-and-forget");
                         continue;
                     };
-                    if let Err(e) = self.dispatch_fire_and_forget(payload) {
+                    if let Err(e) = self.dispatch_fire_and_forget(payload, is_get_clock) {
                         if matches!(e, TransportError::Io(_)) {
                             if self.pending_host_fault.is_none() {
                                 self.pending_host_fault =
@@ -1008,7 +1026,7 @@ impl Reactor {
                         head = %head.join(","),
                         "FireAndForget encoded OK"
                     );
-                    if let Err(e) = self.dispatch_fire_and_forget(payload) {
+                    if let Err(e) = self.dispatch_fire_and_forget(payload, false) {
                         let is_io = matches!(e, TransportError::Io(_));
                         tracing::error!(
                             subsystem = "mcu-comms",
@@ -1033,7 +1051,7 @@ impl Reactor {
                 }
             },
             ReactorCommand::FireAndForgetTyped { payload } => {
-                if let Err(e) = self.dispatch_fire_and_forget(payload) {
+                if let Err(e) = self.dispatch_fire_and_forget(payload, false) {
                     let is_io = matches!(e, TransportError::Io(_));
                     log::warn!("FireAndForgetTyped: send error: {e}");
                     if is_io {
@@ -1096,8 +1114,11 @@ impl Reactor {
             }
             ReactorCommand::GetClockAndDeliver => match self.parser.encode("get_clock") {
                 Ok(payload) => {
-                    self.pending_clock_sent_raw = Some(crate::clock::monotonic_raw_secs());
-                    if let Err(e) = self.dispatch_fire_and_forget(payload) {
+                    // The RAW send stamp is captured inside
+                    // dispatch_fire_and_forget at the actual wire write —
+                    // never here, where the frame may still queue behind a
+                    // busy link for milliseconds.
+                    if let Err(e) = self.dispatch_fire_and_forget(payload, true) {
                         let is_io = matches!(e, TransportError::Io(_));
                         tracing::error!(
                             subsystem = "mcu-comms",
@@ -1108,7 +1129,6 @@ impl Reactor {
                         if is_io {
                             self.transition_closed_on_io_fault();
                         }
-                        self.pending_clock_sent_raw = None;
                     }
                 }
                 Err(e) => {

--- a/rust/kalico-host-rt/src/host_io/reactor.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor.rs
@@ -1139,6 +1139,7 @@ impl Reactor {
 
 impl Reactor {
     fn flush_all_completions(&mut self) {
+        self.pending_clock_sent_raw = None;
         for entry in self.awaiting_response.drain_all() {
             let _ = entry.completion.send(Err(TransportError::Closed));
         }

--- a/rust/kalico-host-rt/src/host_io/reactor.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor.rs
@@ -1094,25 +1094,32 @@ impl Reactor {
                     }
                 }
             }
-            ReactorCommand::GetClockAndDeliver {
-                get_clock_bytes,
-                sent_time_raw,
-            } => {
-                self.pending_clock_sent_raw = Some(sent_time_raw);
-                if let Err(e) = self.dispatch_fire_and_forget(get_clock_bytes) {
-                    let is_io = matches!(e, TransportError::Io(_));
+            ReactorCommand::GetClockAndDeliver => match self.parser.encode("get_clock") {
+                Ok(payload) => {
+                    self.pending_clock_sent_raw = Some(crate::clock::monotonic_raw_secs());
+                    if let Err(e) = self.dispatch_fire_and_forget(payload) {
+                        let is_io = matches!(e, TransportError::Io(_));
+                        tracing::error!(
+                            subsystem = "mcu-comms",
+                            event = "get_clock_async_send_error",
+                            error = %e,
+                            "GetClockAndDeliver dispatch failed"
+                        );
+                        if is_io {
+                            self.transition_closed_on_io_fault();
+                        }
+                        self.pending_clock_sent_raw = None;
+                    }
+                }
+                Err(e) => {
                     tracing::error!(
                         subsystem = "mcu-comms",
-                        event = "get_clock_async_send_error",
-                        error = %e,
-                        "GetClockAndDeliver dispatch failed"
+                        event = "get_clock_async_encode_error",
+                        error = ?e,
+                        "GetClockAndDeliver: encode 'get_clock' failed"
                     );
-                    if is_io {
-                        self.transition_closed_on_io_fault();
-                    }
-                    self.pending_clock_sent_raw = None;
                 }
-            }
+            },
             ReactorCommand::Noop => {}
             ReactorCommand::RegisterInterceptor {
                 msg_name,

--- a/rust/kalico-host-rt/src/host_io/reactor.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor.rs
@@ -51,6 +51,12 @@ pub struct Reactor {
 
     pub(crate) pending_submissions: VecDeque<PendingSubmission>,
 
+    /// When `get_clock_async` is in flight: the CLOCK_MONOTONIC_RAW sent-time
+    /// captured before the frame was written to wire.  The next unsolicited
+    /// "clock" response matching this will be delivered as a PassthroughResponse
+    /// with RAW RTT stamps rather than going through the generic path.
+    pub(crate) pending_clock_sent_raw: Option<f64>,
+
     pub(crate) pending_fire_and_forget: VecDeque<Vec<u8>>,
     pub(crate) pending_outbound_order: VecDeque<PendingOutboundKind>,
     pub(crate) zero_byte_first_seen: Option<Instant>,
@@ -139,6 +145,7 @@ impl Reactor {
             state: ReactorState::Active,
             closed_via_shutdown: false,
             pending_host_fault: None,
+            pending_clock_sent_raw: None,
             pending_submissions: VecDeque::new(),
             pending_fire_and_forget: VecDeque::new(),
             pending_outbound_order: VecDeque::new(),
@@ -674,6 +681,25 @@ impl Reactor {
                             "unsolicited frame"
                         );
                     }
+                    // If this is the "clock" response for a pending get_clock_async
+                    // request, inject RAW timestamps so Python clocksync sees an
+                    // honest RTT rather than the usual half_rtt=0 artefact.
+                    if name == "clock" {
+                        if let Some(sent_raw) = self.pending_clock_sent_raw.take() {
+                            let recv_raw = crate::clock::monotonic_raw_secs();
+                            let mut stamped = params.clone();
+                            stamped.sent_time_raw = sent_raw;
+                            stamped.recv_time_raw = recv_raw;
+                            let event =
+                                crate::host_io::runtime_events::RuntimeEvent::PassthroughResponse {
+                                    name,
+                                    params: stamped,
+                                };
+                            self.dispatch_runtime_event(event);
+                            return Ok(());
+                        }
+                    }
+
                     self.interceptors.dispatch(&name, oid, &params);
 
                     if !self.try_dispatch_passthrough_response(&raw_payload) {
@@ -1066,6 +1092,25 @@ impl Reactor {
                     if is_io {
                         self.transition_closed_on_io_fault();
                     }
+                }
+            }
+            ReactorCommand::GetClockAndDeliver {
+                get_clock_bytes,
+                sent_time_raw,
+            } => {
+                self.pending_clock_sent_raw = Some(sent_time_raw);
+                if let Err(e) = self.dispatch_fire_and_forget(get_clock_bytes) {
+                    let is_io = matches!(e, TransportError::Io(_));
+                    tracing::error!(
+                        subsystem = "mcu-comms",
+                        event = "get_clock_async_send_error",
+                        error = %e,
+                        "GetClockAndDeliver dispatch failed"
+                    );
+                    if is_io {
+                        self.transition_closed_on_io_fault();
+                    }
+                    self.pending_clock_sent_raw = None;
                 }
             }
             ReactorCommand::Noop => {}

--- a/rust/kalico-host-rt/src/host_io/reactor/a8_fire_and_forget_backpressure.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor/a8_fire_and_forget_backpressure.rs
@@ -35,7 +35,7 @@ fn a8_fire_and_forget_enqueues_under_window_full() {
     // Dispatch a fire-and-forget payload while the window is full.
     let payload = vec![0xAB, 0xCD, 0xEF];
     h.reactor
-        .dispatch_fire_and_forget(payload.clone())
+        .dispatch_fire_and_forget(payload.clone(), false)
         .expect("enqueue should not error under ceiling");
 
     // The payload must NOT have been written to the wire — it should be
@@ -73,7 +73,7 @@ fn a8_pending_fire_and_submission_drain_in_fifo_order() {
     fill_window(&mut h);
 
     h.reactor
-        .dispatch_fire_and_forget(vec![0xF1])
+        .dispatch_fire_and_forget(vec![0xF1], false)
         .expect("first fire-and-forget enqueues");
     let (tx, _rx) = sync_channel(1);
     h.reactor
@@ -86,7 +86,7 @@ fn a8_pending_fire_and_submission_drain_in_fifo_order() {
         )
         .expect("submission enqueues");
     h.reactor
-        .dispatch_fire_and_forget(vec![0xF2])
+        .dispatch_fire_and_forget(vec![0xF2], false)
         .expect("second fire-and-forget enqueues");
 
     assert_eq!(
@@ -130,7 +130,7 @@ fn a8_overflow_returns_backpressure_error() {
     // Fill the pending_fire_and_forget queue to the ceiling.
     for _ in 0..PENDING_FIRE_AND_FORGET_CEILING {
         h.reactor
-            .dispatch_fire_and_forget(vec![0x01])
+            .dispatch_fire_and_forget(vec![0x01], false)
             .expect("enqueue should succeed up to ceiling");
     }
     assert_eq!(
@@ -139,7 +139,7 @@ fn a8_overflow_returns_backpressure_error() {
     );
 
     // The next payload must error with Backpressure (not silent-drop).
-    let result = h.reactor.dispatch_fire_and_forget(vec![0x02]);
+    let result = h.reactor.dispatch_fire_and_forget(vec![0x02], false);
     assert!(
         matches!(result, Err(TransportError::Backpressure)),
         "overflow must return Backpressure, got {result:?}",

--- a/rust/kalico-host-rt/src/host_io/reactor/tests.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor/tests.rs
@@ -504,6 +504,17 @@ fn drain_pending_surfaces_write_failure() {
 }
 
 #[test]
+fn flush_all_completions_clears_pending_clock_sent_raw() {
+    let (mut reactor, _) = test_reactor_with_inflight(&[]);
+    reactor.pending_clock_sent_raw = Some(1234.5);
+    reactor.flush_all_completions();
+    assert!(
+        reactor.pending_clock_sent_raw.is_none(),
+        "flush_all_completions must clear pending_clock_sent_raw to avoid stale RTT stamp on reconnect"
+    );
+}
+
+#[test]
 fn broken_pipe_latches_host_disconnect_fault() {
     let (_, rx) = std::sync::mpsc::channel::<crate::host_io::ReactorCommand>();
     let status_snapshot = Arc::new(arc_swap::ArcSwap::from_pointee(

--- a/rust/kalico-host-rt/src/host_io/window.rs
+++ b/rust/kalico-host-rt/src/host_io/window.rs
@@ -72,6 +72,9 @@ pub struct AwaitEntry {
     pub submitted_at: Instant,
     pub deadline: Instant,
     pub abandoned: bool,
+    /// CLOCK_MONOTONIC_RAW seconds captured just before the frame was written to wire.
+    /// Zero when not measured.
+    pub sent_time_raw: f64,
 }
 
 #[derive(Debug, Default)]

--- a/rust/kalico-host-rt/src/host_io/window/awaiting_tests.rs
+++ b/rust/kalico-host-rt/src/host_io/window/awaiting_tests.rs
@@ -20,6 +20,7 @@ fn make_entry(
             submitted_at: Instant::now(),
             deadline,
             abandoned: false,
+            sent_time_raw: 0.0,
         },
         rx,
     )

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Instant;
 
 use indexmap::IndexMap;
@@ -11,7 +11,7 @@ use super::mcu_state::{CommandQueueId, McuState, PushError};
 use super::notify::{NotifyCallback, NotifyResponse, NotifyTable};
 use super::receive_window::ReceiveWindow;
 use super::stats::{PassthroughStats, StatsCounters};
-use crate::clock::Clock;
+use crate::clock::{Clock, instant_to_f64};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct McuHandle(u32);
@@ -93,16 +93,6 @@ impl std::fmt::Debug for PassthroughRouter {
             .field("mcus", &self.mcus)
             .field("next_handle", &self.next_handle)
             .finish()
-    }
-}
-
-fn instant_to_f64(instant: Instant) -> f64 {
-    static ANCHOR: OnceLock<Instant> = OnceLock::new();
-    let anchor = ANCHOR.get_or_init(Instant::now);
-    if instant >= *anchor {
-        instant.duration_since(*anchor).as_secs_f64()
-    } else {
-        -(anchor.duration_since(instant).as_secs_f64())
     }
 }
 

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -361,6 +361,44 @@ impl PassthroughRouter {
         Ok(())
     }
 
+    /// Convert an MCU tick count to a wall-clock `OffsetDateTime`.
+    ///
+    /// Returns `None` when no clock record has been set for this MCU
+    /// (i.e. `clock_freq == 0.0` — no `set_clock_est_rebased` call yet).
+    ///
+    /// `estimated = true` when the tick is more than one frequency-second from
+    /// the anchor, i.e. significant extrapolation.
+    pub fn wall_time_at_mcu(
+        &self,
+        mcu: McuHandle,
+        mcu_ticks: u64,
+    ) -> Option<(time::OffsetDateTime, bool)> {
+        let rec = self.mcus.get(&mcu)?;
+        if rec.clock_freq == 0.0 {
+            return None;
+        }
+        // Project the tick into the Instant epoch used throughout the router.
+        #[allow(clippy::cast_precision_loss)]
+        let delta_ticks = (mcu_ticks as f64) - (rec.last_clock as f64);
+        let mcu_host_instant = rec.clock_offset + delta_ticks / rec.clock_freq;
+        // Anchor Instant epoch → wall time via the gap between the projection
+        // point and the current instant.
+        let now_instant = instant_to_f64(self.clock.now());
+        let delta_from_now = mcu_host_instant - now_instant;
+        let wall_now = std::time::SystemTime::now();
+        let wall_time = if delta_from_now >= 0.0 {
+            wall_now
+                .checked_add(std::time::Duration::from_secs_f64(delta_from_now))
+                .unwrap_or(wall_now)
+        } else {
+            wall_now
+                .checked_sub(std::time::Duration::from_secs_f64(-delta_from_now))
+                .unwrap_or(wall_now)
+        };
+        let estimated = delta_ticks.abs() / rec.clock_freq > 1.0;
+        Some((time::OffsetDateTime::from(wall_time), estimated))
+    }
+
     pub fn ack_clock_and_freq(&self, mcu: McuHandle) -> Option<(u64, f64)> {
         let rec = self.mcus.get(&mcu)?;
         if rec.clock_freq == 0.0 {

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -316,23 +316,31 @@ impl PassthroughRouter {
         Ok(())
     }
 
+    /// Set the router's clock record from a Python-side clocksync estimate.
+    ///
+    /// `offset_raw` is `time_avg + min_half_rtt` in CLOCK_MONOTONIC_RAW seconds
+    /// (what Python's `_handle_clock` computes and the mirror callback exports).
+    /// `host_now_raw` must be a CLOCK_MONOTONIC_RAW reading captured on the Rust
+    /// side (via `kalico_host_rt::clock::monotonic_raw_secs()`) at the same
+    /// instant as the `instant_to_f64(self.clock.now())` reading, so both sides
+    /// of the domain conversion are in RAW units and the resulting `clock_offset`
+    /// lands in the Rust `Instant` epoch used everywhere else in the router.
     pub fn set_clock_est_rebased(
         &mut self,
         mcu: McuHandle,
         freq: f64,
-        offset: f64,
+        offset_raw: f64,
         last_clock: u64,
-        host_now_same_epoch: f64,
+        host_now_raw: f64,
     ) -> Result<(), RouterError> {
-        let bridge_now = instant_to_f64(self.clock.now());
+        let bridge_now_instant = instant_to_f64(self.clock.now());
         let rec = self
             .mcus
             .get_mut(&mcu)
             .ok_or(RouterError::UnknownMcu(mcu))?;
         rec.clock_freq = freq;
-        rec.clock_offset = bridge_now - (host_now_same_epoch - offset);
+        rec.clock_offset = bridge_now_instant - (host_now_raw - offset_raw);
         rec.last_clock = last_clock;
-
         Ok(())
     }
 

--- a/rust/kalico-host-rt/src/passthrough_queue/router/tests.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router/tests.rs
@@ -399,3 +399,50 @@ fn flush_does_not_fire_twice_without_new_entries() {
     router.check_flush(mcu).unwrap();
     assert_eq!(*count.lock().unwrap(), 1);
 }
+
+/// `wall_time_at_mcu` returns a real wall time when a clock record is present.
+///
+/// Anchor at now with last_clock=100_000_000 and freq=100 MHz so that
+/// mcu_tick=100_000_000 (i.e. the anchor itself) maps to "now".  The returned
+/// wall time must be within ±1 second of the current system clock, and
+/// `estimated` must be false (delta_ticks / freq = 0.0, within the 1 s window).
+#[test]
+fn wall_time_at_mcu_known_record_returns_wall_time() {
+    let (mut router, clock) = make_router();
+    let mcu = router.claim_mcu("mcu");
+
+    // Anchor: last_clock=100_000_000 ticks at "now" in the mock clock.
+    let anchor_host = instant_to_f64(clock.now());
+    router
+        .set_clock_est(mcu, 100_000_000.0, anchor_host, 100_000_000)
+        .unwrap();
+
+    let (dt, estimated) = router
+        .wall_time_at_mcu(mcu, 100_000_000)
+        .expect("must return Some when clock record is set");
+
+    // The result must be within 1 second of wall-clock now.
+    let now_unix = time::OffsetDateTime::now_utc();
+    let diff = (dt - now_unix).abs();
+    assert!(
+        diff <= time::Duration::seconds(1),
+        "wall time {dt} must be within 1 s of system clock {now_unix}"
+    );
+    assert!(
+        !estimated,
+        "estimated must be false when delta is exactly 0 ticks"
+    );
+}
+
+/// `wall_time_at_mcu` returns `None` before any clock record has been set.
+#[test]
+fn wall_time_at_mcu_no_record_returns_none() {
+    let (mut router, _) = make_router();
+    let mcu = router.claim_mcu("mcu");
+
+    // No set_clock_est call — clock_freq defaults to 0.0.
+    assert!(
+        router.wall_time_at_mcu(mcu, 1_000_000_000).is_none(),
+        "must return None when no clock record has been set"
+    );
+}

--- a/rust/kalico-host-rt/src/passthrough_queue/router/tests.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router/tests.rs
@@ -434,6 +434,31 @@ fn wall_time_at_mcu_known_record_returns_wall_time() {
     );
 }
 
+/// `wall_time_at_mcu` returns `estimated == true` when the tick is more than
+/// one MCU-frequency-second from the anchor.
+///
+/// Anchor at last_clock=100_000_000 with freq=100 MHz.  A tick at
+/// 300_000_000 is 200_000_000 ticks away = 2.0 s > 1.0 s → estimated.
+#[test]
+fn wall_time_at_mcu_far_from_anchor_returns_estimated_true() {
+    let (mut router, clock) = make_router();
+    let mcu = router.claim_mcu("mcu");
+
+    let anchor_host = crate::clock::instant_to_f64(clock.now());
+    router
+        .set_clock_est(mcu, 100_000_000.0, anchor_host, 100_000_000)
+        .unwrap();
+
+    let (_, estimated) = router
+        .wall_time_at_mcu(mcu, 300_000_000)
+        .expect("must return Some when clock record is set");
+
+    assert!(
+        estimated,
+        "estimated must be true when tick is 2 MCU-seconds from anchor"
+    );
+}
+
 /// `wall_time_at_mcu` returns `None` before any clock record has been set.
 #[test]
 fn wall_time_at_mcu_no_record_returns_none() {

--- a/rust/kalico-host-rt/src/transport.rs
+++ b/rust/kalico-host-rt/src/transport.rs
@@ -89,6 +89,12 @@ pub trait Transport: Send + Sync {
 #[derive(Debug, Default, Clone)]
 pub struct MessageParams {
     pub fields: HashMap<String, MessageValue>,
+    /// CLOCK_MONOTONIC_RAW seconds at the instant the request frame was written to
+    /// the wire. Zero when not measured (e.g. non-bridge path or before first sample).
+    pub sent_time_raw: f64,
+    /// CLOCK_MONOTONIC_RAW seconds at the instant the matching response frame was
+    /// received. Zero when not measured.
+    pub recv_time_raw: f64,
 }
 
 impl MessageParams {

--- a/rust/kalico-host-rt/tests/clock_sync_unit.rs
+++ b/rust/kalico-host-rt/tests/clock_sync_unit.rs
@@ -42,7 +42,7 @@ fn quality_gate_requires_recent_dedicated_sample_per_plan_decision_b() {
         est.is_quality_gate_passed(freq).is_ok(),
         "should pass with fresh dedicated sample on regression line; \
          residual_max={} drift_ppm={} samples={}",
-        est.residual_max_in_window,
+        est.residual_ewma_us,
         est.drift_ppm(freq),
         est.sample_count(),
     );

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1594,6 +1594,38 @@ impl PyMotionBridge {
         offset: f64,
         last_clock: u64,
     ) -> PyResult<()> {
+        // If the Rust periodic sync loop is running for this MCU, it is the
+        // single writer of the router clock record.  Suppress the Python-driven
+        // write to prevent two different estimators alternately re-anchoring
+        // the same projection record, which produces offset steps.
+        //
+        // We still update clock_freqs so the Rust loop can seed its estimator
+        // with the correct nominal frequency even when suppressed.
+        let dedicated_sync_active = {
+            let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
+            mcus.get(&mcu)
+                .map(|c| c.clock_sync_stop.is_some())
+                .unwrap_or(false)
+        };
+
+        self.clock_freqs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(mcu, freq);
+
+        if dedicated_sync_active {
+            use std::sync::atomic::{AtomicBool, Ordering as AOrd};
+            static LOGGED: AtomicBool = AtomicBool::new(false);
+            if !LOGGED.swap(true, AOrd::Relaxed) {
+                log::info!(
+                    "[clocksync] mcu={mcu}: dedicated Rust sync loop active — \
+                     suppressing Python-driven set_clock_est writes to router \
+                     (single-writer discipline)"
+                );
+            }
+            return Ok(());
+        }
+
         let host_now_same_epoch: f64 = py
             .import("time")?
             .getattr("monotonic")?
@@ -1622,10 +1654,6 @@ impl PyMotionBridge {
                 host_now_same_epoch,
             )
             .map_err(router_err)?;
-        self.clock_freqs
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .insert(mcu, freq);
         Ok(())
     }
 

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1399,17 +1399,17 @@ impl PyMotionBridge {
         Ok(Some(d.unbind()))
     }
 
-    /// Send an encoded `get_clock` command and register the pending sent-time
-    /// so the reactor can stamp the unsolicited "clock" response with honest
-    /// CLOCK_MONOTONIC_RAW RTT measurements.
+    /// Ask the MCU's reactor to encode+send `get_clock` and stamp the
+    /// unsolicited "clock" response with honest CLOCK_MONOTONIC_RAW RTT
+    /// measurements. Encoding happens in the reactor with that MCU's own
+    /// dictionary — the bridge-level parser holds whichever dict was set
+    /// last and must never encode for a specific MCU.
     ///
-    /// Called from `serialhdl.raw_send` in bridge mode for the periodic
+    /// Called from `serialhdl` in bridge mode for the periodic
     /// `_get_clock_event` loop.  Returns immediately (fire-and-forget); the
     /// response arrives via `take_runtime_event` as a PassthroughResponse with
     /// `sent_time_raw`/`recv_time_raw` baked in.
     fn bridge_get_clock_async(&self, mcu_handle: u32) -> PyResult<()> {
-        use kalico_host_rt::transport::Transport;
-
         let io = {
             let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
             let conn = mcus.get(&mcu_handle).ok_or_else(|| {
@@ -1424,28 +1424,9 @@ impl PyMotionBridge {
             })?.clone()
         };
 
-        let parser_guard = self.parser.lock().unwrap_or_else(|p| p.into_inner());
-        let parser = parser_guard.as_ref().ok_or_else(|| {
-            pyo3::exceptions::PyRuntimeError::new_err(
-                "bridge_get_clock_async: msgproto parser not configured \
-                 (set_msgproto_dict not called)",
-            )
-        })?;
-
-        let get_clock_bytes = parser.encode("get_clock").map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "bridge_get_clock_async: encode 'get_clock': {e:?}"
-            ))
-        })?;
-
-        let sent_time_raw = kalico_host_rt::clock::monotonic_raw_secs();
-
-        io.get_clock_async(get_clock_bytes, sent_time_raw)
-            .map_err(|e| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "bridge_get_clock_async: {e}"
-                ))
-            })
+        io.get_clock_async().map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("bridge_get_clock_async: {e}"))
+        })
     }
 
     #[pyo3(signature = (mcu_handle, msg))]

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
@@ -38,122 +38,11 @@ struct McuConnection {
     runtime_caps: Option<kalico_protocol::messages::RuntimeCapsResponse>,
     identify_caps: u64,
     kalico_native_supported: bool,
-    clock_sync_stop: Option<Arc<AtomicBool>>,
-    clock_sync_thread: Option<JoinHandle<()>>,
-    clock_sync_estimator:
-        Option<Arc<std::sync::RwLock<kalico_host_rt::clock_sync::ClockSyncEstimator>>>,
     ethercat_socket: Option<String>,
 }
 
-const CLOCK_SYNC_INTERVAL: Duration = Duration::from_millis(500);
-const CLOCK_SYNC_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
 /// Exceeding this means a wedged MCU — fail loudly.
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
-
-fn spawn_periodic_clock_sync(
-    mcu_handle_raw: u32,
-    host_io: Arc<KalicoHostIo>,
-    router: Arc<Mutex<PassthroughRouter>>,
-    clock_freqs: Arc<Mutex<HashMap<u32, f64>>>,
-    stop: Arc<AtomicBool>,
-    estimator: Arc<std::sync::RwLock<kalico_host_rt::clock_sync::ClockSyncEstimator>>,
-) -> JoinHandle<()> {
-    use kalico_host_rt::transport::Transport;
-
-    let mcu_h = mcu_handle_from_raw(mcu_handle_raw);
-    std::thread::Builder::new()
-        .name(format!("clock-sync-mcu-{mcu_handle_raw}"))
-        .spawn(move || {
-                {
-                let initial_freq = {
-                    let guard = clock_freqs.lock().unwrap_or_else(|p| p.into_inner());
-                    guard.get(&mcu_handle_raw).copied().unwrap_or(100_000_000.0)
-                };
-                let mut est = estimator.write().unwrap_or_else(|p| p.into_inner());
-                *est = kalico_host_rt::clock_sync::ClockSyncEstimator::new(initial_freq);
-            }
-
-            std::thread::sleep(Duration::from_millis(200));
-
-            while !stop.load(Ordering::Relaxed) {
-                let request_id = {
-                    let mut est = estimator.write().unwrap_or_else(|p| p.into_inner());
-                    est.next_clock_sync_request_id()
-                };
-                let host_send = Instant::now();
-                let cmd = format!(
-                    "runtime_clock_sync_request request_id={request_id} \
-                     host_send_time_lo=0 host_send_time_hi=0"
-                );
-                if let Ok(resp) = host_io.call(
-                    &cmd,
-                    "kalico_clock_sync_response",
-                    CLOCK_SYNC_REQUEST_TIMEOUT,
-                ) {
-                    let host_recv = Instant::now();
-                    if let Some(echoed) = resp.try_get_u32("request_id") {
-                        if echoed == request_id {
-                            let lo = resp.try_get_u32("mcu_clock_lo").unwrap_or(0);
-                            let hi = resp.try_get_u32("mcu_clock_hi").unwrap_or(0);
-                            let mcu_at_response =
-                                (u64::from(hi) << 32) | u64::from(lo);
-                            // Skip uninitialised MCU clock samples (TIM5 not yet ticking).
-                            // Feeding 0 into the regression collapses slope→0 and overwrites
-                            // klippy's valid clock_freq, wedging dispatch.
-                            const MCU_CLOCK_INIT_FLOOR: u64 = 100_000_000;
-                            if mcu_at_response < MCU_CLOCK_INIT_FLOOR {
-                                use std::sync::atomic::{AtomicUsize, Ordering as AOrd};
-                                static SKIP_COUNT: AtomicUsize = AtomicUsize::new(0);
-                                let n = SKIP_COUNT.fetch_add(1, AOrd::Relaxed);
-                                if n < 3 || n % 100 == 0 {
-                                    log::debug!(
-                                        "[bridge-trace] clock-sync skipping uninit MCU sample #{} mcu_at_response={} (TIM5 likely not yet ticking — pre-first-push)",
-                                        n, mcu_at_response,
-                                    );
-                                }
-                            } else {
-                                let (freq_est, mcu_at_send) = {
-                                    let mut est = estimator
-                                        .write()
-                                        .unwrap_or_else(|p| p.into_inner());
-                                    est.add_dedicated_sample(
-                                        host_send,
-                                        host_recv,
-                                        mcu_at_response,
-                                    );
-                                    let rtt = host_recv.saturating_duration_since(host_send);
-                                    #[allow(
-                                        clippy::cast_sign_loss,
-                                        clippy::cast_possible_truncation
-                                    )]
-                                    let one_way_cycles = (rtt.as_secs_f64()
-                                        * est.clock_freq_estimate
-                                        / 2.0) as u64;
-                                    let at_send =
-                                        mcu_at_response.saturating_sub(one_way_cycles);
-                                    (est.clock_freq_estimate, at_send)
-                                };
-                                let mut r = router.lock().unwrap_or_else(|p| p.into_inner());
-                                let _ = r.set_clock_est_from_sample(
-                                    mcu_h,
-                                    freq_est,
-                                    host_send,
-                                    mcu_at_send,
-                                );
-                            }
-                        }
-                    }
-                }
-                let mut remaining = CLOCK_SYNC_INTERVAL;
-                while remaining > Duration::ZERO && !stop.load(Ordering::Relaxed) {
-                    let chunk = remaining.min(Duration::from_millis(50));
-                    std::thread::sleep(chunk);
-                    remaining = remaining.saturating_sub(chunk);
-                }
-            }
-        })
-        .expect("clock-sync thread spawn")
-}
 
 #[derive(Debug, thiserror::Error)]
 enum RuntimeCapsError {
@@ -561,9 +450,6 @@ impl PyMotionBridge {
                 runtime_caps: None,
                 identify_caps: 0,
                 kalico_native_supported: false,
-                clock_sync_stop: None,
-                clock_sync_thread: None,
-                clock_sync_estimator: None,
                 ethercat_socket: None,
             },
         );
@@ -586,9 +472,6 @@ impl PyMotionBridge {
                 runtime_caps: None,
                 identify_caps: 0,
                 kalico_native_supported: true,
-                clock_sync_stop: None,
-                clock_sync_thread: None,
-                clock_sync_estimator: None,
                 ethercat_socket: Some(socket_path.to_owned()),
             },
         );
@@ -596,20 +479,10 @@ impl PyMotionBridge {
     }
 
     fn release_mcu(&self, handle: u32) -> PyResult<()> {
-        let (stop, join) = {
-            let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
-            let conn_opt = mcus.remove(&handle);
-            match conn_opt {
-                Some(mut c) => (c.clock_sync_stop.take(), c.clock_sync_thread.take()),
-                None => (None, None),
-            }
-        };
-        if let Some(stop) = stop {
-            stop.store(true, Ordering::Release);
-        }
-        if let Some(join) = join {
-            let _ = join.join();
-        }
+        self.mcus
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&handle);
 
         let mut router = self.router.lock().unwrap_or_else(|p| p.into_inner());
         router.release_mcu(mcu_handle_from_raw(handle));
@@ -827,12 +700,6 @@ impl PyMotionBridge {
     fn detach_serial(&self, mcu_handle: u32) -> PyResult<()> {
         let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(conn) = mcus.get_mut(&mcu_handle) {
-            if let Some(stop) = conn.clock_sync_stop.take() {
-                stop.store(true, std::sync::atomic::Ordering::Release);
-            }
-            if let Some(h) = conn.clock_sync_thread.take() {
-                let _ = h.join();
-            }
             conn.runtime_rx = None;
             conn.host_io = None;
         }
@@ -945,12 +812,6 @@ impl PyMotionBridge {
                     "attach_serial: unknown mcu_handle {mcu_handle} (claim_mcu not called)"
                 ))
             })?;
-            if let Some(stop) = conn.clock_sync_stop.take() {
-                stop.store(true, std::sync::atomic::Ordering::Release);
-            }
-            if let Some(h) = conn.clock_sync_thread.take() {
-                let _ = h.join();
-            }
             conn.runtime_rx = None;
             conn.host_io = None;
             conn.label.clone()
@@ -1059,63 +920,49 @@ impl PyMotionBridge {
             .map_err(PyRuntimeError::new_err)?;
         }
 
-        let (clock_sync_stop, clock_sync_thread, clock_sync_estimator_arc) =
-            if kalico_native_supported {
-                let stop = Arc::new(AtomicBool::new(false));
-                let est_arc = Arc::new(std::sync::RwLock::new(
-                    kalico_host_rt::clock_sync::ClockSyncEstimator::new(100_000_000.0),
-                ));
-                let handle = spawn_periodic_clock_sync(
-                    mcu_handle,
-                    Arc::clone(&host_io_arc),
-                    Arc::clone(&self.router),
-                    Arc::clone(&self.clock_freqs),
-                    Arc::clone(&stop),
-                    Arc::clone(&est_arc),
-                );
-
-                let events_dir_guard = self.events_dir.lock().unwrap_or_else(|p| p.into_inner());
-                if let Some(ref dir) = *events_dir_guard {
-                    use crate::logging::writer::{
-                        DEFAULT_BACKUP_COUNT, DEFAULT_MAX_BYTES, FSYNC_INTERVAL,
-                        RotatingJsonlWriter,
-                    };
-                    let source = mcu_label.clone();
-                    let jsonl_path = dir.join(format!("{source}.jsonl"));
-                    match RotatingJsonlWriter::new(
-                        &jsonl_path,
-                        DEFAULT_MAX_BYTES,
-                        DEFAULT_BACKUP_COUNT,
-                        FSYNC_INTERVAL,
-                    ) {
-                        Ok(writer) => {
-                            let arc_writer = Arc::new(Mutex::new(writer));
-                            let hook = crate::mcu_log::build_mcu_log_hook(
-                                Arc::clone(&est_arc),
-                                arc_writer,
-                                source,
-                            );
-                            host_io_arc.set_mcu_log_hook(Box::new(hook));
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "attach_serial: mcu-log: failed to open {}: {e}",
-                                jsonl_path.display()
-                            );
-                        }
+        if kalico_native_supported {
+            // Wire the MCU log hook.  The hook timestamps MCU log events using
+            // the router's clock record — fed by Python clocksync via
+            // set_clock_est, which is the single writer for all MCUs.
+            let events_dir_guard = self.events_dir.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(ref dir) = *events_dir_guard {
+                use crate::logging::writer::{
+                    DEFAULT_BACKUP_COUNT, DEFAULT_MAX_BYTES, FSYNC_INTERVAL, RotatingJsonlWriter,
+                };
+                let source = mcu_label.clone();
+                let jsonl_path = dir.join(format!("{source}.jsonl"));
+                match RotatingJsonlWriter::new(
+                    &jsonl_path,
+                    DEFAULT_MAX_BYTES,
+                    DEFAULT_BACKUP_COUNT,
+                    FSYNC_INTERVAL,
+                ) {
+                    Ok(writer) => {
+                        let arc_writer = Arc::new(Mutex::new(writer));
+                        let mcu_h = mcu_handle_from_raw(mcu_handle);
+                        let hook = crate::mcu_log::build_mcu_log_hook(
+                            Arc::clone(&self.router),
+                            mcu_h,
+                            arc_writer,
+                            source,
+                        );
+                        host_io_arc.set_mcu_log_hook(Box::new(hook));
                     }
-                } else {
-                    unreachable!(
-                        "attach_serial: events_dir is None for a kalico-native MCU \
-                         — require_events_dir_for_kalico_native should have \
-                         rejected this call before reaching hook wiring"
-                    );
+                    Err(e) => {
+                        log::warn!(
+                            "attach_serial: mcu-log: failed to open {}: {e}",
+                            jsonl_path.display()
+                        );
+                    }
                 }
-
-                (Some(stop), Some(handle), Some(est_arc))
             } else {
-                (None, None, None)
-            };
+                unreachable!(
+                    "attach_serial: events_dir is None for a kalico-native MCU \
+                     — require_events_dir_for_kalico_native should have \
+                     rejected this call before reaching hook wiring"
+                );
+            }
+        }
 
         let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
         let conn = mcus.get_mut(&mcu_handle).ok_or_else(|| {
@@ -1126,9 +973,6 @@ impl PyMotionBridge {
         conn.runtime_caps = runtime_caps;
         conn.identify_caps = identify_caps;
         conn.kalico_native_supported = kalico_native_supported;
-        conn.clock_sync_stop = clock_sync_stop;
-        conn.clock_sync_thread = clock_sync_thread;
-        conn.clock_sync_estimator = clock_sync_estimator_arc;
         Ok(())
     }
 

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1543,12 +1543,65 @@ impl PyMotionBridge {
                         MessageValue::String(s) => d.set_item(k, s)?,
                     }
                 }
+                if params.sent_time_raw != 0.0 {
+                    d.set_item("#sent_time_raw", params.sent_time_raw)?;
+                    d.set_item("#receive_time_raw", params.recv_time_raw)?;
+                }
             }
             RuntimeEvent::McuLog(_) => {
                 return Ok(None);
             }
         }
         Ok(Some(d.unbind()))
+    }
+
+    /// Send an encoded `get_clock` command and register the pending sent-time
+    /// so the reactor can stamp the unsolicited "clock" response with honest
+    /// CLOCK_MONOTONIC_RAW RTT measurements.
+    ///
+    /// Called from `serialhdl.raw_send` in bridge mode for the periodic
+    /// `_get_clock_event` loop.  Returns immediately (fire-and-forget); the
+    /// response arrives via `take_runtime_event` as a PassthroughResponse with
+    /// `sent_time_raw`/`recv_time_raw` baked in.
+    fn bridge_get_clock_async(&self, mcu_handle: u32) -> PyResult<()> {
+        use kalico_host_rt::transport::Transport;
+
+        let io = {
+            let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
+            let conn = mcus.get(&mcu_handle).ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "bridge_get_clock_async: unknown mcu_handle {mcu_handle}"
+                ))
+            })?;
+            conn.host_io.as_ref().ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err(
+                    "bridge_get_clock_async: attach_serial has not been called for this MCU",
+                )
+            })?.clone()
+        };
+
+        let parser_guard = self.parser.lock().unwrap_or_else(|p| p.into_inner());
+        let parser = parser_guard.as_ref().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err(
+                "bridge_get_clock_async: msgproto parser not configured \
+                 (set_msgproto_dict not called)",
+            )
+        })?;
+
+        let get_clock_bytes = parser.encode("get_clock").map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "bridge_get_clock_async: encode 'get_clock': {e:?}"
+            ))
+        })?;
+
+        let sent_time_raw = kalico_host_rt::clock::monotonic_raw_secs();
+
+        io.get_clock_async(get_clock_bytes, sent_time_raw)
+            .map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "bridge_get_clock_async: {e}"
+                ))
+            })
     }
 
     #[pyo3(signature = (mcu_handle, msg))]

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1467,7 +1467,7 @@ impl PyMotionBridge {
             .map_err(|e| PyRuntimeError::new_err(format!("bridge_mark_expected_disconnect: {e}")))
     }
 
-    #[pyo3(signature = (mcu, freq, offset, last_clock))]
+    #[pyo3(signature = (mcu, freq, offset, last_clock, host_now_raw))]
     fn set_clock_est(
         &self,
         _py: Python<'_>,
@@ -1475,6 +1475,7 @@ impl PyMotionBridge {
         freq: f64,
         offset: f64,
         last_clock: u64,
+        host_now_raw: f64,
     ) -> PyResult<()> {
         // Python clocksync is the single writer of the router clock record for
         // all MCUs (including kalico-native H7/F446 and Beacon).  The former
@@ -1483,15 +1484,14 @@ impl PyMotionBridge {
         //
         // `offset` arrives as `time_avg + min_half_rtt` in CLOCK_MONOTONIC_RAW
         // seconds (the mirror callback now exports the faithful clock_est triple
-        // rather than TRANSMIT_EXTRA-biased values).  Capture a RAW reading on
-        // the Rust side so both sides of the epoch translation are in the same
-        // domain, then rebase into the Rust Instant epoch.
+        // rather than TRANSMIT_EXTRA-biased values).  `host_now_raw` is captured
+        // by the Python callback as its first action (reactor.monotonic() ==
+        // CLOCK_MONOTONIC_RAW) so both sides of the epoch translation are in the
+        // same domain with no GIL-hop jitter added on the Rust side.
         self.clock_freqs
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .insert(mcu, freq);
-
-        let host_now_raw = kalico_host_rt::clock::monotonic_raw_secs();
 
         use std::sync::atomic::{AtomicUsize, Ordering as AOrd};
         static SET_CLOCK_EST_CALLS: AtomicUsize = AtomicUsize::new(0);

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1447,6 +1447,10 @@ impl PyMotionBridge {
                 MessageValue::String(s) => d.set_item(k, s)?,
             }
         }
+        if params.sent_time_raw != 0.0 {
+            d.set_item("#sent_time_raw", params.sent_time_raw)?;
+            d.set_item("#receive_time_raw", params.recv_time_raw)?;
+        }
         Ok(d.unbind())
     }
 

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1410,19 +1410,20 @@ impl PyMotionBridge {
     /// response arrives via `take_runtime_event` as a PassthroughResponse with
     /// `sent_time_raw`/`recv_time_raw` baked in.
     fn bridge_get_clock_async(&self, mcu_handle: u32) -> PyResult<()> {
-        let io = {
-            let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
-            let conn = mcus.get(&mcu_handle).ok_or_else(|| {
-                pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "bridge_get_clock_async: unknown mcu_handle {mcu_handle}"
-                ))
-            })?;
-            conn.host_io.as_ref().ok_or_else(|| {
+        let io =
+            {
+                let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
+                let conn = mcus.get(&mcu_handle).ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "bridge_get_clock_async: unknown mcu_handle {mcu_handle}"
+                    ))
+                })?;
+                conn.host_io.as_ref().ok_or_else(|| {
                 pyo3::exceptions::PyRuntimeError::new_err(
                     "bridge_get_clock_async: attach_serial has not been called for this MCU",
                 )
             })?.clone()
-        };
+            };
 
         io.get_clock_async().map_err(|e| {
             pyo3::exceptions::PyRuntimeError::new_err(format!("bridge_get_clock_async: {e}"))

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1645,49 +1645,29 @@ impl PyMotionBridge {
     #[pyo3(signature = (mcu, freq, offset, last_clock))]
     fn set_clock_est(
         &self,
-        py: Python<'_>,
+        _py: Python<'_>,
         mcu: u32,
         freq: f64,
         offset: f64,
         last_clock: u64,
     ) -> PyResult<()> {
-        // If the Rust periodic sync loop is running for this MCU, it is the
-        // single writer of the router clock record.  Suppress the Python-driven
-        // write to prevent two different estimators alternately re-anchoring
-        // the same projection record, which produces offset steps.
+        // Python clocksync is the single writer of the router clock record for
+        // all MCUs (including kalico-native H7/F446 and Beacon).  The former
+        // Rust periodic sync loop has been retired — clocksync.py feeds every
+        // MCU via this path.
         //
-        // We still update clock_freqs so the Rust loop can seed its estimator
-        // with the correct nominal frequency even when suppressed.
-        let dedicated_sync_active = {
-            let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
-            mcus.get(&mcu)
-                .map(|c| c.clock_sync_stop.is_some())
-                .unwrap_or(false)
-        };
-
+        // `offset` arrives as `time_avg + min_half_rtt` in CLOCK_MONOTONIC_RAW
+        // seconds (the mirror callback now exports the faithful clock_est triple
+        // rather than TRANSMIT_EXTRA-biased values).  Capture a RAW reading on
+        // the Rust side so both sides of the epoch translation are in the same
+        // domain, then rebase into the Rust Instant epoch.
         self.clock_freqs
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .insert(mcu, freq);
 
-        if dedicated_sync_active {
-            use std::sync::atomic::{AtomicBool, Ordering as AOrd};
-            static LOGGED: AtomicBool = AtomicBool::new(false);
-            if !LOGGED.swap(true, AOrd::Relaxed) {
-                log::info!(
-                    "[clocksync] mcu={mcu}: dedicated Rust sync loop active — \
-                     suppressing Python-driven set_clock_est writes to router \
-                     (single-writer discipline)"
-                );
-            }
-            return Ok(());
-        }
+        let host_now_raw = kalico_host_rt::clock::monotonic_raw_secs();
 
-        let host_now_same_epoch: f64 = py
-            .import("time")?
-            .getattr("monotonic")?
-            .call0()?
-            .extract()?;
         use std::sync::atomic::{AtomicUsize, Ordering as AOrd};
         static SET_CLOCK_EST_CALLS: AtomicUsize = AtomicUsize::new(0);
         let call_n = SET_CLOCK_EST_CALLS.fetch_add(1, AOrd::Relaxed);
@@ -1708,7 +1688,7 @@ impl PyMotionBridge {
                 freq,
                 offset,
                 last_clock,
-                host_now_same_epoch,
+                host_now_raw,
             )
             .map_err(router_err)?;
         Ok(())

--- a/rust/motion-bridge/src/drain.rs
+++ b/rust/motion-bridge/src/drain.rs
@@ -79,7 +79,12 @@ impl DrainSync {
                         let b = c.baseline.get(k).copied().unwrap_or(0);
                         format!(
                             "mcu{} axis{}: retired {} baseline {} delta {} / sent {}",
-                            k.0, k.1, r, b, r.saturating_sub(b), s
+                            k.0,
+                            k.1,
+                            r,
+                            b,
+                            r.saturating_sub(b),
+                            s
                         )
                     })
                     .collect();

--- a/rust/motion-bridge/src/drain.rs
+++ b/rust/motion-bridge/src/drain.rs
@@ -1,3 +1,7 @@
+//! `retired` is the MCU's raw cumulative counter (monotonic per boot); `sent`
+//! is per-stream. `reset()` snapshots `retired` into `baseline` so drained
+//! comparisons (`retired - baseline == sent`) survive multi-stream sessions.
+
 use std::collections::HashMap;
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
@@ -8,6 +12,7 @@ type AxisKey = (u32, u8);
 struct Counts {
     sent: HashMap<AxisKey, u32>,
     retired: HashMap<AxisKey, u32>,
+    baseline: HashMap<AxisKey, u32>,
 }
 
 pub struct DrainSync {
@@ -39,15 +44,20 @@ impl DrainSync {
     pub fn reset(&self) {
         let mut c = self.counts.lock().unwrap_or_else(|p| p.into_inner());
         c.sent.clear();
-        c.retired.clear();
+        let snapshot: Vec<(AxisKey, u32)> = c.retired.iter().map(|(&k, &v)| (k, v)).collect();
+        for (k, v) in snapshot {
+            c.baseline.insert(k, v);
+        }
         drop(c);
         self.cv.notify_all();
     }
 
     fn is_drained(c: &Counts) -> bool {
-        c.sent
-            .iter()
-            .all(|(k, &s)| c.retired.get(k).copied().unwrap_or(0) == s)
+        c.sent.iter().all(|(k, &s)| {
+            let r = c.retired.get(k).copied().unwrap_or(0);
+            let b = c.baseline.get(k).copied().unwrap_or(0);
+            r.saturating_sub(b) == s
+        })
     }
 
     pub fn wait_drained(&self, timeout: Duration) -> Result<(), String> {
@@ -59,10 +69,18 @@ impl DrainSync {
                 let lagging: Vec<String> = c
                     .sent
                     .iter()
-                    .filter(|(k, s)| c.retired.get(*k).copied().unwrap_or(0) != **s)
+                    .filter(|(k, s)| {
+                        let r = c.retired.get(*k).copied().unwrap_or(0);
+                        let b = c.baseline.get(*k).copied().unwrap_or(0);
+                        r.saturating_sub(b) != **s
+                    })
                     .map(|(k, s)| {
                         let r = c.retired.get(k).copied().unwrap_or(0);
-                        format!("mcu{} axis{}: retired {} / sent {}", k.0, k.1, r, s)
+                        let b = c.baseline.get(k).copied().unwrap_or(0);
+                        format!(
+                            "mcu{} axis{}: retired {} baseline {} delta {} / sent {}",
+                            k.0, k.1, r, b, r.saturating_sub(b), s
+                        )
                     })
                     .collect();
                 return Err(format!(
@@ -102,11 +120,113 @@ mod tests {
         assert!(d.wait_drained(Duration::from_millis(20)).is_ok());
     }
 
+    /// After reset, `sent` is cleared, so even with no new activity the stream
+    /// is trivially drained — even when the heartbeat keeps delivering the old
+    /// cumulative retired value.
     #[test]
-    fn reset_clears_both_sides() {
+    fn reset_clears_sent_cumulative_retired_does_not_break_drain() {
         let d = DrainSync::new();
         d.add_sent(1, 0, 5);
-        d.reset();
+        d.set_retired(1, 0, 5);
         assert!(d.wait_drained(Duration::from_millis(20)).is_ok());
+        d.reset();
+        // Heartbeat arrives again with the same cumulative value; no new sent.
+        d.set_retired(1, 0, 5);
+        assert!(d.wait_drained(Duration::from_millis(20)).is_ok());
+    }
+
+    /// Regression: exact bench numbers from the failing session.
+    ///
+    /// Stream 1: 8737 sent, retired reaches 8737 → drained.
+    /// reset() → baseline is set to 8737.
+    /// Heartbeat fires with cumulative 8737 (no new MCU work yet) → still trivially drained.
+    /// Stream 2: 8737 more sent; MCU retires them: cumulative reaches 17474 → drained.
+    #[test]
+    fn regression_cumulative_retired_across_two_streams() {
+        let d = DrainSync::new();
+
+        // Stream 1.
+        d.add_sent(0, 0, 8737);
+        d.set_retired(0, 0, 8737);
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_ok(),
+            "stream 1 should be drained"
+        );
+
+        d.reset();
+
+        // Heartbeat repeats the cumulative value before any new pieces are sent.
+        d.set_retired(0, 0, 8737);
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_ok(),
+            "after reset with no new sent, trivially drained"
+        );
+
+        // Stream 2: same number of pieces again.
+        d.add_sent(0, 0, 8737);
+        // MCU hasn't retired them yet — not drained.
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_err(),
+            "stream 2 not yet drained before MCU catches up"
+        );
+        // MCU retires stream 2: cumulative becomes 17474.
+        d.set_retired(0, 0, 17474);
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_ok(),
+            "stream 2 should be drained at cumulative 17474"
+        );
+    }
+
+    /// After reset, a cumulative retired value that is ahead of baseline must
+    /// NOT satisfy a new stream's sent unless the delta actually covers it.
+    #[test]
+    fn post_reset_partial_retired_not_drained() {
+        let d = DrainSync::new();
+
+        // Stream 1: drain cleanly.
+        d.add_sent(0, 1, 86);
+        d.set_retired(0, 1, 86);
+        assert!(d.wait_drained(Duration::from_millis(20)).is_ok());
+
+        d.reset();
+
+        // Stream 2: send 100 more; MCU heartbeat still at old cumulative 86.
+        d.add_sent(0, 1, 100);
+        d.set_retired(0, 1, 86); // delta = 0 — not drained
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_err(),
+            "delta 0 against sent 100 must not be drained"
+        );
+        // MCU retires 50 of the 100 new pieces: cumulative = 136.
+        d.set_retired(0, 1, 136); // delta = 50 — still not drained
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_err(),
+            "delta 50 against sent 100 must not be drained"
+        );
+        // Full 100 retired: cumulative = 186.
+        d.set_retired(0, 1, 186); // delta = 100 — drained
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_ok(),
+            "delta 100 against sent 100 must be drained"
+        );
+    }
+
+    /// Multi-axis: all axes must be drained before wait_drained returns Ok.
+    #[test]
+    fn multi_axis_all_must_drain() {
+        let d = DrainSync::new();
+        d.add_sent(0, 0, 17474);
+        d.add_sent(1, 2, 86);
+
+        d.set_retired(0, 0, 17474);
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_err(),
+            "axis (1,2) still pending"
+        );
+        d.set_retired(1, 2, 86);
+        assert!(
+            d.wait_drained(Duration::from_millis(20)).is_ok(),
+            "all axes drained"
+        );
     }
 }

--- a/rust/motion-bridge/src/enqueue.rs
+++ b/rust/motion-bridge/src/enqueue.rs
@@ -60,7 +60,12 @@ where
     out
 }
 
-fn flatten_axis<P>(curve: &ScalarNurbs<f64>, t0: f64, mcu_id: u32, project: &P) -> Vec<PieceEntry>
+fn flatten_axis<P>(
+    curve: &ScalarNurbs<f64>,
+    t0: f64,
+    mcu_id: u32,
+    project: &P,
+) -> Vec<(PieceEntry, f64)>
 where
     P: Fn(u32, f64) -> u64,
 {
@@ -88,15 +93,19 @@ where
             }
         }
 
-        let start_time = project(mcu_id, t0 + bp.u_start);
+        let host_secs = t0 + bp.u_start;
+        let start_time = project(mcu_id, host_secs);
         let duration = (bp.u_end - bp.u_start) as f32;
 
-        out.push(PieceEntry {
-            start_time,
-            coeffs,
-            duration,
-            _reserved: 0,
-        });
+        out.push((
+            PieceEntry {
+                start_time,
+                coeffs,
+                duration,
+                _reserved: 0,
+            },
+            host_secs,
+        ));
     }
 
     out
@@ -152,11 +161,11 @@ mod tests {
 
         assert!(!x.pieces.is_empty(), "X must have at least one piece");
         assert_eq!(
-            x.pieces[0].start_time, 100_000,
+            x.pieces[0].0.start_time, 100_000,
             "start_time = (t0=100) * 1000 = 100_000"
         );
         assert!(
-            x.pieces.iter().all(|p| p.duration > 0.0),
+            x.pieces.iter().all(|(p, _)| p.duration > 0.0),
             "all piece durations must be positive"
         );
 
@@ -201,7 +210,7 @@ mod tests {
             .find(|m| m.key == AxisKey { mcu_id: 1, axis: 0 })
             .expect("motor-A (AXIS_X slot) must be present");
 
-        let last_coeff = a.pieces.last().unwrap().coeffs[3];
+        let last_coeff = a.pieces.last().unwrap().0.coeffs[3];
         assert!(
             (last_coeff - 14.0_f32).abs() < 1e-3,
             "motor-A endpoint coefficient expected ≈14, got {last_coeff}"
@@ -212,7 +221,7 @@ mod tests {
             .find(|m| m.key == AxisKey { mcu_id: 1, axis: 1 })
             .expect("motor-B (AXIS_Y slot) must be present");
 
-        let b_last = b.pieces.last().unwrap().coeffs[3];
+        let b_last = b.pieces.last().unwrap().0.coeffs[3];
         assert!(
             (b_last - 6.0_f32).abs() < 1e-3,
             "motor-B endpoint coefficient expected ≈6, got {b_last}"

--- a/rust/motion-bridge/src/mcu_log.rs
+++ b/rust/motion-bridge/src/mcu_log.rs
@@ -1,11 +1,11 @@
 use std::io::Write;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 use serde_json::{Map, Value};
 use time::OffsetDateTime;
 
-use kalico_host_rt::clock_sync::ClockSyncEstimator;
 use kalico_host_rt::host_io::runtime_events::McuLogEvent;
+use kalico_host_rt::passthrough_queue::{McuHandle, PassthroughRouter};
 use runtime::error::FaultCode;
 use runtime::log_codes::{compose_msg, event_info, subsystem_name};
 
@@ -23,16 +23,15 @@ fn mcu_level_str(level: u8) -> &'static str {
 }
 
 pub fn build_mcu_log_hook(
-    clock: Arc<RwLock<ClockSyncEstimator>>,
+    router: Arc<Mutex<PassthroughRouter>>,
+    mcu: McuHandle,
     writer: Arc<Mutex<RotatingJsonlWriter>>,
     source: String,
 ) -> impl Fn(McuLogEvent) + Send + Sync + 'static {
     move |e: McuLogEvent| {
         let (time_str, time_estimated) = {
-            let guard = clock
-                .read()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Some((dt, estimated)) = guard.wall_time_at_mcu(e.mcu_tick) {
+            let guard = router.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some((dt, estimated)) = guard.wall_time_at_mcu(mcu, e.mcu_tick) {
                 (format_time(dt), estimated)
             } else {
                 let elapsed = e.host_recv.elapsed();

--- a/rust/motion-bridge/src/mcu_log.rs
+++ b/rust/motion-bridge/src/mcu_log.rs
@@ -30,7 +30,9 @@ pub fn build_mcu_log_hook(
 ) -> impl Fn(McuLogEvent) + Send + Sync + 'static {
     move |e: McuLogEvent| {
         let (time_str, time_estimated) = {
-            let guard = router.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = router
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some((dt, estimated)) = guard.wall_time_at_mcu(mcu, e.mcu_tick) {
                 (format_time(dt), estimated)
             } else {

--- a/rust/motion-bridge/src/pump.rs
+++ b/rust/motion-bridge/src/pump.rs
@@ -629,33 +629,50 @@ where
                     junction_ends.remove(&key);
                 }
                 if !pieces.is_empty() {
-                    let approx_freq: f64 = if key.mcu_id == 0 {
-                        520_000_000.0
-                    } else {
-                        180_000_000.0
-                    };
-                    let (first_entry, first_host) = &pieces[0];
-                    if let Some(&(prev_end_ticks, prev_end_host)) = junction_ends.get(&key) {
-                        let (tick_jump_us, host_jump_us) = junction_jumps(
-                            first_entry.start_time,
-                            *first_host,
-                            prev_end_ticks,
-                            prev_end_host,
-                            approx_freq,
-                        );
-                        log::warn!(
-                            "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={}",
-                            key,
-                            tick_jump_us,
-                            host_jump_us,
-                            fresh_stream,
-                        );
+                    // Clock not yet synced — skip junction bookkeeping; µs math is
+                    // meaningless without a real frequency and end_time needs it too.
+                    if let Some((_ack_now, freq)) = mcu_clock_of(key.mcu_id) {
+                        let (first_entry, first_host) = &pieces[0];
+                        if let Some(&(prev_end_ticks, prev_end_host)) = junction_ends.get(&key) {
+                            let (tick_jump_us, host_jump_us) = junction_jumps(
+                                first_entry.start_time,
+                                *first_host,
+                                prev_end_ticks,
+                                prev_end_host,
+                                freq,
+                            );
+                            let anomalous = tick_jump_us < -50.0
+                                || (tick_jump_us - host_jump_us).abs() > 50.0;
+                            if fresh_stream || !anomalous {
+                                log::debug!(
+                                    "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={}",
+                                    key,
+                                    tick_jump_us,
+                                    host_jump_us,
+                                    fresh_stream,
+                                );
+                            } else {
+                                let reason = if tick_jump_us < -50.0 {
+                                    "overlap_risk"
+                                } else {
+                                    "projection_divergence"
+                                };
+                                log::warn!(
+                                    "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={} reason={}",
+                                    key,
+                                    tick_jump_us,
+                                    host_jump_us,
+                                    fresh_stream,
+                                    reason,
+                                );
+                            }
+                        }
+                        let (last_entry, last_host) = pieces.last().unwrap();
+                        #[allow(clippy::cast_possible_truncation)]
+                        let last_end_ticks = last_entry.end_time(freq as f32);
+                        let last_end_host = last_host + last_entry.duration as f64;
+                        junction_ends.insert(key, (last_end_ticks, last_end_host));
                     }
-                    let (last_entry, last_host) = pieces.last().unwrap();
-                    let last_end_ticks =
-                        last_entry.end_time(approx_freq as f32);
-                    let last_end_host = last_host + last_entry.duration as f64;
-                    junction_ends.insert(key, (last_end_ticks, last_end_host));
                 }
                 let q = queues
                     .entry(key)

--- a/rust/motion-bridge/src/pump.rs
+++ b/rust/motion-bridge/src/pump.rs
@@ -116,7 +116,9 @@ pub fn schedule(
                     return None;
                 }
                 let already = taken.get(k).copied().unwrap_or(0);
-                q.pieces.get(already).map(|&(ref p, host)| (*k, p.start_time, host))
+                q.pieces
+                    .get(already)
+                    .map(|&(ref p, host)| (*k, p.start_time, host))
             })
             .min_by(|(ka, _, ha), (kb, _, hb)| ha.total_cmp(hb).then(ka.cmp(kb)));
         let (k, start_ticks, _host) = match next {
@@ -374,10 +376,7 @@ mod sched_tests {
         queues.insert(AxisKey { mcu_id: 0, axis: 0 }, mcu0_q);
 
         // mcu1: host-later piece, ring has room
-        queues.insert(
-            AxisKey { mcu_id: 1, axis: 0 },
-            q_with_host(8, &[(50, 5.0)]),
-        );
+        queues.insert(AxisKey { mcu_id: 1, axis: 0 }, q_with_host(8, &[(50, 5.0)]));
 
         assert!(
             matches!(
@@ -549,7 +548,10 @@ mod tests {
         let prev_end_ticks: u64 = 10_000;
         let (tick_us3, host_us3) =
             junction_jumps(prev_end_ticks, 5.0e-4, prev_end_ticks, 0.0, freq);
-        assert!((tick_us3).abs() < 1e-6, "tick gap should be zero, got {tick_us3}");
+        assert!(
+            (tick_us3).abs() < 1e-6,
+            "tick gap should be zero, got {tick_us3}"
+        );
         assert!((host_us3 - 500.0).abs() < 1e-3, "host_jump_us={host_us3}");
     }
 }
@@ -641,8 +643,8 @@ where
                                 prev_end_host,
                                 freq,
                             );
-                            let anomalous = tick_jump_us < -50.0
-                                || (tick_jump_us - host_jump_us).abs() > 50.0;
+                            let anomalous =
+                                tick_jump_us < -50.0 || (tick_jump_us - host_jump_us).abs() > 50.0;
                             if fresh_stream || !anomalous {
                                 log::debug!(
                                     "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={}",

--- a/rust/motion-bridge/src/pump.rs
+++ b/rust/motion-bridge/src/pump.rs
@@ -12,7 +12,7 @@ pub struct AxisKey {
 
 #[derive(Debug)]
 pub struct AxisQueue {
-    pub pieces: VecDeque<PieceEntry>,
+    pub pieces: VecDeque<(PieceEntry, f64)>,
     pub pushed: u32,
     pub retired: u32,
     pub ring_depth: u32,
@@ -56,6 +56,21 @@ pub enum Schedule {
     Idle,
 }
 
+/// Select the globally earliest-host-time piece across all queues, then emit
+/// the same-MCU prefix as one frame batch.
+///
+/// ## Invariants preserved
+///
+/// 1. **Global gating is intentional.** A stalled MCU (StallFull / StallAhead)
+///    gates issuance to all other MCUs — cross-MCU issue-side coherence requires
+///    that a blocked MCU is never overtaken.
+///
+/// 2. **Ordering must use host time.** `start_time` values are raw MCU clock
+///    ticks in per-MCU clock domains (H7: ~520 MHz / own epoch; F446: ~180 MHz /
+///    own epoch). Comparing ticks across MCUs is meaningless; F446 values are
+///    numerically smaller and would always win, starving the H7.  The `f64`
+///    sidecar in each `(PieceEntry, f64)` pair carries the minting host time
+///    (`t0 + u_start`, seconds) and is the only valid cross-queue ordering key.
 #[must_use]
 pub fn schedule(
     queues: &BTreeMap<AxisKey, AxisQueue>,
@@ -64,29 +79,28 @@ pub fn schedule(
 ) -> Schedule {
     let mut stall_ahead_candidate: Option<AxisKey> = None;
 
+    // Head selection: earliest host time across all non-empty queues.
     let head = queues
         .iter()
         .filter(|(_, q)| !q.pieces.is_empty())
         .min_by(|(ka, qa), (kb, qb)| {
-            qa.pieces
-                .front()
-                .unwrap()
-                .start_time
-                .cmp(&qb.pieces.front().unwrap().start_time)
-                .then(ka.cmp(kb))
+            let ha = qa.pieces.front().unwrap().1;
+            let hb = qb.pieces.front().unwrap().1;
+            ha.total_cmp(&hb).then(ka.cmp(kb))
         });
     let (&head_key, head_q) = match head {
         None => return Schedule::Idle,
         Some(h) => h,
     };
-    let head_start = head_q.pieces.front().unwrap().start_time;
+    let (head_entry, _head_host) = head_q.pieces.front().unwrap();
+    let head_start_ticks = head_entry.start_time;
 
     if head_q.room() == 0 {
         return Schedule::StallFull(head_key);
     }
 
     if let Some(horizon) = horizon_of(head_key.mcu_id) {
-        if head_start > horizon {
+        if head_start_ticks > horizon {
             return Schedule::StallAhead(head_key);
         }
     }
@@ -94,6 +108,7 @@ pub fn schedule(
     let mut taken: BTreeMap<AxisKey, usize> = BTreeMap::new();
     let mut maxed: BTreeSet<AxisKey> = BTreeSet::new();
     loop {
+        // Inner batching: order candidates by host time within the same MCU prefix.
         let next = queues
             .iter()
             .filter_map(|(k, q)| {
@@ -101,10 +116,10 @@ pub fn schedule(
                     return None;
                 }
                 let already = taken.get(k).copied().unwrap_or(0);
-                q.pieces.get(already).map(|p| (*k, p.start_time))
+                q.pieces.get(already).map(|&(ref p, host)| (*k, p.start_time, host))
             })
-            .min_by(|(ka, sa), (kb, sb)| sa.cmp(sb).then(ka.cmp(kb)));
-        let (k, start) = match next {
+            .min_by(|(ka, _, ha), (kb, _, hb)| ha.total_cmp(hb).then(ka.cmp(kb)));
+        let (k, start_ticks, _host) = match next {
             Some(n) => n,
             None => break,
         };
@@ -119,7 +134,7 @@ pub fn schedule(
             continue;
         }
         if let Some(horizon) = horizon_of(k.mcu_id) {
-            if start > horizon {
+            if start_ticks > horizon {
                 if stall_ahead_candidate.is_none() {
                     stall_ahead_candidate = Some(k);
                 }
@@ -142,7 +157,7 @@ pub fn schedule(
         .filter(|(_, n)| *n > 0)
         .map(|(k, n)| FramePlan {
             key: k,
-            pieces: queues[&k].pieces.iter().take(n).copied().collect(),
+            pieces: queues[&k].pieces.iter().take(n).map(|(p, _)| *p).collect(),
             start_slot: 0,
         })
         .collect();
@@ -154,17 +169,27 @@ pub fn schedule(
 mod sched_tests {
     use super::*;
 
-    fn q_with(ring_depth: u32, starts: &[u64]) -> AxisQueue {
+    /// Build a queue from (tick_start, host_time) pairs.
+    fn q_with_host(ring_depth: u32, starts: &[(u64, f64)]) -> AxisQueue {
         let mut q = AxisQueue::new(ring_depth);
-        for &s in starts {
-            q.pieces.push_back(PieceEntry {
-                start_time: s,
-                coeffs: [0.0; 4],
-                duration: 0.001,
-                _reserved: 0,
-            });
+        for &(s, h) in starts {
+            q.pieces.push_back((
+                PieceEntry {
+                    start_time: s,
+                    coeffs: [0.0; 4],
+                    duration: 0.001,
+                    _reserved: 0,
+                },
+                h,
+            ));
         }
         q
+    }
+
+    /// Convenience wrapper for single-MCU tests where host_time == tick as f64.
+    fn q_with(ring_depth: u32, starts: &[u64]) -> AxisQueue {
+        let pairs: Vec<(u64, f64)> = starts.iter().map(|&s| (s, s as f64)).collect();
+        q_with_host(ring_depth, &pairs)
     }
 
     #[test]
@@ -283,6 +308,85 @@ mod sched_tests {
             other => panic!("expected Send (no time gate), got {other:?}"),
         }
     }
+
+    /// Regression: bench shape from 2026-06-04.
+    ///
+    /// mcu1 (F446, 180 MHz) has a far-future piece whose tick value is numerically
+    /// small (~4.8e12) but whose host time is large (beyond mcu1's horizon).
+    /// mcu0 (H7, 520 MHz) has past-due pieces whose tick value is numerically large
+    /// (~13.8e12) but whose host time is now-ish (within mcu0's horizon, room available).
+    ///
+    /// Old code: `min_by` on raw ticks → mcu1's small ticks win → StallAhead(mcu1),
+    /// H7 starved for up to 2+ seconds.
+    /// New code: `min_by` on host time → mcu0's smaller host time wins → Send(mcu0).
+    #[test]
+    fn cross_mcu_host_time_ordering_bench_regression() {
+        let f446_tick: u64 = 4_790_000_000_000;
+        let h7_tick: u64 = 13_800_000_000_000;
+
+        // mcu1 (F446): numerically smaller tick, but host time is far in the future
+        let f446_host: f64 = 1_000.0; // far future, beyond any horizon
+        // mcu0 (H7): numerically larger tick, but host time is now-ish
+        let h7_host: f64 = 1.0; // near present
+
+        let mut queues = BTreeMap::new();
+        queues.insert(
+            AxisKey { mcu_id: 1, axis: 2 }, // F446, Z axis
+            q_with_host(8, &[(f446_tick, f446_host)]),
+        );
+        queues.insert(
+            AxisKey { mcu_id: 0, axis: 0 }, // H7, X axis
+            q_with_host(8, &[(h7_tick, h7_host)]),
+        );
+
+        // mcu0 horizon covers h7_tick; mcu1 horizon does NOT cover f446_tick.
+        let horizon_of = |mcu_id: u32| -> Option<u64> {
+            if mcu_id == 0 {
+                Some(h7_tick + 1_000_000)
+            } else {
+                Some(f446_tick - 1) // mcu1 piece is ahead of this horizon
+            }
+        };
+
+        match schedule(&queues, 255, horizon_of) {
+            Schedule::Send(frames) => {
+                assert_eq!(frames.len(), 1);
+                assert_eq!(
+                    frames[0].key.mcu_id, 0,
+                    "H7 (mcu0) should be selected, not F446 (mcu1)"
+                );
+            }
+            other => panic!(
+                "expected Send(mcu0) — cross-MCU host-time ordering regression, got {other:?}"
+            ),
+        }
+    }
+
+    /// The globally host-earliest piece's queue having room==0 must block everything
+    /// (intentional global-gating invariant).
+    #[test]
+    fn stall_full_on_globally_earliest_gates_all() {
+        let mut queues = BTreeMap::new();
+
+        // mcu0: host-earliest piece, but ring is full
+        let mut mcu0_q = q_with_host(2, &[(100, 1.0)]);
+        mcu0_q.pushed = 2; // full
+        queues.insert(AxisKey { mcu_id: 0, axis: 0 }, mcu0_q);
+
+        // mcu1: host-later piece, ring has room
+        queues.insert(
+            AxisKey { mcu_id: 1, axis: 0 },
+            q_with_host(8, &[(50, 5.0)]),
+        );
+
+        assert!(
+            matches!(
+                schedule(&queues, 255, |_| None),
+                Schedule::StallFull(AxisKey { mcu_id: 0, axis: 0 })
+            ),
+            "StallFull on the globally host-earliest queue must gate all issuance"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -348,13 +452,16 @@ mod tests {
         }
     }
 
-    fn make_piece(t: u64) -> PieceEntry {
-        PieceEntry {
-            start_time: t,
-            coeffs: [0.0; 4],
-            duration: 0.001,
-            _reserved: 0,
-        }
+    fn make_piece(t: u64) -> (PieceEntry, f64) {
+        (
+            PieceEntry {
+                start_time: t,
+                coeffs: [0.0; 4],
+                duration: 0.001,
+                _reserved: 0,
+            },
+            t as f64,
+        )
     }
 
     #[test]
@@ -424,11 +531,35 @@ mod tests {
         assert_eq!(s1, expected_s1, "second start_slot should be {expected_s1}");
         assert_eq!(h1, N * 2, "second new_head should be {}", N * 2);
     }
+
+    #[test]
+    fn junction_jumps_math() {
+        // Exact gap: first piece starts exactly where previous ended.
+        let (tick_us, host_us) = junction_jumps(2000, 2.0e-3, 1000, 1.0e-3, 1_000_000.0);
+        assert!((tick_us - 1000.0).abs() < 1e-6, "tick_jump_us={tick_us}");
+        assert!((host_us - 1000.0).abs() < 1e-6, "host_jump_us={host_us}");
+
+        // Overlap (negative jump).
+        let (tick_us2, host_us2) = junction_jumps(900, 0.9e-3, 1000, 1.0e-3, 1_000_000.0);
+        assert!(tick_us2 < 0.0, "overlap should be negative tick jump");
+        assert!(host_us2 < 0.0, "overlap should be negative host jump");
+
+        // Cross-domain divergence: tick gap == 0 µs but host gap == 500 µs.
+        let freq = 520_000_000.0_f64;
+        let prev_end_ticks: u64 = 10_000;
+        let (tick_us3, host_us3) =
+            junction_jumps(prev_end_ticks, 5.0e-4, prev_end_ticks, 0.0, freq);
+        assert!((tick_us3).abs() < 1e-6, "tick gap should be zero, got {tick_us3}");
+        assert!((host_us3 - 500.0).abs() < 1e-3, "host_jump_us={host_us3}");
+    }
 }
 
 pub struct EnqueueMsg {
     pub key: AxisKey,
-    pub pieces: Vec<PieceEntry>,
+    /// Each entry pairs the `PieceEntry` with its minting host time (`t0 + u_start`, seconds).
+    /// The host time is the ordering key used by `schedule()`; the raw `start_time` tick is
+    /// MCU-clock-domain-specific and incomparable across MCUs.
+    pub pieces: Vec<(PieceEntry, f64)>,
     pub fresh_stream: bool,
 }
 
@@ -453,6 +584,23 @@ pub trait PieceSink: Send {
     ) -> Result<i32, String>;
 }
 
+/// Compute the tick-domain and host-domain gaps at a batch boundary.
+///
+/// Returns `(tick_jump_us, host_jump_us)` where negative values indicate overlap.
+/// The difference between the two isolates clock-projection error from planner-intent gaps.
+pub fn junction_jumps(
+    first_start_ticks: u64,
+    first_host: f64,
+    prev_end_ticks: u64,
+    prev_end_host: f64,
+    approx_freq_hz: f64,
+) -> (f64, f64) {
+    let tick_jump_us =
+        (first_start_ticks as i64 - prev_end_ticks as i64) as f64 / approx_freq_hz * 1e6;
+    let host_jump_us = (first_host - prev_end_host) * 1e6;
+    (tick_jump_us, host_jump_us)
+}
+
 const MAX_LEAD_SECS: f64 = 1.0;
 
 pub fn run_pump<S, F, C>(rx: Receiver<PumpMsg>, sink: S, ring_depth_of: F, mcu_clock_of: C)
@@ -462,16 +610,53 @@ where
     C: Fn(u32) -> Option<(u64, f64)>,
 {
     let mut queues: BTreeMap<AxisKey, AxisQueue> = BTreeMap::new();
+    // Per-axis junction tracking for clock-projection jitter measurement.
+    let mut junction_ends: BTreeMap<AxisKey, (u64, f64)> = BTreeMap::new();
     const MAX_PER_FRAME: usize = 32;
 
-    let apply = |msg: PumpMsg, queues: &mut BTreeMap<AxisKey, AxisQueue>| -> bool {
+    let apply = |msg: PumpMsg,
+                 queues: &mut BTreeMap<AxisKey, AxisQueue>,
+                 junction_ends: &mut BTreeMap<AxisKey, (u64, f64)>|
+     -> bool {
         match msg {
             PumpMsg::Shutdown => return false,
             PumpMsg::Enqueue(EnqueueMsg {
                 key,
                 pieces,
-                fresh_stream: _,
+                fresh_stream,
             }) => {
+                if fresh_stream {
+                    junction_ends.remove(&key);
+                }
+                if !pieces.is_empty() {
+                    let approx_freq: f64 = if key.mcu_id == 0 {
+                        520_000_000.0
+                    } else {
+                        180_000_000.0
+                    };
+                    let (first_entry, first_host) = &pieces[0];
+                    if let Some(&(prev_end_ticks, prev_end_host)) = junction_ends.get(&key) {
+                        let (tick_jump_us, host_jump_us) = junction_jumps(
+                            first_entry.start_time,
+                            *first_host,
+                            prev_end_ticks,
+                            prev_end_host,
+                            approx_freq,
+                        );
+                        log::warn!(
+                            "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={}",
+                            key,
+                            tick_jump_us,
+                            host_jump_us,
+                            fresh_stream,
+                        );
+                    }
+                    let (last_entry, last_host) = pieces.last().unwrap();
+                    let last_end_ticks =
+                        last_entry.end_time(approx_freq as f32);
+                    let last_end_host = last_host + last_entry.duration as f64;
+                    junction_ends.insert(key, (last_end_ticks, last_end_host));
+                }
                 let q = queues
                     .entry(key)
                     .or_insert_with(|| AxisQueue::new(ring_depth_of(key)));
@@ -522,11 +707,11 @@ where
         };
 
         if let Some(msg) = first {
-            if !apply(msg, &mut queues) {
+            if !apply(msg, &mut queues, &mut junction_ends) {
                 return;
             }
             while let Ok(m) = rx.try_recv() {
-                if !apply(m, &mut queues) {
+                if !apply(m, &mut queues, &mut junction_ends) {
                     return;
                 }
             }

--- a/rust/motion-bridge/tests/ethercat_transport.rs
+++ b/rust/motion-bridge/tests/ethercat_transport.rs
@@ -19,13 +19,16 @@ use runtime::piece_ring::PieceEntry;
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-fn piece(t: u64) -> PieceEntry {
-    PieceEntry {
-        start_time: t,
-        coeffs: [0.0; 4],
-        duration: 0.001,
-        _reserved: 0,
-    }
+fn piece(t: u64) -> (PieceEntry, f64) {
+    (
+        PieceEntry {
+            start_time: t,
+            coeffs: [0.0; 4],
+            duration: 0.001,
+            _reserved: 0,
+        },
+        t as f64,
+    )
 }
 
 // ── 1. WireSink hard error on missing transport ───────────────────────────
@@ -40,7 +43,7 @@ fn wire_sink_missing_transport_is_hard_error() {
         transports: HashMap::new(), // intentionally empty
         timeout: Duration::from_secs(1),
     };
-    let p = piece(0);
+    let (p, _) = piece(0);
     let result = sink.send_frame(
         AxisKey {
             mcu_id: 99,

--- a/rust/motion-bridge/tests/mcu_log_reemit.rs
+++ b/rust/motion-bridge/tests/mcu_log_reemit.rs
@@ -9,13 +9,14 @@
 //! explicitly exercises this for both canonical label values so a regression
 //! to a numeric handle-based name (e.g. "mcu-0") is caught immediately.
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use time::OffsetDateTime;
 
-use kalico_host_rt::clock_sync::ClockSyncEstimator;
+use kalico_host_rt::clock::RealClock;
 use kalico_host_rt::host_io::runtime_events::McuLogEvent;
+use kalico_host_rt::passthrough_queue::{McuHandle, PassthroughRouter};
 use motion_bridge_native::logging::context;
 use motion_bridge_native::logging::writer::RotatingJsonlWriter;
 use motion_bridge_native::logging::writer::{
@@ -39,6 +40,32 @@ fn tmp_jsonl(dir_suffix: &str, filename: &str) -> std::path::PathBuf {
     p
 }
 
+fn make_router_with_clock_record(label: &str) -> (Arc<Mutex<PassthroughRouter>>, McuHandle) {
+    let router = Arc::new(Mutex::new(PassthroughRouter::with_clock(Arc::new(
+        RealClock,
+    ))));
+    let mcu = router.lock().unwrap().claim_mcu(label);
+    // Seed a valid clock record anchored at the current instant so
+    // wall_time_at_mcu returns a real time (not None).
+    // freq=100 MHz, current instant as the anchor, last_clock=15*100M (matches
+    // the mcu_tick used in re_emit_closure_produces_schema_conformant_line).
+    router
+        .lock()
+        .unwrap()
+        .set_clock_est_from_sample(mcu, 100_000_000.0, Instant::now(), 15 * 100_000_000)
+        .unwrap();
+    (router, mcu)
+}
+
+fn make_empty_router(label: &str) -> (Arc<Mutex<PassthroughRouter>>, McuHandle) {
+    let router = Arc::new(Mutex::new(PassthroughRouter::with_clock(Arc::new(
+        RealClock,
+    ))));
+    let mcu = router.lock().unwrap().claim_mcu(label);
+    // No clock record set — clock_freq stays 0.0, wall_time_at_mcu returns None.
+    (router, mcu)
+}
+
 #[test]
 fn re_emit_closure_produces_schema_conformant_line() {
     let _ctx_guard = CTX_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -56,18 +83,8 @@ fn re_emit_closure_produces_schema_conformant_line() {
         .unwrap(),
     ));
 
-    // Build an estimator with 30 samples so wall_time_at_mcu works.
-    let est = Arc::new(RwLock::new(ClockSyncEstimator::new(100_000_000.0)));
-    {
-        let mut guard = est.write().unwrap();
-        let now = Instant::now();
-        for i in 0..30u64 {
-            let t = now + std::time::Duration::from_secs(i);
-            guard.add_piggyback_sample(t, (i + 1) * 100_000_000);
-        }
-    }
-
-    let hook = build_mcu_log_hook(Arc::clone(&est), Arc::clone(&writer), "mcu-h7".to_string());
+    let (router, mcu) = make_router_with_clock_record("mcu-h7");
+    let hook = build_mcu_log_hook(router, mcu, Arc::clone(&writer), "mcu-h7".to_string());
 
     let event = McuLogEvent {
         mcu_tick: 15 * 100_000_000u64,
@@ -120,11 +137,11 @@ fn re_emit_closure_produces_schema_conformant_line() {
     assert_eq!(rec["arg1"], 200u64);
 }
 
-/// When the clock-sync estimator has no samples, `wall_time_at_mcu` returns
+/// When the router has no clock record for the MCU, `wall_time_at_mcu` returns
 /// `None`.  The hook must fall back to `host_recv`-derived wall time and set
-/// `time_estimated = true`.  This test constructs a freshly-allocated estimator
-/// (zero samples) and verifies both invariants: a valid RFC3339 `_time` **and**
-/// `time_estimated == true`.
+/// `time_estimated = true`.  This test constructs a router with no clock record
+/// (clock_freq == 0.0) and verifies both invariants: a valid RFC3339 `_time`
+/// **and** `time_estimated == true`.
 ///
 /// Spec §7 / §8 (fallback branch, `mcu_log.rs:67-75`).
 #[test]
@@ -146,10 +163,9 @@ fn fallback_stamps_time_estimated_true_when_no_clock_sync_samples() {
         .unwrap(),
     ));
 
-    // Empty estimator — zero samples, so wall_time_at_mcu always returns None.
-    let est = Arc::new(RwLock::new(ClockSyncEstimator::new(100_000_000.0)));
-
-    let hook = build_mcu_log_hook(Arc::clone(&est), Arc::clone(&writer), "mcu-h7".to_string());
+    // Empty router — no clock record, so wall_time_at_mcu always returns None.
+    let (router, mcu) = make_empty_router("mcu-h7");
+    let hook = build_mcu_log_hook(router, mcu, Arc::clone(&writer), "mcu-h7".to_string());
 
     let event = McuLogEvent {
         mcu_tick: 5 * 100_000_000u64,
@@ -187,7 +203,7 @@ fn fallback_stamps_time_estimated_true_when_no_clock_sync_samples() {
     assert_eq!(
         rec["time_estimated"],
         serde_json::Value::Bool(true),
-        "time_estimated must be true when the estimator has no samples (fallback path)"
+        "time_estimated must be true when the router has no clock record (fallback path)"
     );
 }
 
@@ -219,17 +235,8 @@ fn source_matches_label() {
             .unwrap(),
         ));
 
-        let est = Arc::new(RwLock::new(ClockSyncEstimator::new(100_000_000.0)));
-        {
-            let mut guard = est.write().unwrap();
-            let now = Instant::now();
-            for i in 0..5u64 {
-                let t = now + std::time::Duration::from_secs(i);
-                guard.add_piggyback_sample(t, (i + 1) * 100_000_000);
-            }
-        }
-
-        let hook = build_mcu_log_hook(Arc::clone(&est), Arc::clone(&writer), (*label).to_string());
+        let (router, mcu) = make_router_with_clock_record(label);
+        let hook = build_mcu_log_hook(router, mcu, Arc::clone(&writer), (*label).to_string());
 
         let event = McuLogEvent {
             mcu_tick: 3 * 100_000_000u64,

--- a/rust/motion-bridge/tests/pump_loop.rs
+++ b/rust/motion-bridge/tests/pump_loop.rs
@@ -18,13 +18,16 @@ impl PieceSink for RecordingSink {
     }
 }
 
-fn p(start: u64) -> PieceEntry {
-    PieceEntry {
-        start_time: start,
-        coeffs: [0.0; 4],
-        duration: 0.001,
-        _reserved: 0,
-    }
+fn p(start: u64) -> (PieceEntry, f64) {
+    (
+        PieceEntry {
+            start_time: start,
+            coeffs: [0.0; 4],
+            duration: 0.001,
+            _reserved: 0,
+        },
+        start as f64,
+    )
 }
 
 #[test]


### PR DESCRIPTION
## What this fixes

The bench-reproducible crash (\`SET_KINEMATIC_POSITION\` + rapid X jogs → \`-308 PieceStartInPast\` → MCU shutdown → IWDG) turned out to be a family of stacked defects. Bench-verified back-to-back against bare sota-motion (crashes on 100mm jogs and rapid 10mm jogs there; 7/7 runs + fresh-boot worst case clean here).

### 1. Pump scheduled across MCU clock domains (\`187b9b430\`)
\`schedule()\` picked its global head by comparing raw \`start_time\` ticks across MCUs — F446 ticks (180MHz epoch) always compare below H7 ticks (520MHz epoch), so any queued far-future Z piece froze all queues via its StallAhead early-return. Bench-measured: 2.15s starvation → pieces 649ms stale → -308. Global gating stays (intentional: a stalled MCU gates all issuance); pieces now carry their minting host time as a sidecar and all cross-queue ordering uses it. Adds an enqueue-boundary junction detector (tick vs host domain) as standing measurement infrastructure.

### 2. DrainSync could never drain a second stream (\`b76dcb1b8\`)
\`retired\` is the MCU's cumulative counter; \`sent\` is per-stream; the predicate was strict equality — any session with a second \`SET_KINEMATIC_POSITION\` died in the 60s drain timeout (\`retired = 2×sent\`). Baseline the counters at \`reset()\`. Was masked by the -308 crashes IWDG-resetting the counters between runs.

### 3. Clock sync consolidation: stock klippy clocksync owns the router record (\`01ed4187e\`…\`24cfb468d\`)
The fork had severed stock clocksync's transport (raw_send no-op in bridge mode → estimator frozen after the 8-sample connect burst) and grown a parallel 500ms Rust estimator that only kalico-native MCUs could feed — Beacon (closed firmware) was permanently frozen, with its 32-bit clock reconstruction breaking ~134s into a session. This PR:
- stamps \`#sent_time\`/\`#receive_time\` at the Rust wire layer in CLOCK_MONOTONIC_RAW (previously both were set after the round-trip → half_rtt was always 0)
- restores the stock periodic get_clock loop for **all** MCUs over the bridge (encoded in the per-MCU reactor — the shared bridge parser holds whichever dict was set last)
- exports klippy's true \`clock_est\` triple to the router (the old mirror paired centroid time with the newest clock — a point off the regression line) and rebases in the RAW domain end-to-end
- restores stock \`is_active()\` (MCU-timeout watchdog input) and the periodic \`calibrate_clock\` call (SecondarySync recalibration — frozen since the steppersync removal)
- retires the dedicated Rust sync loop; \`mcu_log\` timestamping rewired to a router-backed clock view. The estimator type and the \`runtime_clock_sync_request\` command stay — the homing arm path owns them.

(The two intermediate estimator-hardening commits, \`731e614f3\`/\`3603e3a15\`, were superseded by the consolidation within this branch — kept unsquashed per review preference.)

## Measurements (same base, same firmware, same jog protocol)

| junction projection error | Rust estimator (raw) | Rust + decay/outlier | stock clocksync + RAW stamps |
|---|---|---|---|
| median | 80µs | 85µs | **16µs** |
| p90 | 464µs | 1614µs | **84µs** |
| max | 583µs | 2129µs | **281µs** (gap side; worst overlap −104µs vs 225µs fault tolerance) |
| jog gauntlet | 3/3 crash | 3/3 crash | **7/7 pass** incl. fresh-boot |

## Deliberately not in this PR

- **Dispatch clock** (never-jumps piece-timestamp projection): designed and shelved — the measured wobble no longer justifies it. Build trigger: any -308 in real use, or overlap-side junction >150µs in the detector logs.
- **\`append_and_replan\` cost** (4s reversal replans; multi-second jog-after-idle latency that resets with a fresh session): separate session.
- Follow-up: a beacon frequency warning at connect appeared once on this branch (likely the \`_ready()\` freq check sampling the now-live estimator mid-convergence) — to be traced and quieted properly.