### PR TITLE
nurbs: single-pass knot refinement (P&T A5.4), drop O(m²) hot path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,16 @@ We are working on a complete rewrite of the motion planner and more:
 
   The `compat` crate has two callers: the offline Step-13 binary (file → file) and the live bridge (terminal/macro G1/G2/G3 conversion via `compat::collinear::to_collinear_g5`, `compat::arc::arc_to_g5`, `compat::degree_elev::elevate_g51_to_g5`). Both share the lexer.
 
+# Testing
+
+Run the Rust suite with `cargo nextest run` from `rust/`, not `cargo test`.
+`cargo test` executes the ~110 test binaries one at a time (each only
+parallelizes internally), which leaves most cores idle — the full suite takes
+~100s. `nextest` schedules every test into one global pool: same suite, ~11s.
+Use `cargo nextest run -p <crate>` or `-E 'test(<name>)'` to scope down.
+Doc-tests are the one gap — `nextest` skips them, so run `cargo test --doc`
+when you touch doc examples.
+
 # Observability / structured logging
 
 Log via the structured pipeline (`kalico_log_emit` → `events/*.jsonl`), not

--- a/rust/kalico-host-rt/src/host_io/identify/tests.rs
+++ b/rust/kalico-host-rt/src/host_io/identify/tests.rs
@@ -12,9 +12,7 @@ struct ScriptedPort {
 
 impl ScriptedPort {
     fn boxed(chunks: Vec<Vec<u8>>) -> Box<dyn serialport::SerialPort> {
-        Box::new(Self {
-            rx: chunks.into(),
-        })
+        Box::new(Self { rx: chunks.into() })
     }
 }
 

--- a/rust/nurbs/src/knot.rs
+++ b/rust/nurbs/src/knot.rs
@@ -269,7 +269,7 @@ fn refine_knot_vect_curve<T: Float>(knots: &[T], cps: &[T], p: usize, x: &[T]) -
         }
 
         new_knots[k] = x[xi];
-        k = k.saturating_sub(1);
+        k -= 1;
     }
 
     (new_knots, new_cps)

