### PR TITLE
Make input shaper optional on all axes (no shaper = disabled)

### DIFF
--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -17,7 +17,7 @@ use kalico_host_rt::unix_native_conn::UnixNativeConn;
 use trajectory::{AxisShaper, ShaperConfig};
 
 use crate::classify;
-use crate::config::{self, PlannerConfig, PlannerLimits, parse_required_shaper};
+use crate::config::{self, PlannerConfig, PlannerLimits, parse_axis_shaper};
 use crate::dispatch::{McuAxisConfig, McuCaps, build_mcu_configs};
 use crate::homing::HomingState;
 use crate::planner::{DispatchError, PlannerError, PlannerHandle};
@@ -382,8 +382,8 @@ fn build_shaper_config(
     freq_y: f64,
 ) -> Result<ShaperConfig, crate::config::ShaperConfigError> {
     Ok(ShaperConfig {
-        x: parse_required_shaper(type_x, freq_x)?,
-        y: parse_required_shaper(type_y, freq_y)?,
+        x: parse_axis_shaper(type_x, freq_x)?,
+        y: parse_axis_shaper(type_y, freq_y)?,
         z: AxisShaper::Passthrough,
     })
 }

--- a/rust/motion-bridge/src/config.rs
+++ b/rust/motion-bridge/src/config.rs
@@ -72,12 +72,6 @@ impl Default for PlannerConfig {
     }
 }
 
-/// Parses an axis shaper from a type name and frequency.
-///
-/// - `smooth_zv` / `smooth-zv` with finite `freq > 0` → `SmoothZv`
-/// - `smooth_mzv` / `smooth-mzv` with finite `freq > 0` → `SmoothMzv`
-/// - `""` / `"none"` / `"passthrough"` (any freq), or any type with `freq ≤ 0` / non-finite → `Passthrough`
-/// - Any other non-empty type string with finite `freq > 0` → `Err(UnsupportedKind)`
 pub fn parse_axis_shaper(name: &str, freq: f64) -> Result<AxisShaper, ShaperConfigError> {
     match name {
         "" | "none" | "passthrough" => return Ok(AxisShaper::Passthrough),

--- a/rust/motion-bridge/src/config.rs
+++ b/rust/motion-bridge/src/config.rs
@@ -1,18 +1,10 @@
 use temporal::Limits;
 use thiserror::Error;
-use trajectory::{AxisShaper, ELimits, RequiredShaper, ShaperConfig};
+use trajectory::{AxisShaper, ELimits, ShaperConfig};
 
 #[derive(Debug, Error)]
 pub enum ShaperConfigError {
-    #[error(
-        "shaper frequency must be finite and > 0 Hz, got {value}; \
-         check shaper_freq_x / shaper_freq_y in printer.cfg \
-         (sim configs commonly set 0 to disable shaping — there is no passthrough \
-         for X/Y today; use a real frequency, e.g. 50)"
-    )]
-    InvalidFrequency { value: f64 },
-
-    #[error("unsupported shaper type for MVP: '{kind}'. Use smooth_zv or smooth_mzv")]
+    #[error("unsupported shaper type: '{kind}'. Use smooth_zv or smooth_mzv")]
     UnsupportedKind { kind: String },
 }
 
@@ -63,8 +55,8 @@ impl Default for PlannerConfig {
                 square_corner_velocity: 5.0,
             },
             shaper: ShaperConfig {
-                x: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
-                y: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
+                x: AxisShaper::Passthrough,
+                y: AxisShaper::Passthrough,
                 z: AxisShaper::Passthrough,
             },
             e_limits: ELimits {
@@ -80,13 +72,25 @@ impl Default for PlannerConfig {
     }
 }
 
