### PR TITLE
ci: parallelize rust-host (test/clippy/fmt) + lld + drop redundant build

### DIFF
--- a/.github/workflows/ci-rust-runtime.yaml
+++ b/.github/workflows/ci-rust-runtime.yaml
@@ -40,7 +40,27 @@ jobs:
               - 'scripts/ci.sh'
               - '.github/workflows/ci-rust-runtime.yaml'
 
-  rust-host:
+  rust-test:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev lld
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          key: test
+      - name: test (nextest + doctests)
+        run: ./scripts/ci.sh rust-test
+
+  rust-clippy:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
@@ -51,15 +71,26 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy, rustfmt
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-      - name: build + test (nextest) + clippy + fmt
-        run: ./scripts/ci.sh rust-host
+          key: clippy
+      - name: clippy
+        run: ./scripts/ci.sh rust-clippy
+
+  rust-fmt:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: fmt --check
+        run: ./scripts/ci.sh rust-fmt
 
   # Step-6 §11.4 / §11.3 loom tests for half-split SPSC, widened-clock
   # seqlock, force_idle handshake, and curve-pool alloc race. Loom

--- a/docs/kalico-rewrite/ci.md
+++ b/docs/kalico-rewrite/ci.md
@@ -14,8 +14,8 @@ disagreed with the workflows — that is exactly the failure mode this prevents)
 
 ```sh
 ./scripts/ci.sh            # run every gate, with a pass/fail summary
-./scripts/ci.sh quick      # fast pre-push subset: ruff + rust build/test/clippy/fmt
-./scripts/ci.sh rust-host  # one gate (what the rust-host CI job runs)
+./scripts/ci.sh quick      # fast pre-push subset: ruff + rust test/clippy/fmt
+./scripts/ci.sh rust-test  # one gate (CI runs rust-test / rust-clippy / rust-fmt as parallel jobs)
 ./scripts/ci.sh py 3.13    # klippy pytest under one Python version (needs docker)
 ./scripts/ci.sh sim        # kalico-sim unit tests
 ```
@@ -39,7 +39,7 @@ The single source of truth runs the same gates CI does. Before opening a PR to
 merge a chunk of work, run the fast subset (or the full suite):
 
 ```sh
-./scripts/ci.sh quick      # ruff + rust build/test/clippy/fmt
+./scripts/ci.sh quick      # ruff + rust test/clippy/fmt
 ./scripts/ci.sh            # everything
 ```
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Usage:
 #   ./scripts/ci.sh                 # run all gates with a summary (local)
-#   ./scripts/ci.sh quick           # fast subset: ruff + rust build/test/clippy/fmt
+#   ./scripts/ci.sh quick           # fast subset: ruff + rust test/clippy/fmt
 #   ./scripts/ci.sh install-hooks   # enable the pre-push hook (runs `quick` per push)
 #   ./scripts/ci.sh <job>           # run one gate, exit with its status (CI)
 #
@@ -20,18 +20,30 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUST="$ROOT/rust"
 DOCKER_IMAGE="dangerklippers/klipper-build:latest"
 
+# Linux-only: env RUSTFLAGS replaces (does not merge with) the per-target
+# rustflags in rust/.cargo/config.toml, so widening this past the host target
+# would drop the macOS cdylib `-undefined dynamic_lookup` and the cross-build
+# target-cpu/--nmagic flags.
+host_cargo() {
+    if [ "$(uname -s)" = Linux ] && command -v ld.lld >/dev/null 2>&1; then
+        RUSTFLAGS="-Clink-arg=-fuse-ld=lld" cargo "$@"
+    else
+        cargo "$@"
+    fi
+}
+
 job_rust_build()  { cd "$RUST" && cargo build --workspace; }
 
 job_rust_test() {
     cd "$RUST"
-    cargo nextest run --workspace --profile ci
-    cargo test --workspace --doc
+    host_cargo nextest run --workspace --profile ci
+    host_cargo test --workspace --doc
 }
 
 job_rust_clippy() { cd "$RUST" && cargo clippy --workspace --all-targets -- -D warnings; }
 job_rust_fmt()    { cd "$RUST" && cargo fmt --all -- --check; }
 
-job_rust_host()   { job_rust_build && job_rust_test && job_rust_clippy && job_rust_fmt; }
+job_rust_host()   { job_rust_test && job_rust_clippy && job_rust_fmt; }
 
 job_rust_loom() {
     cd "$RUST"
@@ -206,7 +218,6 @@ run_check() {
 run_all() {
     local quick="${1:-false}"
     run_check "ruff"            job_ruff
-    run_check "rust-build"      job_rust_build
     run_check "rust-test"       job_rust_test
     run_check "rust-clippy"     job_rust_clippy
     run_check "rust-fmt"        job_rust_fmt

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -7,7 +7,9 @@ BRANCH="${2:-sota-motion}"
 REQUIRED_CHECKS=(
   # ci-rust-runtime.yaml
   changes
-  rust-host
+  rust-test
+  rust-clippy
+  rust-fmt
   rust-loom
   rust-mcu-h7
   rust-mcu-f4


### PR DESCRIPTION
`./scripts/ci.sh rust-host` was the longest CI step. It was **one job running build → test → clippy → fmt serially**, so the step's wall-clock was their sum and a `cargo fmt` typo only surfaced after a ~50s compile.

Measured cold (local; CI ubuntu is slower but ratios hold): build 16.6s · **nextest 51s (23s compile + 10s run)** · doctest 3.6s · clippy 4.2s · fmt 0.35s. Dominant cost = compiling+linking **120 separate test binaries** with the default linker. clippy is cheap (deps shared, only re-checks our 13 workspace crates).

### Changes
1. **Split into parallel jobs** `rust-test` / `rust-clippy` / `rust-fmt`. Wall-clock drops from sum → ≈ the test job; fmt fails in seconds. Each gets its own `rust-cache` key.
2. **lld for the host test build** (`host_cargo`). 120+ test/doctest binaries link several-fold faster. Gated to **Linux-with-lld only**: env `RUSTFLAGS` *replaces* (doesn't merge with) the per-target rustflags in `rust/.cargo/config.toml`, so applying it on macOS would drop the cdylib `-undefined dynamic_lookup` flags and on cross builds drop `target-cpu`/`--nmagic`. The Linux host triple has no config entry → nothing clobbered. `lld` added to the rust-test runner.
3. **Dropped standalone `cargo build --workspace`** — nextest + clippy `--all-targets` already compile every target; the build only added non-test bin codegen (covered by c-smoke + MCU jobs).

Also updated `setup-branch-protection.sh` and `docs/kalico-rewrite/ci.md`.

### Local verification
`rust-fmt` ✅ · `rust-clippy` ✅ (`-D warnings`) · `rust-test` ✅ (1443 tests + doctests). lld speedup only shows in real CI (Linux) — `host_cargo` is a no-op on macOS.

### ⚠️ Action after merge
Branch protection still requires the old `rust-host` context (`strict: true`) — re-run `./scripts/setup-branch-protection.sh` so it requires `rust-test`/`rust-clippy`/`rust-fmt` instead, or PRs will hang waiting on a context that no longer reports.