--- a/rust/nurbs/src/knot.rs
+++ b/rust/nurbs/src/knot.rs
@@ -177,28 +177,102 @@ fn boehm_insert_unweighted_single<T: Float>(
 
 pub fn refined_to_full_multiplicity<T: Float>(curve: &ScalarNurbs<T>) -> ScalarNurbs<T> {
     let p = curve.degree() as usize;
-    let mut current = curve.clone();
+    let knots = curve.knots();
+    let cps = curve.control_points();
 
-    let knots_snapshot: Vec<T> = current.knots().to_vec();
-    let mut interior: Vec<T> = Vec::new();
-    let mut i = p + 1;
-    while i < knots_snapshot.len() - p - 1 {
-        let u = knots_snapshot[i];
-        if !interior.contains(&u) {
-            interior.push(u);
-        }
-        i += 1;
+    let refinement = build_refinement_vector(knots, p);
+    if refinement.is_empty() {
+        return curve.clone();
     }
 
-    for u in interior {
-        let existing = current.knots().iter().filter(|k| **k == u).count();
-        if existing < p {
-            current = insert_knot(&current, u, p - existing)
-                .expect("refined_to_full_multiplicity: insertion should be valid");
-        }
+    let (new_knots, new_cps) = refine_knot_vect_curve(knots, cps, p, &refinement);
+
+    ScalarNurbs::try_new(curve.degree(), new_knots, new_cps)
+        .expect("refined_to_full_multiplicity: result invariants should hold")
+}
+
+fn build_refinement_vector<T: Float>(knots: &[T], p: usize) -> Vec<T> {
+    let interior_start = p + 1;
+    let interior_end = knots.len() - p - 1;
+    if interior_end <= interior_start {
+        return Vec::new();
     }
 
-    current
+    let mut x: Vec<T> = Vec::new();
+    let mut i = interior_start;
+    while i < interior_end {
+        let u = knots[i];
+        let mut s = 0usize;
+        while i + s < interior_end && knots[i + s] == u {
+            s += 1;
+        }
+        let deficit = p.saturating_sub(s);
+        for _ in 0..deficit {
+            x.push(u);
+        }
+        i += s;
+    }
+    x
+}
+
+fn refine_knot_vect_curve<T: Float>(knots: &[T], cps: &[T], p: usize, x: &[T]) -> (Vec<T>, Vec<T>) {
+    let n_pt = cps.len() - 1;
+    let n_span = cps.len();
+    let m = knots.len() - 1;
+    let r = x.len() - 1;
+
+    let a = find_knot_span(knots, p, n_span, x[0]);
+    let b = find_knot_span(knots, p, n_span, x[r]) + 1;
+
+    let new_cp_count = cps.len() + x.len();
+    let new_knot_count = knots.len() + x.len();
+
+    let mut new_cps = vec![T::ZERO; new_cp_count];
+    let mut new_knots = vec![T::ZERO; new_knot_count];
+
+    for j in 0..=(a - p) {
+        new_cps[j] = cps[j];
+    }
+    for j in (b - 1)..=n_pt {
+        new_cps[j + r + 1] = cps[j];
+    }
+    for j in 0..=a {
+        new_knots[j] = knots[j];
+    }
+    for j in (b + p)..=m {
+        new_knots[j + r + 1] = knots[j];
+    }
+
+    let mut i = b + p - 1;
+    let mut k = b + p + r;
+
+    for xi in (0..=r).rev() {
+        while x[xi] <= knots[i] && i > a {
+            new_cps[k - p - 1] = cps[i - p - 1];
+            new_knots[k] = knots[i];
+            k -= 1;
+            i -= 1;
+        }
+
+        new_cps[k - p - 1] = new_cps[k - p];
+
+        for l in 1..=p {
+            let ind = k - p + l;
+            let alpha_num = new_knots[k + l] - x[xi];
+            if alpha_num == T::ZERO {
+                new_cps[ind - 1] = new_cps[ind];
+            } else {
+                let denom = new_knots[k + l] - knots[i - p + l];
+                let alpha = alpha_num / denom;
+                new_cps[ind - 1] = alpha * new_cps[ind - 1] + (T::ONE - alpha) * new_cps[ind];
+            }
+        }
+
+        new_knots[k] = x[xi];
+        k = k.saturating_sub(1);
+    }
+
+    (new_knots, new_cps)
 }
 
 // Tiller knot removal: Piegl & Tiller Algorithm A5.8.

--- a/rust/nurbs/src/knot/tests.rs
+++ b/rust/nurbs/src/knot/tests.rs
@@ -2,6 +2,28 @@ use super::*;
 use crate::ScalarNurbs;
 use crate::eval::eval;
 
+fn reference_refined_to_full_multiplicity(curve: &ScalarNurbs<f64>) -> ScalarNurbs<f64> {
+    let p = curve.degree() as usize;
+    let mut current = curve.clone();
+    let knots_snapshot: Vec<f64> = current.knots().to_vec();
+    let mut seen: Vec<f64> = Vec::new();
+    let mut i = p + 1;
+    while i < knots_snapshot.len() - p - 1 {
+        let u = knots_snapshot[i];
+        if !seen.contains(&u) {
+            seen.push(u);
+        }
+        i += 1;
+    }
+    for u in seen {
+        let existing = current.knots().iter().filter(|k| **k == u).count();
+        if existing < p {
+            current = insert_knot(&current, u, p - existing).unwrap();
+        }
+    }
+    current
+}
+
 #[test]
 fn try_new_accepts_monotone_knots() {
     let kv = KnotVector::<f64>::try_new(vec![0.0, 0.0, 0.5, 1.0, 1.0]).unwrap();
@@ -163,6 +185,66 @@ fn refined_to_full_multiplicity_raises_interior_knots() {
         assert!(
             (before - after).abs() < 1e-10,
             "u={u}: before={before}, after={after}"
+        );
+    }
+}
+
+#[test]
+fn refined_to_full_multiplicity_matches_reference_on_mixed_multiplicity_curve() {
+    let p: u8 = 3;
+    let n_interior = 50usize;
+
+    let mut knots: Vec<f64> = vec![0.0; p as usize + 1];
+    for k in 0..n_interior {
+        let u = (k + 1) as f64 / (n_interior + 1) as f64;
+        let mult = 1 + (k % (p as usize));
+        for _ in 0..mult {
+            knots.push(u);
+        }
+    }
+    knots.extend(vec![1.0; p as usize + 1]);
+
+    let n_cps = knots.len() - p as usize - 1;
+    let cps: Vec<f64> = (0..n_cps)
+        .map(|i| {
+            let t = i as f64 / (n_cps - 1) as f64;
+            t * t - 0.5 * t + 0.1 * (i as f64 * 1.3).sin()
+        })
+        .collect();
+
+    let curve = ScalarNurbs::<f64>::try_new(p, knots, cps).unwrap();
+
+    let fast = refined_to_full_multiplicity(&curve);
+    let reference = reference_refined_to_full_multiplicity(&curve);
+
+    assert_eq!(fast.knots(), reference.knots(), "knot vectors differ");
+    assert_eq!(
+        fast.control_points().len(),
+        reference.control_points().len(),
+        "control point count differs"
+    );
+
+    for (idx, (a, b)) in fast
+        .control_points()
+        .iter()
+        .zip(reference.control_points())
+        .enumerate()
+    {
+        let rel_tol = 1e-12 * (a.abs().max(b.abs()) + 1.0);
+        assert!(
+            (a - b).abs() <= rel_tol,
+            "cp[{idx}]: fast={a:.15e} reference={b:.15e} diff={:.3e}",
+            (a - b).abs()
+        );
+    }
+
+    let sample_params: Vec<f64> = (0..=20).map(|i| i as f64 / 20.0).collect();
+    for u in sample_params {
+        let v_fast = eval(&fast.as_view(), u);
+        let v_ref = eval(&reference.as_view(), u);
+        assert!(
+            (v_fast - v_ref).abs() < 1e-12,
+            "eval mismatch at u={u}: fast={v_fast:.15e} ref={v_ref:.15e}"
         );
     }
 }

--- a/rust/nurbs/src/knot/tests.rs
+++ b/rust/nurbs/src/knot/tests.rs
@@ -190,6 +190,36 @@ fn refined_to_full_multiplicity_raises_interior_knots() {
 }
 
 #[test]
+fn refined_to_full_multiplicity_is_identity_when_interior_knots_already_full() {
+    let curve = ScalarNurbs::<f64>::try_new(
+        3,
+        vec![0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0],
+        vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    )
+    .unwrap();
+
+    let refined = refined_to_full_multiplicity(&curve);
+
+    assert_eq!(refined.knots(), curve.knots());
+    assert_eq!(refined.control_points(), curve.control_points());
+}
+
+#[test]
+fn refined_to_full_multiplicity_is_identity_when_no_interior_knots() {
+    let curve = ScalarNurbs::<f64>::try_new(
+        3,
+        vec![0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+        vec![0.0, 1.0, 2.0, 3.0],
+    )
+    .unwrap();
+
+    let refined = refined_to_full_multiplicity(&curve);
+
+    assert_eq!(refined.knots(), curve.knots());
+    assert_eq!(refined.control_points(), curve.control_points());
+}
+
+#[test]
 fn refined_to_full_multiplicity_matches_reference_on_mixed_multiplicity_curve() {
     let p: u8 = 3;
     let n_interior = 50usize;


### PR DESCRIPTION
## What

`refined_to_full_multiplicity` (nurbs/src/knot.rs) sits on the planner's hot path through `extract_bezier_pieces`, and it was **quadratic in the knot count**. Replaced with Piegl & Tiller **A5.4 RefineKnotVectCurve** — single linear scan to build the refinement vector, single backward-merge pass to apply it, one allocation for the output arrays. `O(m²·p) → O((n+r)·p)`.

## Why it mattered (not just a test fix)

This runs every time the planner extracts Bézier pieces, so long moves on the Pi were paying the quadratic cost for real. A `sample` profile of the three motion-bridge z-move tests showed **100% of stack samples (2256/2256) inside this one function**, ~43s per test. A 342mm Z move expands to a ~70s trajectory → thousands of knots, which is where the O(m²) blew up.

The old code, per distinct interior knot: rescanned the whole knot vector to count multiplicity, cloned the entire curve, and copied the full control-point vector on every single insertion.

## Correctness

- The per-knot single-insertion helpers (`insert_knot`, `boehm_insert_unweighted*`) are **untouched** — other callers keep their behavior.
- Exact `==` knot comparison preserved; no epsilon introduced (knots are inserted exactly, so this stays sound).
- New differential test pins the A5.4 path against the original sequential-insertion algorithm on a cubic curve with **50 interior knots of mixed multiplicity** — identical knot vectors, control points within `1e-12` relative (difference is float summation order only).

## Timings

| | before | after |
|---|---|---|
| three z-move tests | ~43s each | 0.39s / 0.73s / 0.74s |
| full rust suite (`cargo nextest run`) | 45s | 11s |

Full suite: **1438 passed, 3 skipped**. clippy clean, fmt clean, doc-tests pass.

## Also

Documents the test-runner convention in `CLAUDE.md`: prefer `cargo nextest run` (one global test pool) over `cargo test` (runs the ~110 test binaries serially, ~100s with mostly-idle cores), with the doc-test caveat (`nextest` skips doc-tests; run `cargo test --doc` when touching doc examples).