### PR TITLE
F401 UART bring-up + step-output compare-race fix

### DIFF
--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -381,7 +381,7 @@ class SerialReader:
             )
             self.disconnect()
 
-    def connect_pipe(self, filename):
+    def connect_pipe(self, filename, baud=0):
         logging.info("%sStarting connect", self.warn_prefix)
         bridge = self.mcu._motion_bridge
         # claim_mcu may not have been called yet (it normally happens in
@@ -392,7 +392,7 @@ class SerialReader:
             self.mcu._bridge_handle = bridge.claim_mcu(
                 self.mcu._name,
                 filename,
-                0,
+                baud,
             )
         handle = self.mcu._bridge_handle
         klippy_non_critical = bool(getattr(self.mcu, "is_non_critical", False))
@@ -406,7 +406,7 @@ class SerialReader:
         bridge.attach_serial(
             handle,
             filename,
-            0,
+            baud,
             timeout_s=30.0,
             klippy_non_critical=klippy_non_critical,
         )
@@ -426,7 +426,7 @@ class SerialReader:
         )
 
     def connect_uart(self, serialport, baud, rts=True):
-        self.connect_pipe(serialport)
+        self.connect_pipe(serialport, baud)
 
     def check_connect(self, serialport, baud, rts=True):
         serial_dev = serial.Serial(baudrate=baud, timeout=0, exclusive=False)

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -404,7 +404,7 @@ config KALICO_MOTION_SAMPLE_RATE_HZ
     int "Motion engine sample rate in Hz (motion-timer ISR fire rate)"
     depends on MACH_STM32H7 || MACH_STM32F4 || MACH_STM32G0 || MACH_LINUX
     default 40000 if MACH_STM32H7
-    default 10000 if MACH_STM32F401
+    default 5000 if MACH_STM32F401
     default 20000 if MACH_STM32F4
     default 2000 if MACH_STM32G0
     default 1000 if MACH_LINUX

--- a/src/stm32/runtime_tick_f4.c
+++ b/src/stm32/runtime_tick_f4.c
@@ -194,6 +194,11 @@ step_output_timer_arm(uint32_t cycle_abs)
     TIM2->CCR1 = TIM2->CNT + delta;
     TIM2->SR = ~TIM_SR_CC1IF;
     TIM2->DIER |= TIM_DIER_CC1IE;
+    // A 32-bit compare passed between the CNT read above and going live won't
+    // match again for a full wrap; force the handler so a re-arm can never leave
+    // step_out_running=1 with a silent timer (the consumer-stall overflow).
+    if ((int32_t)(TIM2->CNT - TIM2->CCR1) >= 0)
+        NVIC_SetPendingIRQ(TIM2_IRQn);
 }
 
 __attribute__((used, externally_visible))

--- a/src/stm32/serial.c
+++ b/src/stm32/serial.c
@@ -8,6 +8,7 @@
 #include "board/armcm_boot.h" // armcm_enable_irq
 #include "board/serial_irq.h" // serial_rx_byte
 #include "command.h" // DECL_CONSTANT_STR
+#include "generic/kalico_nvic_prio.h" // KALICO_MOTION_NVIC_PRIO
 #include "internal.h" // enable_pclock
 #include "sched.h" // DECL_INIT
 
@@ -108,7 +109,7 @@ serial_init(void)
     USARTx->BRR = (((div / 16) << USART_BRR_DIV_Mantissa_Pos)
                    | ((div % 16) << USART_BRR_DIV_Fraction_Pos));
     USARTx->CR1 = CR1_FLAGS;
-    armcm_enable_irq(USARTx_IRQHandler, USARTx_IRQn, 0);
+    armcm_enable_irq(USARTx_IRQHandler, USARTx_IRQn, KALICO_MOTION_NVIC_PRIO);
 
     gpio_peripheral(GPIO_Rx, GPIO_FUNCTION(GPIO_AF_MODE), 1);
     gpio_peripheral(GPIO_Tx, GPIO_FUNCTION(GPIO_AF_MODE), 0);


### PR DESCRIPTION
Brings the STM32F401 (ZNP Robin Nano DW v2.2 / Neptune 3 Pro, CH340 → USART1) far enough to enumerate, connect, and execute short moves, plus a general step-output timer fix.

## What's in here (4 commits)
- **`serialhdl`: thread configured baud through the bridge serial path** — the bridge hard-coded baud=0, so the configured baud never reached the UART. General correctness fix (was breaking the F401 connect).
- **`stm32/serial`: drop USART RX IRQ priority to the motion band** — at NVIC prio 0 (stock Klipper default) the byte-IRQ RX preempts the live curve-sampling TIM5/TIM2 ISRs, jittering them until steps bunch and the step queue overflows (−300). Equal priority makes them cooperative. Neutral for USB-CDC boards (they don't use this IRQ).
- **`kconfig`: F401 motion sample rate 10 kHz → 5 kHz** — 84 MHz compute ceiling for live Bézier sampling.
- **`fix(f4)`: force the step-output handler when the TIM2 compare is already passed** — genuine missed-compare race in `step_output_timer_arm`: on the slow F401 the CNT-read→CCR1-write→enable sequence can let the 32-bit counter pass CCR1 before the compare goes live, so it won't match for a full ~51 s wrap; the ISR never fires, `step_out_running` stays 1, and the producer never re-arms → −300. The guard pends the handler if CNT already reached the target. This race is general (applies to H7 too — worth a follow-up).

## What's deliberately NOT here
Dropped from the investigation branch: hot-path diagnostic logging (`place_diag`/`hb_diag`/`transit-diag`/etc.), the step-queue depth test churn, and the `pump_timeout 5 s→1 s` falsification experiment. Those stay on the investigation worktree as a debugging harness.

## Known limitation (not fixed here — tracked separately)
**Sustained motion over the CH340 serial still faults −308 `PieceStartInPast`.** Root cause: the F401 USART has no RX FIFO and is serviced one byte per interrupt; with that IRQ now at motion priority it cannot preempt a running motion ISR, so during motion incoming bytes are overrun-dropped → CRC retransmits stall the synchronous per-frame PushPieces round-trip past its timeout → in-flight pieces arrive in the MCU's past. −300 and −308 are two faces of the same no-FIFO byte-IRQ root; this PR settles one side. **The proper cure is DMA RX** (hardware catches bytes with no per-byte IRQ → no priority conflict, no drops), which the `stm32/serial` commit message already names as the tracked follow-up. So: this PR gets the board talking and short moves working; it does not claim full serial motion support yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)