### PR TITLE
serialhdl: thread configured baud through the bridge serial path

### DIFF
--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -381,7 +381,7 @@ class SerialReader:
             )
             self.disconnect()
 
-    def connect_pipe(self, filename):
+    def connect_pipe(self, filename, baud=0):
         logging.info("%sStarting connect", self.warn_prefix)
         bridge = self.mcu._motion_bridge
         # claim_mcu may not have been called yet (it normally happens in
@@ -392,7 +392,7 @@ class SerialReader:
             self.mcu._bridge_handle = bridge.claim_mcu(
                 self.mcu._name,
                 filename,
-                0,
+                baud,
             )
         handle = self.mcu._bridge_handle
         klippy_non_critical = bool(getattr(self.mcu, "is_non_critical", False))
@@ -406,7 +406,7 @@ class SerialReader:
         bridge.attach_serial(
             handle,
             filename,
-            0,
+            baud,
             timeout_s=30.0,
             klippy_non_critical=klippy_non_critical,
         )
@@ -426,7 +426,7 @@ class SerialReader:
         )
 
     def connect_uart(self, serialport, baud, rts=True):
-        self.connect_pipe(serialport)
+        self.connect_pipe(serialport, baud)
 
     def check_connect(self, serialport, baud, rts=True):
         serial_dev = serial.Serial(baudrate=baud, timeout=0, exclusive=False)


### PR DESCRIPTION
The motion-bridge serial path (`serialhdl.connect_pipe`) hardcoded `baud=0` in both `claim_mcu()` and `attach_serial()`, so the Rust bridge always fell back to `effective_baud=250000` and `[mcu] baud:` was silently ignored. `connect_uart()` even received the configured baud and dropped it.

Threads baud through `connect_uart → connect_pipe → claim_mcu/attach_serial` (default 0 for the Linux-process pipe MCU, where baud is irrelevant).

**How it surfaced:** the Neptune F401 bench moved to a Pi 5 whose `ch341` driver (kernel 6.18-rt) quantizes a 250000 request to a wrong divisor — the host decoded the MCU's stream garbled and identify timed out. `baud: 255000` maps to the true 250000 on that driver, but it only takes effect now that the bridge honors the config value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)