-pub fn parse_required_shaper(name: &str, freq: f64) -> Result<RequiredShaper, ShaperConfigError> {
-    if !freq.is_finite() || freq <= 0.0 {
-        return Err(ShaperConfigError::InvalidFrequency { value: freq });
-    }
+/// Parses an axis shaper from a type name and frequency.
+///
+/// - `smooth_zv` / `smooth-zv` with finite `freq > 0` → `SmoothZv`
+/// - `smooth_mzv` / `smooth-mzv` with finite `freq > 0` → `SmoothMzv`
+/// - `""` / `"none"` / `"passthrough"` (any freq), or any type with `freq ≤ 0` / non-finite → `Passthrough`
+/// - Any other non-empty type string with finite `freq > 0` → `Err(UnsupportedKind)`
+pub fn parse_axis_shaper(name: &str, freq: f64) -> Result<AxisShaper, ShaperConfigError> {
     match name {
-        "smooth_zv" | "smooth-zv" => Ok(RequiredShaper::SmoothZv { frequency_hz: freq }),
-        "smooth_mzv" | "smooth-mzv" => Ok(RequiredShaper::SmoothMzv { frequency_hz: freq }),
+        "" | "none" | "passthrough" => return Ok(AxisShaper::Passthrough),
+        _ => {}
+    }
+
+    if !freq.is_finite() || freq <= 0.0 {
+        return Ok(AxisShaper::Passthrough);
+    }
+
+    match name {
+        "smooth_zv" | "smooth-zv" => Ok(AxisShaper::SmoothZv { frequency_hz: freq }),
+        "smooth_mzv" | "smooth-mzv" => Ok(AxisShaper::SmoothMzv { frequency_hz: freq }),
         other => Err(ShaperConfigError::UnsupportedKind {
             kind: other.to_string(),
         }),

--- a/rust/motion-bridge/src/config/tests.rs
+++ b/rust/motion-bridge/src/config/tests.rs
@@ -8,6 +8,14 @@ fn default_config_has_sensible_values() {
 }
 
 #[test]
+fn default_config_shaper_is_passthrough() {
+    let c = PlannerConfig::default();
+    assert!(matches!(c.shaper.x, AxisShaper::Passthrough));
+    assert!(matches!(c.shaper.y, AxisShaper::Passthrough));
+    assert!(matches!(c.shaper.z, AxisShaper::Passthrough));
+}
+
+#[test]
 fn temporal_limits_converts() {
     let l = PlannerLimits {
         max_velocity: 300.0,
@@ -25,21 +33,43 @@ fn temporal_limits_converts() {
 #[test]
 fn parse_shaper_types() {
     assert!(matches!(
-        parse_required_shaper("smooth_mzv", 50.0),
-        Ok(RequiredShaper::SmoothMzv { frequency_hz }) if (frequency_hz - 50.0).abs() < 1e-9
+        parse_axis_shaper("smooth_mzv", 50.0),
+        Ok(AxisShaper::SmoothMzv { frequency_hz }) if (frequency_hz - 50.0).abs() < 1e-9
     ));
-    assert!(parse_required_shaper("ei", 50.0).is_err());
+    assert!(parse_axis_shaper("smooth_zv", 50.0).is_ok());
+    assert!(parse_axis_shaper("ei", 50.0).is_err());
 
-    let err = parse_required_shaper("smooth_zv", 0.0)
-        .unwrap_err()
-        .to_string();
-    assert!(
-        err.contains("shaper_freq"),
-        "error must name the field, got: {err}"
-    );
+    // freq ≤ 0 or non-finite → Passthrough, not an error
+    assert!(matches!(
+        parse_axis_shaper("smooth_zv", 0.0),
+        Ok(AxisShaper::Passthrough)
+    ));
+    assert!(matches!(
+        parse_axis_shaper("smooth_mzv", -1.0),
+        Ok(AxisShaper::Passthrough)
+    ));
+    assert!(matches!(
+        parse_axis_shaper("smooth_zv", f64::NAN),
+        Ok(AxisShaper::Passthrough)
+    ));
+    assert!(matches!(
+        parse_axis_shaper("smooth_zv", f64::INFINITY),
+        Ok(AxisShaper::Passthrough)
+    ));
+}
 
-    assert!(parse_required_shaper("smooth_mzv", -1.0).is_err());
-
-    assert!(parse_required_shaper("smooth_zv", f64::NAN).is_err());
-    assert!(parse_required_shaper("smooth_zv", f64::INFINITY).is_err());
+#[test]
+fn parse_explicit_passthrough_names() {
+    assert!(matches!(
+        parse_axis_shaper("", 0.0),
+        Ok(AxisShaper::Passthrough)
+    ));
+    assert!(matches!(
+        parse_axis_shaper("none", 50.0),
+        Ok(AxisShaper::Passthrough)
+    ));
+    assert!(matches!(
+        parse_axis_shaper("passthrough", 50.0),
+        Ok(AxisShaper::Passthrough)
+    ));
 }

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -10,7 +10,7 @@ use crate::classify::ClassifiedMove;
 use crate::config::{PlannerConfig, PlannerLimits};
 use trajectory::plan_velocity::{PlanShaper, SafetyMode};
 use trajectory::streaming::{EmitContext, ReplanContext, ReplanReport, ShaperState};
-use trajectory::{AxisShaper, EHalo, RequiredShaper, ShapedSegment, ShaperConfig};
+use trajectory::{AxisShaper, EHalo, ShapedSegment, ShaperConfig};
 
 const T_IDLE: Duration = Duration::from_secs(3600);
 
@@ -679,32 +679,7 @@ fn build_replan_context(config: &PlannerConfig) -> ReplanContext {
 fn shaper_config_to_emit_kernels(
     cfg: &ShaperConfig,
 ) -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
-    [
-        Some(required_to_kernel(cfg.x)),
-        Some(required_to_kernel(cfg.y)),
-        cfg.z.to_kernel(),
-        None,
-    ]
-}
-
-fn required_to_kernel(req: RequiredShaper) -> PiecewisePolynomialKernel<f64> {
-    req.to_kernel()
-}
-
-fn shaper_config_to_plan_shapers(cfg: &ShaperConfig) -> [Option<PlanShaper>; 4] {
-    [
-        Some(required_to_plan(cfg.x)),
-        Some(required_to_plan(cfg.y)),
-        Some(axis_to_plan(cfg.z)),
-        None,
-    ]
-}
-
-fn required_to_plan(req: RequiredShaper) -> PlanShaper {
-    match req {
-        RequiredShaper::SmoothZv { frequency_hz } => PlanShaper::SmoothZv { frequency_hz },
-        RequiredShaper::SmoothMzv { frequency_hz } => PlanShaper::SmoothMzv { frequency_hz },
-    }
+    [cfg.x.to_kernel(), cfg.y.to_kernel(), cfg.z.to_kernel(), None]
 }
 
 fn axis_to_plan(ax: AxisShaper) -> PlanShaper {
@@ -715,20 +690,17 @@ fn axis_to_plan(ax: AxisShaper) -> PlanShaper {
     }
 }
 
-fn shaper_config_to_axis_shapers(cfg: &ShaperConfig) -> [Option<AxisShaper>; 4] {
+fn shaper_config_to_plan_shapers(cfg: &ShaperConfig) -> [Option<PlanShaper>; 4] {
     [
-        Some(required_to_axis(cfg.x)),
-        Some(required_to_axis(cfg.y)),
-        Some(cfg.z),
+        Some(axis_to_plan(cfg.x)),
+        Some(axis_to_plan(cfg.y)),
+        Some(axis_to_plan(cfg.z)),
         None,
     ]
 }
 
-fn required_to_axis(req: RequiredShaper) -> AxisShaper {
-    match req {
-        RequiredShaper::SmoothZv { frequency_hz } => AxisShaper::SmoothZv { frequency_hz },
-        RequiredShaper::SmoothMzv { frequency_hz } => AxisShaper::SmoothMzv { frequency_hz },
-    }
+fn shaper_config_to_axis_shapers(cfg: &ShaperConfig) -> [Option<AxisShaper>; 4] {
+    [Some(cfg.x), Some(cfg.y), Some(cfg.z), None]
 }
 
 #[cfg(test)]

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -679,7 +679,12 @@ fn build_replan_context(config: &PlannerConfig) -> ReplanContext {
 fn shaper_config_to_emit_kernels(
     cfg: &ShaperConfig,
 ) -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
-    [cfg.x.to_kernel(), cfg.y.to_kernel(), cfg.z.to_kernel(), None]
+    [
+        cfg.x.to_kernel(),
+        cfg.y.to_kernel(),
+        cfg.z.to_kernel(),
+        None,
+    ]
 }
 
 fn axis_to_plan(ax: AxisShaper) -> PlanShaper {

--- a/rust/motion-bridge/src/planner/tests.rs
+++ b/rust/motion-bridge/src/planner/tests.rs
@@ -86,8 +86,8 @@ fn update_shaper_processed_without_error() {
     let mut h = PlannerHandle::spawn(PlannerConfig::default(), dispatch);
 
     let shaper = ShaperConfig {
-        x: trajectory::RequiredShaper::SmoothZv { frequency_hz: 60.0 },
-        y: trajectory::RequiredShaper::SmoothZv { frequency_hz: 60.0 },
+        x: trajectory::AxisShaper::SmoothZv { frequency_hz: 60.0 },
+        y: trajectory::AxisShaper::SmoothZv { frequency_hz: 60.0 },
         z: trajectory::AxisShaper::Passthrough,
     };
     h.update_shaper(shaper).unwrap();
@@ -123,10 +123,10 @@ fn z_only_move_after_homing_xy_shaped_axes_are_constant() {
     use crate::classify::classify_and_build;
 
     let shaper_cfg = ShaperConfig {
-        x: trajectory::RequiredShaper::SmoothMzv {
+        x: trajectory::AxisShaper::SmoothMzv {
             frequency_hz: 186.0,
         },
-        y: trajectory::RequiredShaper::SmoothMzv {
+        y: trajectory::AxisShaper::SmoothMzv {
             frequency_hz: 122.0,
         },
         z: trajectory::AxisShaper::Passthrough,
@@ -242,10 +242,10 @@ fn z_move_with_tiny_x_after_homing_xy_deviation_proportional() {
     use crate::classify::classify_and_build;
 
     let shaper_cfg = ShaperConfig {
-        x: RequiredShaper::SmoothMzv {
+        x: AxisShaper::SmoothMzv {
             frequency_hz: 186.0,
         },
-        y: RequiredShaper::SmoothMzv {
+        y: AxisShaper::SmoothMzv {
             frequency_hz: 122.0,
         },
         z: AxisShaper::Passthrough,
@@ -406,10 +406,10 @@ fn z_only_move_no_prior_xy_motion() {
     use crate::classify::classify_and_build;
 
     let shaper_cfg = ShaperConfig {
-        x: RequiredShaper::SmoothMzv {
+        x: AxisShaper::SmoothMzv {
             frequency_hz: 186.0,
         },
-        y: RequiredShaper::SmoothMzv {
+        y: AxisShaper::SmoothMzv {
             frequency_hz: 122.0,
         },
         z: AxisShaper::Passthrough,

--- a/rust/motion-bridge/tests/streaming_replan.rs
+++ b/rust/motion-bridge/tests/streaming_replan.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use motion_bridge_native::classify::classify_and_build;
 use motion_bridge_native::config::{PlannerConfig, PlannerLimits};
 use motion_bridge_native::planner::{DispatchError, PlannerHandle};
-use trajectory::{AxisShaper, RequiredShaper, ShapedSegment, ShaperConfig};
+use trajectory::{AxisShaper, ShapedSegment, ShaperConfig};
 
 use nurbs::ScalarNurbs;
 use nurbs::eval::{eval_derivative, eval_polynomial};
@@ -30,10 +30,10 @@ fn recording_dispatch() -> (
 fn smooth_zv_186hz_config() -> PlannerConfig {
     let mut c = PlannerConfig::default();
     c.shaper = ShaperConfig {
-        x: RequiredShaper::SmoothZv {
+        x: AxisShaper::SmoothZv {
             frequency_hz: 186.0,
         },
-        y: RequiredShaper::SmoothZv {
+        y: AxisShaper::SmoothZv {
             frequency_hz: 186.0,
         },
         z: AxisShaper::Passthrough,
@@ -916,8 +916,8 @@ fn update_shaper_commits_held_output_before_swap() {
     let commit_count_before = h.commit_fire_count();
 
     let new_shaper = ShaperConfig {
-        x: RequiredShaper::SmoothZv { frequency_hz: 60.0 },
-        y: RequiredShaper::SmoothZv { frequency_hz: 60.0 },
+        x: AxisShaper::SmoothZv { frequency_hz: 60.0 },
+        y: AxisShaper::SmoothZv { frequency_hz: 60.0 },
         z: AxisShaper::Passthrough,
     };
     h.update_shaper(new_shaper).expect("update_shaper");

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -82,7 +82,12 @@ pub fn plan_batch_full(
 fn build_kernel_array_from_shaper_config(
     shaper: &crate::ShaperConfig,
 ) -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
-    [shaper.x.to_kernel(), shaper.y.to_kernel(), shaper.z.to_kernel(), None]
+    [
+        shaper.x.to_kernel(),
+        shaper.y.to_kernel(),
+        shaper.z.to_kernel(),
+        None,
+    ]
 }
 
 fn collect_xy_meta(
@@ -539,7 +544,12 @@ fn run_one_iteration(
 fn build_kernel_array_from_axis_kernels(
     kernels: &AxisKernels,
 ) -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
-    [kernels.x.clone(), kernels.y.clone(), kernels.z.clone(), None]
+    [
+        kernels.x.clone(),
+        kernels.y.clone(),
+        kernels.z.clone(),
+        None,
+    ]
 }
 
 struct DerateInfo {

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -12,8 +12,8 @@ const MIN_AXIS_SPAN_FOR_DERATE: f64 = 0.5;
 const BETA_ACCEL_MIN_RATIO: f64 = 0.02;
 
 struct AxisKernels {
-    x: PiecewisePolynomialKernel<f64>,
-    y: PiecewisePolynomialKernel<f64>,
+    x: Option<PiecewisePolynomialKernel<f64>>,
+    y: Option<PiecewisePolynomialKernel<f64>>,
     z: Option<PiecewisePolynomialKernel<f64>>,
 }
 
@@ -82,12 +82,7 @@ pub fn plan_batch_full(
 fn build_kernel_array_from_shaper_config(
     shaper: &crate::ShaperConfig,
 ) -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
-    [
-        Some(shaper.x.to_kernel()),
-        Some(shaper.y.to_kernel()),
-        shaper.z.to_kernel(),
-        None,
-    ]
+    [shaper.x.to_kernel(), shaper.y.to_kernel(), shaper.z.to_kernel(), None]
 }
 
 fn collect_xy_meta(
@@ -544,12 +539,7 @@ fn run_one_iteration(
 fn build_kernel_array_from_axis_kernels(
     kernels: &AxisKernels,
 ) -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
-    [
-        Some(kernels.x.clone()),
-        Some(kernels.y.clone()),
-        kernels.z.clone(),
-        None,
-    ]
+    [kernels.x.clone(), kernels.y.clone(), kernels.z.clone(), None]
 }
 
 struct DerateInfo {

--- a/rust/trajectory/src/beta/tests.rs
+++ b/rust/trajectory/src/beta/tests.rs
@@ -13,10 +13,10 @@ fn default_limits() -> temporal::Limits {
 
 fn default_shaper_config() -> ShaperConfig {
     ShaperConfig {
-        x: crate::RequiredShaper::SmoothZv {
+        x: crate::AxisShaper::SmoothZv {
             frequency_hz: 180.0,
         },
-        y: crate::RequiredShaper::SmoothZv {
+        y: crate::AxisShaper::SmoothZv {
             frequency_hz: 120.0,
         },
         z: crate::AxisShaper::Passthrough,

--- a/rust/trajectory/src/emit_shaped/tests.rs
+++ b/rust/trajectory/src/emit_shaped/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::fit::FittedSegment;
 use crate::{
-    plan_velocity, AxisShaper, ELimits, PlanInput, PlanSegment, PlanShaper, RequiredShaper,
-    SafetyMode, ShapeBatchInput, ShapeSegmentInput, ShaperConfig,
+    plan_velocity, AxisShaper, ELimits, PlanInput, PlanSegment, PlanShaper, SafetyMode,
+    ShapeBatchInput, ShapeSegmentInput, ShaperConfig,
 };
 use geometry::segment::EMode;
 use nurbs::bezier::{bezier_pieces_to_nurbs, extract_bezier_pieces};
@@ -30,10 +30,10 @@ fn default_e_limits() -> ELimits {
 
 fn default_shaper_config() -> ShaperConfig {
     ShaperConfig {
-        x: RequiredShaper::SmoothZv {
+        x: AxisShaper::SmoothZv {
             frequency_hz: 180.0,
         },
-        y: RequiredShaper::SmoothZv {
+        y: AxisShaper::SmoothZv {
             frequency_hz: 120.0,
         },
         z: AxisShaper::Passthrough,
@@ -121,18 +121,14 @@ fn empty_history_matches_shape_batch_byte_identical() {
     assert_eq!(planned.len(), 1);
 
     let kernels: [Option<PiecewisePolynomialKernel<f64>>; 4] = [
-        Some(
-            RequiredShaper::SmoothZv {
-                frequency_hz: 180.0,
-            }
-            .to_kernel(),
-        ),
-        Some(
-            RequiredShaper::SmoothZv {
-                frequency_hz: 120.0,
-            }
-            .to_kernel(),
-        ),
+        AxisShaper::SmoothZv {
+            frequency_hz: 180.0,
+        }
+        .to_kernel(),
+        AxisShaper::SmoothZv {
+            frequency_hz: 120.0,
+        }
+        .to_kernel(),
         None,
         None,
     ];

--- a/rust/trajectory/src/kernel.rs
+++ b/rust/trajectory/src/kernel.rs
@@ -23,15 +23,6 @@ pub fn build_smooth_mzv_kernel(t_sm: f64) -> PiecewisePolynomialKernel<f64> {
     build_bell_kernel(t_sm)
 }
 
-impl crate::RequiredShaper {
-    pub fn to_kernel(&self) -> PiecewisePolynomialKernel<f64> {
-        match self {
-            Self::SmoothZv { frequency_hz } => build_smooth_zv_kernel(0.8025 / frequency_hz),
-            Self::SmoothMzv { frequency_hz } => build_smooth_mzv_kernel(0.95625 / frequency_hz),
-        }
-    }
-}
-
 impl crate::AxisShaper {
     pub fn to_kernel(&self) -> Option<PiecewisePolynomialKernel<f64>> {
         match self {

--- a/rust/trajectory/src/kernel/tests.rs
+++ b/rust/trajectory/src/kernel/tests.rs
@@ -84,7 +84,7 @@ fn kernel_peak_at_center() {
 #[test]
 fn smooth_zv_support_width() {
     let f = 150.0;
-    let kernel = crate::RequiredShaper::SmoothZv { frequency_hz: f }.to_kernel();
+    let kernel = crate::AxisShaper::SmoothZv { frequency_hz: f }.to_kernel().unwrap();
     let (lo, hi) = kernel.support();
     let expected_t_sm = 0.8025 / f;
     assert!((hi - lo - expected_t_sm).abs() < 1e-12);
@@ -93,7 +93,7 @@ fn smooth_zv_support_width() {
 #[test]
 fn smooth_mzv_support_width() {
     let f = 120.0;
-    let kernel = crate::RequiredShaper::SmoothMzv { frequency_hz: f }.to_kernel();
+    let kernel = crate::AxisShaper::SmoothMzv { frequency_hz: f }.to_kernel().unwrap();
     let (lo, hi) = kernel.support();
     let expected_t_sm = 0.95625 / f;
     assert!((hi - lo - expected_t_sm).abs() < 1e-12);

--- a/rust/trajectory/src/kernel/tests.rs
+++ b/rust/trajectory/src/kernel/tests.rs
@@ -84,7 +84,9 @@ fn kernel_peak_at_center() {
 #[test]
 fn smooth_zv_support_width() {
     let f = 150.0;
-    let kernel = crate::AxisShaper::SmoothZv { frequency_hz: f }.to_kernel().unwrap();
+    let kernel = crate::AxisShaper::SmoothZv { frequency_hz: f }
+        .to_kernel()
+        .unwrap();
     let (lo, hi) = kernel.support();
     let expected_t_sm = 0.8025 / f;
     assert!((hi - lo - expected_t_sm).abs() < 1e-12);
@@ -93,7 +95,9 @@ fn smooth_zv_support_width() {
 #[test]
 fn smooth_mzv_support_width() {
     let f = 120.0;
-    let kernel = crate::AxisShaper::SmoothMzv { frequency_hz: f }.to_kernel().unwrap();
+    let kernel = crate::AxisShaper::SmoothMzv { frequency_hz: f }
+        .to_kernel()
+        .unwrap();
     let (lo, hi) = kernel.support();
     let expected_t_sm = 0.95625 / f;
     assert!((hi - lo - expected_t_sm).abs() < 1e-12);

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -52,15 +52,9 @@ pub struct ELimits {
 
 #[derive(Debug, Clone)]
 pub struct ShaperConfig {
-    pub x: RequiredShaper,
-    pub y: RequiredShaper,
+    pub x: AxisShaper,
+    pub y: AxisShaper,
     pub z: AxisShaper,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum RequiredShaper {
-    SmoothZv { frequency_hz: f64 },
-    SmoothMzv { frequency_hz: f64 },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -119,8 +113,6 @@ pub enum ShapeError {
     ArcLength { index: usize, detail: String },
     #[error("empty segment buffer")]
     EmptySegments,
-    #[error("unsupported shaper configuration: Passthrough on X or Y is not supported")]
-    UnsupportedShaperOnXY,
     #[error("unsupported boundary velocity: initial_v and terminal_v must be finite and ≥ 0.0")]
     UnsupportedBoundaryVelocity,
 }

--- a/rust/trajectory/src/plan_velocity.rs
+++ b/rust/trajectory/src/plan_velocity.rs
@@ -1,9 +1,6 @@
 use crate::fit::FittedSegment;
 use crate::partition::partition_batch;
-use crate::{
-    AxisShaper, ELimits, RequiredShaper, ShapeBatchInput, ShapeError, ShapeSegmentInput,
-    ShaperConfig,
-};
+use crate::{AxisShaper, ELimits, ShapeBatchInput, ShapeError, ShapeSegmentInput, ShaperConfig};
 
 pub use crate::beta::{PlanOutput, PlanStats};
 
@@ -27,14 +24,6 @@ pub enum PlanShaper {
 }
 
 impl PlanShaper {
-    fn into_required(self) -> Result<RequiredShaper, ShapeError> {
-        match self {
-            Self::SmoothZv { frequency_hz } => Ok(RequiredShaper::SmoothZv { frequency_hz }),
-            Self::SmoothMzv { frequency_hz } => Ok(RequiredShaper::SmoothMzv { frequency_hz }),
-            Self::Passthrough => Err(ShapeError::UnsupportedShaperOnXY),
-        }
-    }
-
     fn into_axis(self) -> AxisShaper {
         match self {
             Self::SmoothZv { frequency_hz } => AxisShaper::SmoothZv { frequency_hz },
@@ -74,7 +63,6 @@ pub struct PlanInput<'a> {
 /// # Errors
 ///
 /// - [`ShapeError::EmptySegments`] — `input.segments` is empty.
-/// - [`ShapeError::UnsupportedShaperOnXY`] — X or Y kernel is `None` or `Passthrough`.
 /// - [`ShapeError::UnsupportedBoundaryVelocity`] — `initial_v` or `terminal_v` is non-finite or negative.
 /// - Any error from the underlying β-medium loop.
 pub fn plan_velocity(input: &PlanInput<'_>) -> Result<PlanOutput, ShapeError> {
@@ -89,7 +77,7 @@ pub fn plan_velocity(input: &PlanInput<'_>) -> Result<PlanOutput, ShapeError> {
         return Err(ShapeError::UnsupportedBoundaryVelocity);
     }
 
-    let shaper = build_shaper_config(&input.kernels)?;
+    let shaper = build_shaper_config(&input.kernels);
     let segments: Vec<ShapeSegmentInput<'_>> = input
         .segments
         .iter()
@@ -119,15 +107,11 @@ pub fn plan_velocity(input: &PlanInput<'_>) -> Result<PlanOutput, ShapeError> {
     crate::beta::plan_velocity_inner(&shape_input, &partition, input.safety_mode)
 }
 
-fn build_shaper_config(kernels: &[Option<PlanShaper>; 4]) -> Result<ShaperConfig, ShapeError> {
-    let x = kernels[0]
-        .ok_or(ShapeError::UnsupportedShaperOnXY)?
-        .into_required()?;
-    let y = kernels[1]
-        .ok_or(ShapeError::UnsupportedShaperOnXY)?
-        .into_required()?;
+fn build_shaper_config(kernels: &[Option<PlanShaper>; 4]) -> ShaperConfig {
+    let x = kernels[0].map_or(AxisShaper::Passthrough, PlanShaper::into_axis);
+    let y = kernels[1].map_or(AxisShaper::Passthrough, PlanShaper::into_axis);
     let z = kernels[2].map_or(AxisShaper::Passthrough, PlanShaper::into_axis);
-    Ok(ShaperConfig { x, y, z })
+    ShaperConfig { x, y, z }
 }
 
 #[cfg(test)]

--- a/rust/trajectory/src/plan_velocity/tests.rs
+++ b/rust/trajectory/src/plan_velocity/tests.rs
@@ -158,7 +158,10 @@ fn passthrough_on_x_is_valid() {
     let mut input = default_input(&segments, SafetyMode::TerminalKnown);
     input.kernels[0] = Some(PlanShaper::Passthrough);
     let result = plan_velocity(&input);
-    assert!(result.is_ok(), "passthrough on X must succeed, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "passthrough on X must succeed, got: {result:?}"
+    );
 }
 
 #[test]
@@ -178,7 +181,10 @@ fn passthrough_on_y_is_valid() {
     let mut input = default_input(&segments, SafetyMode::TerminalKnown);
     input.kernels[1] = Some(PlanShaper::Passthrough);
     let result = plan_velocity(&input);
-    assert!(result.is_ok(), "passthrough on Y must succeed, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "passthrough on Y must succeed, got: {result:?}"
+    );
 }
 
 #[test]
@@ -198,7 +204,10 @@ fn none_on_x_treated_as_passthrough() {
     let mut input = default_input(&segments, SafetyMode::TerminalKnown);
     input.kernels[0] = None;
     let result = plan_velocity(&input);
-    assert!(result.is_ok(), "None on X must be treated as passthrough, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "None on X must be treated as passthrough, got: {result:?}"
+    );
 }
 
 #[test]

--- a/rust/trajectory/src/plan_velocity/tests.rs
+++ b/rust/trajectory/src/plan_velocity/tests.rs
@@ -142,7 +142,7 @@ fn nonzero_initial_v_produces_chained_profile() {
 }
 
 #[test]
-fn rejects_passthrough_on_x() {
+fn passthrough_on_x_is_valid() {
     let curve = straight_linear([0.0, 0.0, 0.0], [50.0, 0.0, 0.0]);
     let segments = [PlanSegment {
         temporal: temporal::multi::SegmentInput {
@@ -158,11 +158,11 @@ fn rejects_passthrough_on_x() {
     let mut input = default_input(&segments, SafetyMode::TerminalKnown);
     input.kernels[0] = Some(PlanShaper::Passthrough);
     let result = plan_velocity(&input);
-    assert!(matches!(result, Err(ShapeError::UnsupportedShaperOnXY)));
+    assert!(result.is_ok(), "passthrough on X must succeed, got: {result:?}");
 }
 
 #[test]
-fn rejects_passthrough_on_y() {
+fn passthrough_on_y_is_valid() {
     let curve = straight_linear([0.0, 0.0, 0.0], [50.0, 0.0, 0.0]);
     let segments = [PlanSegment {
         temporal: temporal::multi::SegmentInput {
@@ -178,11 +178,11 @@ fn rejects_passthrough_on_y() {
     let mut input = default_input(&segments, SafetyMode::TerminalKnown);
     input.kernels[1] = Some(PlanShaper::Passthrough);
     let result = plan_velocity(&input);
-    assert!(matches!(result, Err(ShapeError::UnsupportedShaperOnXY)));
+    assert!(result.is_ok(), "passthrough on Y must succeed, got: {result:?}");
 }
 
 #[test]
-fn rejects_none_on_x() {
+fn none_on_x_treated_as_passthrough() {
     let curve = straight_linear([0.0, 0.0, 0.0], [50.0, 0.0, 0.0]);
     let segments = [PlanSegment {
         temporal: temporal::multi::SegmentInput {
@@ -198,7 +198,28 @@ fn rejects_none_on_x() {
     let mut input = default_input(&segments, SafetyMode::TerminalKnown);
     input.kernels[0] = None;
     let result = plan_velocity(&input);
-    assert!(matches!(result, Err(ShapeError::UnsupportedShaperOnXY)));
+    assert!(result.is_ok(), "None on X must be treated as passthrough, got: {result:?}");
+}
+
+#[test]
+fn all_passthrough_produces_fitted_output() {
+    let curve = straight_linear([0.0, 0.0, 0.0], [50.0, 0.0, 0.0]);
+    let segments = [PlanSegment {
+        temporal: temporal::multi::SegmentInput {
+            curve: &curve,
+            limits: default_limits(),
+            trailing_junction_chord_tolerance_mm: 0.05,
+        },
+        e_mode: EMode::CoupledToXy,
+        extrusion_per_xy_mm: 0.04,
+        e_independent: None,
+        feedrate_mm_s: 100.0,
+    }];
+    let mut input = default_input(&segments, SafetyMode::TerminalKnown);
+    input.kernels = [None, None, None, None];
+    let out = plan_velocity(&input).expect("all-passthrough plan must succeed");
+    assert_eq!(out.fitted.len(), 1);
+    assert!(out.fitted[0].t_end > out.fitted[0].t_start);
 }
 
 #[test]

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -779,12 +779,7 @@ fn append_and_replan_rolls_back_planned_caches_on_plan_velocity_error() {
         .collect();
 
     let mut ctx_bad = ctx_good;
-    ctx_bad.limits = temporal::Limits::new(
-        [1e-10; 3],
-        [5_000.0; 3],
-        [100_000.0; 3],
-        2_500.0,
-    );
+    ctx_bad.limits = temporal::Limits::new([1e-10; 3], [5_000.0; 3], [100_000.0; 3], 2_500.0);
 
     let m_broken = linear_x_segment(200.0, 400.0, 200.0);
     let bad_result = state.append_and_replan(m_broken, &ctx_bad);

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -19,7 +19,7 @@ use crate::pad::{pad_segment_axis, EHalo};
 use crate::plan_velocity::{PlanShaper, SafetyMode};
 use crate::refit::{refit_to_cubic, REFIT_TOLERANCE_MM};
 use crate::shaper::shape_axis;
-use crate::{AxisShaper, ELimits, RequiredShaper};
+use crate::{AxisShaper, ELimits};
 
 fn linear_segment() -> FittedSegment {
     let x_nurbs = bezier_pieces_to_nurbs(&[BezierPiece {
@@ -179,18 +179,20 @@ fn required_shaper_h_matches_axis_shaper_h() {
     ];
     let state = ShaperState::new([0.0; 4], &shapers);
 
-    let kernel_x = RequiredShaper::SmoothZv {
+    let kernel_x = AxisShaper::SmoothZv {
         frequency_hz: 186.0,
     }
-    .to_kernel();
+    .to_kernel()
+    .unwrap();
     let (lo_x, hi_x) = kernel_x.support();
     let expected_h_x = (hi_x - lo_x) / 2.0;
     assert!((state.axes[0].h - expected_h_x).abs() < 1e-15);
 
-    let kernel_y = RequiredShaper::SmoothMzv {
+    let kernel_y = AxisShaper::SmoothMzv {
         frequency_hz: 122.0,
     }
-    .to_kernel();
+    .to_kernel()
+    .unwrap();
     let (lo_y, hi_y) = kernel_y.support();
     let expected_h_y = (hi_y - lo_y) / 2.0;
     assert!((state.axes[1].h - expected_h_y).abs() < 1e-15);
@@ -216,8 +218,8 @@ fn replan_kernels_planshaper() -> [Option<PlanShaper>; 4] {
 
 fn replan_kernels_piecewise() -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
     [
-        Some(RequiredShaper::SmoothMzv { frequency_hz: 60.0 }.to_kernel()),
-        Some(RequiredShaper::SmoothMzv { frequency_hz: 60.0 }.to_kernel()),
+        AxisShaper::SmoothMzv { frequency_hz: 60.0 }.to_kernel(),
+        AxisShaper::SmoothMzv { frequency_hz: 60.0 }.to_kernel(),
         None,
         None,
     ]
@@ -777,7 +779,12 @@ fn append_and_replan_rolls_back_planned_caches_on_plan_velocity_error() {
         .collect();
 
     let mut ctx_bad = ctx_good;
-    ctx_bad.kernels[0] = Some(PlanShaper::Passthrough);
+    ctx_bad.limits = temporal::Limits::new(
+        [1e-10; 3],
+        [5_000.0; 3],
+        [100_000.0; 3],
+        2_500.0,
+    );
 
     let m_broken = linear_x_segment(200.0, 400.0, 200.0);
     let bad_result = state.append_and_replan(m_broken, &ctx_bad);

--- a/rust/trajectory/src/tests.rs
+++ b/rust/trajectory/src/tests.rs
@@ -7,10 +7,10 @@ fn shape_batch_rejects_empty_segments() {
         grid_strategy: temporal::multi::GridStrategy::Fixed(100),
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothZv {
+            x: AxisShaper::SmoothZv {
                 frequency_hz: 180.0,
             },
-            y: RequiredShaper::SmoothMzv {
+            y: AxisShaper::SmoothMzv {
                 frequency_hz: 120.0,
             },
             z: AxisShaper::Passthrough,

--- a/rust/trajectory/tests/end_to_end.rs
+++ b/rust/trajectory/tests/end_to_end.rs
@@ -12,8 +12,7 @@ use geometry::segment::EMode;
 use nurbs::{ScalarNurbs, VectorNurbs};
 use temporal::multi::{GridStrategy, SegmentInput};
 use trajectory::{
-    AxisShaper, ELimits, RequiredShaper, ShapeBatchInput, ShapeError, ShapeSegmentInput,
-    ShaperConfig,
+    AxisShaper, ELimits, ShapeBatchInput, ShapeError, ShapeSegmentInput, ShaperConfig,
 };
 
 fn make_straight_line(from: [f64; 3], to: [f64; 3]) -> VectorNurbs<f64, 3> {
@@ -31,8 +30,8 @@ fn default_limits() -> temporal::Limits {
 
 fn test_shaper_config() -> ShaperConfig {
     ShaperConfig {
-        x: RequiredShaper::SmoothZv { frequency_hz: 10.0 },
-        y: RequiredShaper::SmoothZv { frequency_hz: 10.0 },
+        x: AxisShaper::SmoothZv { frequency_hz: 10.0 },
+        y: AxisShaper::SmoothZv { frequency_hz: 10.0 },
         z: AxisShaper::Passthrough,
     }
 }
@@ -127,8 +126,8 @@ fn shape_batch_short_low_velocity_line_refits_at_five_microns() {
         grid_strategy: GridStrategy::Fixed(25),
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothZv { frequency_hz: 50.0 },
-            y: RequiredShaper::SmoothZv { frequency_hz: 50.0 },
+            x: AxisShaper::SmoothZv { frequency_hz: 50.0 },
+            y: AxisShaper::SmoothZv { frequency_hz: 50.0 },
             z: AxisShaper::Passthrough,
         },
         fit_tolerance_mm: 0.005,

--- a/rust/trajectory/tests/homing_300mm_pure_x.rs
+++ b/rust/trajectory/tests/homing_300mm_pure_x.rs
@@ -2,8 +2,7 @@ use geometry::segment::EMode;
 use nurbs::VectorNurbs;
 use temporal::multi::{GridStrategy, JoiningStatus, SegmentInput};
 use trajectory::{
-    AxisShaper, ELimits, RequiredShaper, ShapeBatchInput, ShapeError, ShapeSegmentInput,
-    ShaperConfig,
+    AxisShaper, ELimits, ShapeBatchInput, ShapeError, ShapeSegmentInput, ShaperConfig,
 };
 
 fn pure_x_300mm_collinear_cubic() -> VectorNurbs<f64, 3> {
@@ -54,8 +53,8 @@ fn homing_300mm_pure_x_at_uniform_jerk_converges() {
         },
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
-            y: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
+            x: AxisShaper::SmoothMzv { frequency_hz: 50.0 },
+            y: AxisShaper::SmoothMzv { frequency_hz: 50.0 },
             z: AxisShaper::Passthrough,
         },
         fit_tolerance_mm: 0.005,

--- a/rust/trajectory/tests/homing_diagnostic.rs
+++ b/rust/trajectory/tests/homing_diagnostic.rs
@@ -2,8 +2,7 @@ use geometry::segment::EMode;
 use nurbs::VectorNurbs;
 use temporal::multi::{BatchInput, GridStrategy, SegmentInput};
 use trajectory::{
-    AxisShaper, ELimits, RequiredShaper, ShapeBatchInput, ShapeError, ShapeSegmentInput,
-    ShaperConfig,
+    AxisShaper, ELimits, ShapeBatchInput, ShapeError, ShapeSegmentInput, ShaperConfig,
 };
 
 fn pure_x_collinear_cubic(start_x: f64) -> VectorNurbs<f64, 3> {
@@ -145,8 +144,8 @@ fn run_topp_only_with_grid(
 
 fn smooth_mzv_50() -> ShaperConfig {
     ShaperConfig {
-        x: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
-        y: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
+        x: AxisShaper::SmoothMzv { frequency_hz: 50.0 },
+        y: AxisShaper::SmoothMzv { frequency_hz: 50.0 },
         z: AxisShaper::Passthrough,
     }
 }
@@ -175,10 +174,10 @@ fn regression_pure_x_homing_matrix_all_variants_converge() {
     ));
 
     let narrow_mzv = ShaperConfig {
-        x: RequiredShaper::SmoothMzv {
+        x: AxisShaper::SmoothMzv {
             frequency_hz: 500.0,
         },
-        y: RequiredShaper::SmoothMzv {
+        y: AxisShaper::SmoothMzv {
             frequency_hz: 500.0,
         },
         z: AxisShaper::Passthrough,

--- a/rust/trajectory/tests/jog_50mm_live_limits.rs
+++ b/rust/trajectory/tests/jog_50mm_live_limits.rs
@@ -1,9 +1,7 @@
 use geometry::segment::EMode;
 use nurbs::VectorNurbs;
 use temporal::multi::{GridStrategy, SegmentInput};
-use trajectory::{
-    AxisShaper, ELimits, ShapeBatchInput, ShapeSegmentInput, ShaperConfig,
-};
+use trajectory::{AxisShaper, ELimits, ShapeBatchInput, ShapeSegmentInput, ShaperConfig};
 
 fn x_50mm_collinear_cubic() -> VectorNurbs<f64, 3> {
     VectorNurbs::<f64, 3>::try_new(

--- a/rust/trajectory/tests/jog_50mm_live_limits.rs
+++ b/rust/trajectory/tests/jog_50mm_live_limits.rs
@@ -2,7 +2,7 @@ use geometry::segment::EMode;
 use nurbs::VectorNurbs;
 use temporal::multi::{GridStrategy, SegmentInput};
 use trajectory::{
-    AxisShaper, ELimits, RequiredShaper, ShapeBatchInput, ShapeSegmentInput, ShaperConfig,
+    AxisShaper, ELimits, ShapeBatchInput, ShapeSegmentInput, ShaperConfig,
 };
 
 fn x_50mm_collinear_cubic() -> VectorNurbs<f64, 3> {
@@ -53,10 +53,10 @@ fn jog_50mm_at_100mms_with_live_limits() {
         },
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothMzv {
+            x: AxisShaper::SmoothMzv {
                 frequency_hz: 186.0,
             },
-            y: RequiredShaper::SmoothMzv {
+            y: AxisShaper::SmoothMzv {
                 frequency_hz: 122.0,
             },
             z: AxisShaper::Passthrough,
@@ -121,10 +121,10 @@ fn jog_50mm_with_higher_scv() {
         },
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothMzv {
+            x: AxisShaper::SmoothMzv {
                 frequency_hz: 186.0,
             },
-            y: RequiredShaper::SmoothMzv {
+            y: AxisShaper::SmoothMzv {
                 frequency_hz: 122.0,
             },
             z: AxisShaper::Passthrough,
@@ -183,10 +183,10 @@ fn probe_with_feedrate(feedrate: f64, dist_mm: f64) -> f64 {
         },
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothMzv {
+            x: AxisShaper::SmoothMzv {
                 frequency_hz: 186.0,
             },
-            y: RequiredShaper::SmoothMzv {
+            y: AxisShaper::SmoothMzv {
                 frequency_hz: 122.0,
             },
             z: AxisShaper::Passthrough,
@@ -250,10 +250,10 @@ fn jog_50mm_with_z_jmax_uncapped() {
         },
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothMzv {
+            x: AxisShaper::SmoothMzv {
                 frequency_hz: 186.0,
             },
-            y: RequiredShaper::SmoothMzv {
+            y: AxisShaper::SmoothMzv {
                 frequency_hz: 122.0,
             },
             z: AxisShaper::Passthrough,
@@ -323,8 +323,8 @@ fn jog_50mm_low_accel_baseline() {
         },
         worker_threads: 1,
         shaper: ShaperConfig {
-            x: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
-            y: RequiredShaper::SmoothMzv { frequency_hz: 50.0 },
+            x: AxisShaper::SmoothMzv { frequency_hz: 50.0 },
+            y: AxisShaper::SmoothMzv { frequency_hz: 50.0 },
             z: AxisShaper::Passthrough,
         },
         fit_tolerance_mm: 0.005,


### PR DESCRIPTION
## What

Makes the input shaper optional on **all** axes, including X/Y. Previously the architecture *forced* a smooth shaper on X/Y: `ShaperConfig.{x,y}` were `RequiredShaper` (no passthrough variant), `plan_velocity` hard-errored `UnsupportedShaperOnXY`, and `parse_required_shaper` rejected `freq ≤ 0`. The emit/plan/beta paths already handled an unshaped axis (Z ran `Passthrough` end-to-end), so the X/Y asymmetry was the only thing forbidding it.

- Unify all three axes on `AxisShaper`; delete `RequiredShaper` and the `UnsupportedShaperOnXY` / `InvalidFrequency` errors.
- `parse_axis_shaper`: `""`/`none`/`passthrough`, or `freq ≤ 0`/non-finite → `Passthrough` (disabled). An unknown type *with* a real frequency still fails loud (`UnsupportedKind`).
- `PlannerConfig::default().shaper` is now all-`Passthrough` → an absent `[input_shaper]` section means the shaper is disabled.

## Why

Disabling the shaper drops the emit stage's per-segment convolution **resampling** (`convolve_discrete`, ~1 piece/ms on the moving axis). That densifier is what saturated the 500k serial link on the F401 bench and caused the `-308 PieceStartInPast` crashes on back-to-back jogs. This gives a clean, first-class "no input shaping" config so the bench is unblocked while the shaper representation (analytic/adaptive refit vs higher-degree primitive) is evaluated separately.

## Test

- `cargo nextest run` — 1443 passed, plus `cargo test --doc`.
- Bench (Neptune 3 Pro / STM32F401, 500k serial, shaper disabled): the exact gcode that crashed on the 2nd jog (`G1 X-100` / `G1 X100 F6000`) now runs **6 cycles / 12 jogs with zero crashes and zero negative-lead pieces**. Moving axis confirmed at optimizer-grid density (~164 pieces/jog) instead of the ~900 the shaper produced.