### PR TITLE
fix(gcode): lexer panicked on multi-byte whitespace after head letter

### DIFF
--- a/rust/gcode/proptest-regressions/property_lex.txt
+++ b/rust/gcode/proptest-regressions/property_lex.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 272ba2348127a304418b3343f7d76270bdd6abb5e82302b3188d8d299838f878 # shrinks to lines = ["A\u{85}0\t"]

--- a/rust/gcode/src/lexer.rs
+++ b/rust/gcode/src/lexer.rs
@@ -50,7 +50,9 @@ fn tokenize_command_line(line: &str, line_no: u32) -> Result<Token, ParseError> 
     let after_letter_idx = chars.next().map_or(line.len(), |(i, _)| i);
     let after_letter = &line[after_letter_idx..];
 
-    let head_number_str = after_letter.split_whitespace().next().unwrap_or("");
+    let head_number_str = after_letter
+        .find(char::is_whitespace)
+        .map_or(after_letter, |ws_idx| &after_letter[..ws_idx]);
     let (major, minor) =
         parse_head_number(head_number_str).ok_or_else(|| ParseError::UnrecognizedHead {
             line_no,

--- a/rust/gcode/src/lexer/tests.rs
+++ b/rust/gcode/src/lexer/tests.rs
@@ -143,6 +143,26 @@ fn lowercase_param_letter_returns_error() {
 }
 
 #[test]
+fn multibyte_whitespace_after_head_letter_returns_error() {
+    let toks = collect("A\u{85}0\t");
+    assert_eq!(toks.len(), 1);
+    match &toks[0] {
+        Err(ParseError::UnrecognizedHead { line_no: 1, .. }) => {}
+        other => panic!("expected UnrecognizedHead, got {other:?}"),
+    }
+}
+
+#[test]
+fn ascii_space_after_head_letter_returns_error() {
+    let toks = collect("G 1 X0\n");
+    assert_eq!(toks.len(), 1);
+    match &toks[0] {
+        Err(ParseError::UnrecognizedHead { line_no: 1, .. }) => {}
+        other => panic!("expected UnrecognizedHead, got {other:?}"),
+    }
+}
+
+#[test]
 fn head_with_no_number_returns_error() {
     let toks = collect("G\n");
     assert_eq!(toks.len(), 1);

--- a/rust/gcode/tests/property_lex.rs
+++ b/rust/gcode/tests/property_lex.rs
@@ -1,9 +1,13 @@
 use gcode::lex;
 use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
 
 proptest! {
     #![proptest_config(ProptestConfig {
         cases: 1024,
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
+            "proptest-regressions/property_lex.txt",
+        ))),
         ..Default::default()
     })]
 
@@ -23,8 +27,6 @@ proptest! {
                     prop_assert!(line_no >= 1 && line_no <= line_count,
                         "line_no {line_no} out of range 1..={line_count}");
                 }
-                // Token is non_exhaustive; ParseError doesn't expose line_no uniformly;
-                // both arms exist purely for the no-panic guarantee.
                 Ok(_) | Err(_) => {}
             }
         }


### PR DESCRIPTION
## Problem

The proptest property `lexer_never_panics_on_arbitrary_lines` shrank a failure to `"A\u{85}0\t"` (U+0085 NEL): the lexer panicked with *byte index 2 is not a char boundary*.

`tokenize_command_line` extracted the head number with `split_whitespace().next()`, which skips leading whitespace, but computed `after_head_idx` as if the number were a prefix of `after_letter`. With whitespace between the command letter and its number the offset was short by the skipped bytes:

- **Multi-byte Unicode whitespace** (NEL, NBSP — the latter routinely sneaks into copy-pasted G-code) → `line[after_head_idx..]` sliced mid-character → panic in the live bridge / compat binary.
- **ASCII space** (`G 1 X0`) → the head number was re-scanned as a parameter → misleading `MalformedNumber { text: "1" }`.

## Fix

The head number is now taken as a true prefix of the text after the letter, ending at the first whitespace char, so the offset arithmetic is exact. A whitespace gap between letter and number is rejected as `UnrecognizedHead` — consistent with the existing bare-`G` behavior and upstream Klipper treating `G 1` as unknown command `G`. The generated golden corpus never uses gapped heads, so no accepted input changes.

## Test-infra bug fixed alongside

proptest's default `SourceParallel` failure persistence silently fails for integration tests (no `lib.rs`/`main.rs` above `tests/`), so failing seeds were never saved. The config now uses `Direct` persistence; the shrunk seed for this bug is checked in at `rust/gcode/proptest-regressions/property_lex.txt` and verified to replay: with the fix stashed out, the proptest reproduces the panic from the seed alone.

## Verification

- Two unit regression tests pin both symptoms (red before fix, green after)
- Full workspace suite: 1443/1443 passing; `clippy --workspace --all-targets` clean
- 20,000-case sweep over all three lexer properties: no further panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)