### PR TITLE
DMA RX for F401 USART1 serial

### DIFF
--- a/src/stm32/serial.c
+++ b/src/stm32/serial.c
@@ -20,6 +20,7 @@
   #define GPIO_AF_MODE 7
   #define USARTx USART1
   #define USARTx_IRQn USART1_IRQn
+  #define USARTx_RX_DMA_USART1 1
 #elif CONFIG_STM32_SERIAL_USART1_ALT_PB7_PB6
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PB7,PB6");
   #define GPIO_Rx GPIO('B', 7)
@@ -27,6 +28,7 @@
   #define GPIO_AF_MODE 7
   #define USARTx USART1
   #define USARTx_IRQn USART1_IRQn
+  #define USARTx_RX_DMA_USART1 1
 #elif CONFIG_STM32_SERIAL_USART2
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PA3,PA2");
   #define GPIO_Rx GPIO('A', 3)
@@ -71,18 +73,107 @@
   #define USARTx_IRQn USART6_IRQn
 #endif
 
-#define CR1_FLAGS (USART_CR1_UE | USART_CR1_RE | USART_CR1_TE   \
-                   | USART_CR1_RXNEIE)
+// DMA-based RX. Without an RX FIFO, the per-byte RX interrupt drops bytes
+// whenever an equal-priority motion ISR is running (no time to read DR before
+// the next byte overruns it) -> corrupt frames -> retransmit stalls. DMA
+// captures every byte into a RAM ring with no per-byte interrupt, so the motion
+// ISRs and serial RX no longer compete. Scoped to F401/USART1 (the only
+// validated bench); every other config keeps the byte-interrupt path below.
+// USART1_RX is DMA2 Stream 2 Channel 4 on the STM32F4 request map.
+#if USARTx_RX_DMA_USART1 && CONFIG_MACH_STM32F401
+  #define SERIAL_RX_DMA          1
+  #define SERIAL_RX_DMA_CTRL     DMA2
+  #define SERIAL_RX_DMA_STREAM   DMA2_Stream2
+  #define SERIAL_RX_DMA_IRQn     DMA2_Stream2_IRQn
+  #define SERIAL_RX_DMA_CHANNEL  4u
+  #define SERIAL_RX_DMA_RCC_EN   RCC_AHB1ENR_DMA2EN
+  #define SERIAL_RX_DMA_CLEAR    (DMA_LIFCR_CTCIF2 | DMA_LIFCR_CHTIF2     \
+                                  | DMA_LIFCR_CTEIF2 | DMA_LIFCR_CDMEIF2  \
+                                  | DMA_LIFCR_CFEIF2)
+#endif
+
+#if SERIAL_RX_DMA
+  #define CR1_FLAGS (USART_CR1_UE | USART_CR1_RE | USART_CR1_TE   \
+                     | USART_CR1_IDLEIE)
+#else
+  #define CR1_FLAGS (USART_CR1_UE | USART_CR1_RE | USART_CR1_TE   \
+                     | USART_CR1_RXNEIE)
+#endif
+
+#if SERIAL_RX_DMA
+
+// Power-of-two so the read cursor wraps with a mask. 256 B at 250000 baud is
+// ~10 ms of runway; the drain runs every 128 B (DMA half/full IRQ) plus on each
+// idle gap, so the ring never laps even when a motion ISR delays the drain.
+#define SERIAL_RX_DMA_BUF_SIZE 256
+static uint8_t dma_rx_buf[SERIAL_RX_DMA_BUF_SIZE];
+static uint16_t dma_rx_tail;
+
+// Feed the parser everything the DMA engine has captured since last drain. The
+// DMA write cursor is BUF_SIZE - NDTR; bytes [tail, head) are new. Non-critical
+// timing: DMA has already saved the bytes, so a delayed drain can't lose data.
+static void
+serial_rx_dma_drain(void)
+{
+    uint16_t ndtr = SERIAL_RX_DMA_STREAM->NDTR;
+    uint16_t head = (SERIAL_RX_DMA_BUF_SIZE - ndtr) & (SERIAL_RX_DMA_BUF_SIZE - 1);
+    while (dma_rx_tail != head) {
+        serial_rx_byte(dma_rx_buf[dma_rx_tail]);
+        dma_rx_tail = (dma_rx_tail + 1) & (SERIAL_RX_DMA_BUF_SIZE - 1);
+    }
+}
+
+// Non-static: the armcm vector table (a separately-generated TU) references
+// this handler by name, so it needs external linkage like USARTx_IRQHandler.
+void
+serial_rx_dma_irq(void)
+{
+    SERIAL_RX_DMA_CTRL->LIFCR = SERIAL_RX_DMA_CLEAR;
+    serial_rx_dma_drain();
+}
+
+static void
+serial_rx_dma_init(void)
+{
+    RCC->AHB1ENR |= SERIAL_RX_DMA_RCC_EN;
+    (void)RCC->AHB1ENR;
+    SERIAL_RX_DMA_STREAM->CR = 0;
+    while (SERIAL_RX_DMA_STREAM->CR & DMA_SxCR_EN)
+        ;
+    SERIAL_RX_DMA_CTRL->LIFCR = SERIAL_RX_DMA_CLEAR;
+    SERIAL_RX_DMA_STREAM->PAR = (uint32_t)&USARTx->DR;
+    SERIAL_RX_DMA_STREAM->M0AR = (uint32_t)dma_rx_buf;
+    SERIAL_RX_DMA_STREAM->NDTR = SERIAL_RX_DMA_BUF_SIZE;
+    dma_rx_tail = 0;
+    // peripheral-to-memory (DIR=00), byte size (00): hardware defaults
+    SERIAL_RX_DMA_STREAM->CR =
+        (SERIAL_RX_DMA_CHANNEL << DMA_SxCR_CHSEL_Pos)
+        | DMA_SxCR_MINC | DMA_SxCR_CIRC | DMA_SxCR_HTIE | DMA_SxCR_TCIE;
+    SERIAL_RX_DMA_STREAM->CR |= DMA_SxCR_EN;
+    USARTx->CR3 |= USART_CR3_DMAR;
+    armcm_enable_irq(serial_rx_dma_irq, SERIAL_RX_DMA_IRQn, KALICO_MOTION_NVIC_PRIO);
+}
+
+#endif
 
 void
 USARTx_IRQHandler(void)
 {
     uint32_t sr = USARTx->SR;
+#if SERIAL_RX_DMA
+    if (sr & USART_SR_IDLE) {
+        // Reading SR (above) then DR clears IDLE; the byte itself was already
+        // taken by DMA, so this read just acks the flag.
+        (void)USARTx->DR;
+        serial_rx_dma_drain();
+    }
+#else
     if (sr & (USART_SR_RXNE | USART_SR_ORE)) {
         // The ORE flag is automatically cleared by reading SR, followed
         // by reading DR.
         serial_rx_byte(USARTx->DR);
     }
+#endif
     if (sr & USART_SR_TXE && USARTx->CR1 & USART_CR1_TXEIE) {
         uint8_t data;
         int ret = serial_get_tx_byte(&data);
@@ -110,6 +201,10 @@ serial_init(void)
                    | ((div % 16) << USART_BRR_DIV_Fraction_Pos));
     USARTx->CR1 = CR1_FLAGS;
     armcm_enable_irq(USARTx_IRQHandler, USARTx_IRQn, KALICO_MOTION_NVIC_PRIO);
+
+#if SERIAL_RX_DMA
+    serial_rx_dma_init();
+#endif
 
     gpio_peripheral(GPIO_Rx, GPIO_FUNCTION(GPIO_AF_MODE), 1);
     gpio_peripheral(GPIO_Tx, GPIO_FUNCTION(GPIO_AF_MODE), 0);


### PR DESCRIPTION
Adds DMA-based serial RX for the STM32F401 (USART1), replacing the per-byte RX interrupt.

## Why
On the F401 the USART has no RX FIFO and is serviced one byte per interrupt, at the motion NVIC priority (so it can't preempt a running motion ISR). During motion, incoming bytes are overrun-dropped → corrupt host→MCU piece frames → CRC retransmits that stall the synchronous PushPieces round-trip until pieces arrive in the MCU's past (−308 PieceStartInPast). This is the root cause of the F401-over-serial motion faults.

## What
- DMA2 Stream 2 Channel 4 captures `USART1->DR` into a 256-byte circular RAM buffer with **no per-byte interrupt**.
- A drain (DMA half/full-transfer IRQ + USART IDLE IRQ) feeds the existing `serial_rx_byte()` parser path. Because DMA captures every byte regardless of CPU state, the motion ISRs and serial RX no longer compete — no overruns, no jitter.
- **Scoped to `CONFIG_MACH_STM32F401` + USART1.** Every other config keeps the byte-interrupt path unchanged; the Trident F446 is untouched.

## Verified on the Neptune 3 Pro bench
- Connects reliably; the dropped-byte/retransmit stalls (1 s round-trip timeouts) are gone — round-trips are consistent.
- Single jogs at all speeds, and small multi-jogs, run cleanly.

## Not fixed here (separate)
DMA RX makes the serial **link reliable**; it does not raise the **bandwidth** of the link. Heavy/fast continuous moves can still exceed the 250–500 k serial byte budget — that's a separate, tracked limitation (needs higher baud or pipeline changes), not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)