### PR TITLE
fix: M84 crashed klippy and then silently failed to drop servo torque

### DIFF
--- a/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt-stub.rs
+++ b/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt-stub.rs
@@ -176,38 +176,36 @@ fn main() {
                 Command::SetTorque {
                     correlation_id,
                     msg,
-                } => {
-                    match gate.on_set_torque(msg.value != 0, msg.execute_at_ns) {
-                        CommandAction::Enable => {
-                            let ok = !fail_enable;
-                            gate.enable_finished(ok);
-                            if ok {
-                                eprintln!("ec-rt-stub: torque enabled (simulated)");
-                                server.respond(&set_torque_response_frame(correlation_id, 0));
-                            } else {
-                                eprintln!("ec-rt-stub: simulated enable failure — exiting");
-                                server.respond(&set_torque_response_frame(
-                                    correlation_id,
-                                    ERR_ENABLE_FAILED,
-                                ));
-                                std::process::exit(1);
-                            }
-                        }
-                        CommandAction::ScheduleDisable => {
-                            eprintln!(
-                                "ec-rt-stub: torque disable scheduled at {} (now {})",
-                                msg.execute_at_ns,
-                                monotonic_ns()
-                            );
+                } => match gate.on_set_torque(msg.value != 0, msg.execute_at_ns) {
+                    CommandAction::Enable => {
+                        let ok = !fail_enable;
+                        gate.enable_finished(ok);
+                        if ok {
+                            eprintln!("ec-rt-stub: torque enabled (simulated)");
                             server.respond(&set_torque_response_frame(correlation_id, 0));
-                        }
-                        CommandAction::Reject { code } => {
-                            eprintln!("ec-rt-stub: SetTorque rejected code={code} — exiting");
-                            server.respond(&set_torque_response_frame(correlation_id, code));
+                        } else {
+                            eprintln!("ec-rt-stub: simulated enable failure — exiting");
+                            server.respond(&set_torque_response_frame(
+                                correlation_id,
+                                ERR_ENABLE_FAILED,
+                            ));
                             std::process::exit(1);
                         }
                     }
-                }
+                    CommandAction::ScheduleDisable => {
+                        eprintln!(
+                            "ec-rt-stub: torque disable scheduled at {} (now {})",
+                            msg.execute_at_ns,
+                            monotonic_ns()
+                        );
+                        server.respond(&set_torque_response_frame(correlation_id, 0));
+                    }
+                    CommandAction::Reject { code } => {
+                        eprintln!("ec-rt-stub: SetTorque rejected code={code} — exiting");
+                        server.respond(&set_torque_response_frame(correlation_id, code));
+                        std::process::exit(1);
+                    }
+                },
                 Command::SetDriveLimits {
                     correlation_id,
                     msg,

--- a/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt-stub.rs
+++ b/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt-stub.rs
@@ -177,8 +177,7 @@ fn main() {
                     correlation_id,
                     msg,
                 } => {
-                    let now_ns = monotonic_ns();
-                    match gate.on_set_torque(msg.value != 0, msg.execute_at_ns, now_ns) {
+                    match gate.on_set_torque(msg.value != 0, msg.execute_at_ns) {
                         CommandAction::Enable => {
                             let ok = !fail_enable;
                             gate.enable_finished(ok);
@@ -196,8 +195,9 @@ fn main() {
                         }
                         CommandAction::ScheduleDisable => {
                             eprintln!(
-                                "ec-rt-stub: torque disable scheduled at {} (now {now_ns})",
-                                msg.execute_at_ns
+                                "ec-rt-stub: torque disable scheduled at {} (now {})",
+                                msg.execute_at_ns,
+                                monotonic_ns()
                             );
                             server.respond(&set_torque_response_frame(correlation_id, 0));
                         }

--- a/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt.rs
+++ b/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt.rs
@@ -214,46 +214,21 @@ fn main() {
                 Command::SetTorque {
                     correlation_id,
                     msg,
-                } => {
-                    match gate.on_set_torque(msg.value != 0, msg.execute_at_ns) {
-                        CommandAction::Enable => {
-                            let rc = unsafe { ffi::ec_rt_enable() };
-                            gate.enable_finished(rc == 0);
-                            if rc == 0 {
-                                eprintln!("ec-rt: torque enabled (CiA402 operation enabled)");
-                                server.respond(&set_torque_response_frame(correlation_id, 0));
-                            } else {
-                                eprintln!(
-                                    "ec-rt: CiA402 enable failed rc={rc} — disabling and exiting"
-                                );
-                                server.respond(&set_torque_response_frame(
-                                    correlation_id,
-                                    ERR_ENABLE_FAILED,
-                                ));
-                                unsafe {
-                                    ffi::ec_rt_disable();
-                                    ffi::ec_rt_shutdown();
-                                }
-                                std::process::exit(1);
-                            }
-                        }
-                        CommandAction::ScheduleDisable => {
-                            eprintln!(
-                                "ec-rt: torque disable scheduled at {} (now {})",
-                                msg.execute_at_ns,
-                                monotonic_ns()
-                            );
+                } => match gate.on_set_torque(msg.value != 0, msg.execute_at_ns) {
+                    CommandAction::Enable => {
+                        let rc = unsafe { ffi::ec_rt_enable() };
+                        gate.enable_finished(rc == 0);
+                        if rc == 0 {
+                            eprintln!("ec-rt: torque enabled (CiA402 operation enabled)");
                             server.respond(&set_torque_response_frame(correlation_id, 0));
-                        }
-                        CommandAction::Reject { code } => {
+                        } else {
                             eprintln!(
-                                "ec-rt: SetTorque rejected code={code} \
-                                 (value={} execute_at={} now={}) — exiting",
-                                msg.value,
-                                msg.execute_at_ns,
-                                monotonic_ns()
+                                "ec-rt: CiA402 enable failed rc={rc} — disabling and exiting"
                             );
-                            server.respond(&set_torque_response_frame(correlation_id, code));
+                            server.respond(&set_torque_response_frame(
+                                correlation_id,
+                                ERR_ENABLE_FAILED,
+                            ));
                             unsafe {
                                 ffi::ec_rt_disable();
                                 ffi::ec_rt_shutdown();
@@ -261,7 +236,30 @@ fn main() {
                             std::process::exit(1);
                         }
                     }
-                }
+                    CommandAction::ScheduleDisable => {
+                        eprintln!(
+                            "ec-rt: torque disable scheduled at {} (now {})",
+                            msg.execute_at_ns,
+                            monotonic_ns()
+                        );
+                        server.respond(&set_torque_response_frame(correlation_id, 0));
+                    }
+                    CommandAction::Reject { code } => {
+                        eprintln!(
+                            "ec-rt: SetTorque rejected code={code} \
+                                 (value={} execute_at={} now={}) — exiting",
+                            msg.value,
+                            msg.execute_at_ns,
+                            monotonic_ns()
+                        );
+                        server.respond(&set_torque_response_frame(correlation_id, code));
+                        unsafe {
+                            ffi::ec_rt_disable();
+                            ffi::ec_rt_shutdown();
+                        }
+                        std::process::exit(1);
+                    }
+                },
                 Command::Stop { correlation_id } => {
                     let now_ns = monotonic_ns();
                     ring.reset();

--- a/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt.rs
+++ b/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt.rs
@@ -215,8 +215,7 @@ fn main() {
                     correlation_id,
                     msg,
                 } => {
-                    let now_ns = monotonic_ns();
-                    match gate.on_set_torque(msg.value != 0, msg.execute_at_ns, now_ns) {
+                    match gate.on_set_torque(msg.value != 0, msg.execute_at_ns) {
                         CommandAction::Enable => {
                             let rc = unsafe { ffi::ec_rt_enable() };
                             gate.enable_finished(rc == 0);
@@ -240,16 +239,19 @@ fn main() {
                         }
                         CommandAction::ScheduleDisable => {
                             eprintln!(
-                                "ec-rt: torque disable scheduled at {} (now {now_ns})",
-                                msg.execute_at_ns
+                                "ec-rt: torque disable scheduled at {} (now {})",
+                                msg.execute_at_ns,
+                                monotonic_ns()
                             );
                             server.respond(&set_torque_response_frame(correlation_id, 0));
                         }
                         CommandAction::Reject { code } => {
                             eprintln!(
                                 "ec-rt: SetTorque rejected code={code} \
-                                 (value={} execute_at={} now={now_ns}) — exiting",
-                                msg.value, msg.execute_at_ns
+                                 (value={} execute_at={} now={}) — exiting",
+                                msg.value,
+                                msg.execute_at_ns,
+                                monotonic_ns()
                             );
                             server.respond(&set_torque_response_frame(correlation_id, code));
                             unsafe {

--- a/rust/kalico-ethercat-rt/src/torque.rs
+++ b/rust/kalico-ethercat-rt/src/torque.rs
@@ -1,5 +1,4 @@
 pub const ERR_ENABLE_FAILED: i32 = -310;
-pub const ERR_DISABLE_IN_PAST: i32 = -311;
 pub const ERR_BAD_TORQUE_STATE: i32 = -312;
 pub const ERR_PIECES_WHILE_PARKED: i32 = -313;
 pub const ERR_PIECES_WHILE_FAULTED: i32 = -314;
@@ -45,7 +44,9 @@ impl TorqueGate {
         self.state
     }
 
-    pub fn on_set_torque(&mut self, value: bool, execute_at_ns: u64, now_ns: u64) -> CommandAction {
+    /// `not_before_ns` is an ordering token, not a deadline: a disable whose
+    /// time has already passed executes on the next tick.
+    pub fn on_set_torque(&mut self, value: bool, not_before_ns: u64) -> CommandAction {
         if value {
             if self.state == TorqueState::Enabled && self.pending_disable_at.is_none() {
                 return CommandAction::Reject {
@@ -63,12 +64,7 @@ impl TorqueGate {
                     code: ERR_BAD_TORQUE_STATE,
                 };
             }
-            if execute_at_ns <= now_ns {
-                return CommandAction::Reject {
-                    code: ERR_DISABLE_IN_PAST,
-                };
-            }
-            self.pending_disable_at = Some(execute_at_ns);
+            self.pending_disable_at = Some(not_before_ns);
             CommandAction::ScheduleDisable
         }
     }

--- a/rust/kalico-ethercat-rt/src/torque.rs
+++ b/rust/kalico-ethercat-rt/src/torque.rs
@@ -44,8 +44,6 @@ impl TorqueGate {
         self.state
     }
 
-    /// `not_before_ns` is an ordering token, not a deadline: a disable whose
-    /// time has already passed executes on the next tick.
     pub fn on_set_torque(&mut self, value: bool, not_before_ns: u64) -> CommandAction {
         if value {
             if self.state == TorqueState::Enabled && self.pending_disable_at.is_none() {

--- a/rust/kalico-ethercat-rt/src/torque/tests.rs
+++ b/rust/kalico-ethercat-rt/src/torque/tests.rs
@@ -94,10 +94,7 @@ fn reenable_with_pending_disable_cancels_it() {
     g.enable_finished(true);
     let _ = g.on_set_torque(false, T0 + 500);
     assert_eq!(g.on_tick(T0 + 100, false), TickAction::None);
-    assert_eq!(
-        g.on_set_torque(true, T0 + 600),
-        CommandAction::Enable
-    );
+    assert_eq!(g.on_set_torque(true, T0 + 600), CommandAction::Enable);
     g.enable_finished(true);
     assert_eq!(g.state(), TorqueState::Enabled);
     assert_eq!(g.on_tick(T0 + 1_000, false), TickAction::None);
@@ -133,12 +130,9 @@ fn pieces_at_disable_time_fault() {
 #[test]
 fn drive_fault_parks_in_faulted_and_clears_pending_disable() {
     let mut g = TorqueGate::new();
-    assert_eq!(g.on_set_torque(true, 0, 0), CommandAction::Enable);
+    assert_eq!(g.on_set_torque(true, 0), CommandAction::Enable);
     g.enable_finished(true);
-    assert_eq!(
-        g.on_set_torque(false, 100, 50),
-        CommandAction::ScheduleDisable
-    );
+    assert_eq!(g.on_set_torque(false, 100), CommandAction::ScheduleDisable);
     g.on_drive_fault();
     assert_eq!(g.state(), TorqueState::Faulted);
     assert_eq!(g.on_tick(200, true), TickAction::None);
@@ -155,7 +149,7 @@ fn faulted_tick_with_pieces_is_not_a_fault() {
 fn enable_from_faulted_recovers() {
     let mut g = TorqueGate::new();
     g.on_drive_fault();
-    assert_eq!(g.on_set_torque(true, 0, 0), CommandAction::Enable);
+    assert_eq!(g.on_set_torque(true, 0), CommandAction::Enable);
     g.enable_finished(true);
     assert_eq!(g.state(), TorqueState::Enabled);
 }
@@ -164,10 +158,7 @@ fn enable_from_faulted_recovers() {
 fn disable_from_faulted_schedules_and_lands_parked() {
     let mut g = TorqueGate::new();
     g.on_drive_fault();
-    assert_eq!(
-        g.on_set_torque(false, 100, 50),
-        CommandAction::ScheduleDisable
-    );
+    assert_eq!(g.on_set_torque(false, 100), CommandAction::ScheduleDisable);
     assert_eq!(g.on_tick(150, true), TickAction::ExecuteDisable);
     g.disable_finished();
     assert_eq!(g.state(), TorqueState::Parked);

--- a/rust/kalico-ethercat-rt/src/torque/tests.rs
+++ b/rust/kalico-ethercat-rt/src/torque/tests.rs
@@ -6,7 +6,7 @@ const T0: u64 = 1_000_000_000;
 fn enable_from_parked_runs_ladder() {
     let mut g = TorqueGate::new();
     assert_eq!(g.state(), TorqueState::Parked);
-    assert_eq!(g.on_set_torque(true, T0, T0 - 1), CommandAction::Enable);
+    assert_eq!(g.on_set_torque(true, T0), CommandAction::Enable);
     g.enable_finished(true);
     assert_eq!(g.state(), TorqueState::Enabled);
 }
@@ -14,7 +14,7 @@ fn enable_from_parked_runs_ladder() {
 #[test]
 fn failed_ladder_leaves_gate_parked() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(false);
     assert_eq!(g.state(), TorqueState::Parked);
 }
@@ -22,10 +22,10 @@ fn failed_ladder_leaves_gate_parked() {
 #[test]
 fn double_enable_rejected() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
     assert_eq!(
-        g.on_set_torque(true, T0 + 1, T0),
+        g.on_set_torque(true, T0 + 1),
         CommandAction::Reject {
             code: ERR_BAD_TORQUE_STATE
         }
@@ -36,7 +36,7 @@ fn double_enable_rejected() {
 fn disable_while_parked_rejected() {
     let mut g = TorqueGate::new();
     assert_eq!(
-        g.on_set_torque(false, T0 + 1, T0),
+        g.on_set_torque(false, T0 + 1),
         CommandAction::Reject {
             code: ERR_BAD_TORQUE_STATE
         }
@@ -46,10 +46,10 @@ fn disable_while_parked_rejected() {
 #[test]
 fn disable_schedules_then_tick_executes_at_time() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
     assert_eq!(
-        g.on_set_torque(false, T0 + 500, T0),
+        g.on_set_torque(false, T0 + 500),
         CommandAction::ScheduleDisable
     );
     assert_eq!(g.on_tick(T0 + 499, true), TickAction::None);
@@ -60,26 +60,27 @@ fn disable_schedules_then_tick_executes_at_time() {
 }
 
 #[test]
-fn disable_in_past_rejected() {
+fn disable_in_past_executes_on_next_tick() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
     assert_eq!(
-        g.on_set_torque(false, T0, T0),
-        CommandAction::Reject {
-            code: ERR_DISABLE_IN_PAST
-        }
+        g.on_set_torque(false, T0 - 500),
+        CommandAction::ScheduleDisable
     );
+    assert_eq!(g.on_tick(T0, true), TickAction::ExecuteDisable);
+    g.disable_finished();
+    assert_eq!(g.state(), TorqueState::Parked);
 }
 
 #[test]
 fn double_disable_rejected() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
-    let _ = g.on_set_torque(false, T0 + 500, T0);
+    let _ = g.on_set_torque(false, T0 + 500);
     assert_eq!(
-        g.on_set_torque(false, T0 + 600, T0),
+        g.on_set_torque(false, T0 + 600),
         CommandAction::Reject {
             code: ERR_BAD_TORQUE_STATE
         }
@@ -89,12 +90,12 @@ fn double_disable_rejected() {
 #[test]
 fn reenable_with_pending_disable_cancels_it() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
-    let _ = g.on_set_torque(false, T0 + 500, T0);
+    let _ = g.on_set_torque(false, T0 + 500);
     assert_eq!(g.on_tick(T0 + 100, false), TickAction::None);
     assert_eq!(
-        g.on_set_torque(true, T0 + 600, T0 + 100),
+        g.on_set_torque(true, T0 + 600),
         CommandAction::Enable
     );
     g.enable_finished(true);
@@ -117,9 +118,9 @@ fn pieces_while_parked_fault() {
 #[test]
 fn pieces_at_disable_time_fault() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
-    let _ = g.on_set_torque(false, T0 + 500, T0);
+    let _ = g.on_set_torque(false, T0 + 500);
     assert_eq!(g.on_tick(T0 + 100, false), TickAction::None);
     assert_eq!(
         g.on_tick(T0 + 500, false),
@@ -175,7 +176,7 @@ fn disable_from_faulted_schedules_and_lands_parked() {
 #[test]
 fn enabled_idle_ticks_are_quiet() {
     let mut g = TorqueGate::new();
-    let _ = g.on_set_torque(true, T0, T0 - 1);
+    let _ = g.on_set_torque(true, T0);
     g.enable_finished(true);
     assert_eq!(g.on_tick(T0 + 10, true), TickAction::None);
     assert_eq!(g.on_tick(T0 + 10, false), TickAction::None);

--- a/rust/kalico-ethercat-rt/tests/torque_lifecycle.rs
+++ b/rust/kalico-ethercat-rt/tests/torque_lifecycle.rs
@@ -215,17 +215,25 @@ fn double_enable_rejects_and_exits() {
 }
 
 #[test]
-fn disable_in_past_rejects_and_exits() {
+fn disable_in_past_executes_immediately() {
     let (mut guard, conn, path) = spawn_and_claim("tq-past", &[]);
 
     let r1 = set_torque(&conn, true, now_ns() + 50_000_000);
     assert_eq!(r1, 0, "enable must return 0, got {r1}");
 
     let r2 = set_torque(&conn, false, 1);
-    assert_eq!(r2, -311, "disable-in-past must return -311, got {r2}");
+    assert_eq!(r2, 0, "disable with past not-before must ack 0, got {r2}");
 
-    let mut child = guard.defuse();
-    wait_for_exit(&mut child, Instant::now() + Duration::from_secs(4));
+    thread::sleep(Duration::from_millis(200));
+
+    let r3 = set_torque(&conn, true, now_ns() + 50_000_000);
+    assert_eq!(
+        r3, 0,
+        "re-enable after past disable executed must return 0 (gate Parked), got {r3}"
+    );
+
+    drop(conn);
+    let _ = guard.defuse().wait();
     let _ = std::fs::remove_file(&path);
 }
 

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -458,6 +458,22 @@ impl PassthroughRouter {
         Some(rec.clock_offset + delta_ticks / rec.clock_freq)
     }
 
+    /// Klippy `print_time` is the reference MCU's extended clock divided by its
+    /// frequency, so it converts exactly like `clock_to_host_secs` with
+    /// `mcu_clock = print_time * clock_freq`.
+    pub fn print_time_to_host_secs(
+        &self,
+        reference_mcu: McuHandle,
+        print_time: f64,
+    ) -> Option<f64> {
+        let rec = self.mcus.get(&reference_mcu)?;
+        if rec.clock_freq == 0.0 {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        Some(rec.clock_offset + print_time - (rec.last_clock as f64) / rec.clock_freq)
+    }
+
     pub fn host_time_to_mcu_clock(
         &self,
         mcu: McuHandle,

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -458,9 +458,6 @@ impl PassthroughRouter {
         Some(rec.clock_offset + delta_ticks / rec.clock_freq)
     }
 
-    /// Klippy `print_time` is the reference MCU's extended clock divided by its
-    /// frequency, so it converts exactly like `clock_to_host_secs` with
-    /// `mcu_clock = print_time * clock_freq`.
     pub fn print_time_to_host_secs(
         &self,
         reference_mcu: McuHandle,

--- a/rust/kalico-host-rt/src/passthrough_queue/router/tests.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router/tests.rs
@@ -524,6 +524,36 @@ fn clock_to_host_secs_no_record_returns_none() {
 }
 
 #[test]
+fn print_time_to_host_secs_matches_clock_conversion() {
+    let (mut router, clock) = make_router();
+    let mcu = router.claim_mcu("mcu");
+
+    let base_host = instant_to_f64(clock.now());
+    router
+        .set_clock_est(mcu, 1_000_000.0, base_host, 10_000_000)
+        .unwrap();
+
+    let via_print_time = router.print_time_to_host_secs(mcu, 11.5).unwrap();
+    let via_clock = router.clock_to_host_secs(mcu, 11_500_000).unwrap();
+    let diff = (via_print_time - via_clock).abs();
+    assert!(
+        diff < 1e-9,
+        "print_time conversion must equal clock conversion: \
+         via_print_time={via_print_time:.12} via_clock={via_clock:.12}"
+    );
+}
+
+#[test]
+fn print_time_to_host_secs_unsynced_returns_none() {
+    let (mut router, _) = make_router();
+    let mcu = router.claim_mcu("mcu");
+    assert!(
+        router.print_time_to_host_secs(mcu, 1.0).is_none(),
+        "must return None when clock_freq == 0"
+    );
+}
+
+#[test]
 fn clock_to_host_secs_unknown_mcu_returns_none() {
     let (router, _) = make_router();
     assert!(

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -818,10 +818,31 @@ impl PyMotionBridge {
     }
 
     fn set_torque(&self, mcu_handle: u32, value: bool, print_time: f64) -> PyResult<()> {
+        let reference_mcu = {
+            let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
+            *mcus
+                .iter()
+                .find(|(_, mc)| mc.label == "mcu")
+                .map(|(raw, _)| raw)
+                .ok_or_else(|| {
+                    PyRuntimeError::new_err(
+                        "set_torque: no MCU labeled 'mcu' claimed — \
+                         cannot resolve the print_time reference clock",
+                    )
+                })?
+        };
         let execute_at_ns = {
             let router = self.router.lock().unwrap_or_else(|p| p.into_inner());
+            let host_secs = router
+                .print_time_to_host_secs(mcu_handle_from_raw(reference_mcu), print_time)
+                .ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "set_torque: reference mcu {reference_mcu} clock not synced — \
+                         cannot convert print_time {print_time}"
+                    ))
+                })?;
             router
-                .host_time_to_mcu_clock(mcu_handle_from_raw(mcu_handle), print_time)
+                .host_time_to_mcu_clock(mcu_handle_from_raw(mcu_handle), host_secs)
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!(
                         "set_torque: no clock mapping for mcu {mcu_handle}: {e:?}"


### PR DESCRIPTION
## What

`G28 Y` followed by `M84` shut klippy down on the Neptune bench (`servo torque disable failed: endpoint result -311`), and after the first fix the disable was accepted but never executed. Two distinct bugs in the EtherCAT servo torque path:

### 1. Torque gate treated the disable timestamp as a hard deadline

Klippy schedules idle-state commands (M84 etc.) at `get_last_move_time()`, which stops advancing while the machine is idle — the timestamp is routinely in the past and means "after the last move," not "at this instant." Stock Klipper MCUs absorb this by firing past timers immediately; `TorqueGate` instead rejected with `ERR_DISABLE_IN_PAST` (-311), and the bridge escalated to a klippy shutdown.

The disable time is now a **not-before bound**: a past value schedules normally and `on_tick` executes it on the next cycle. Past *enables* were never time-checked; motion segments keep their strict in-the-past fault.

### 2. `set_torque` fed `print_time` into a host-seconds API

`host_time_to_mcu_clock` expects host-instant seconds, but `set_torque` passed raw klippy `print_time` (the main MCU's clock domain). The domains only coincide when the MCU boots together with the host process; after klippy restarts with the F401 left running, `print_time` resumed from MCU uptime and the disable was scheduled ~26 minutes in the future — torque silently never dropped.

`print_time` is the reference MCU's extended clock over its frequency, so the bridge now converts via that MCU's clocksync record (new `Router::print_time_to_host_secs`) before projecting into the endpoint's clock domain.

## Testing

- `cargo nextest run`: 1443 passed; clippy and fmt clean.
- Gate unit tests updated (past disable executes on next tick) + wire-level lifecycle test (past disable acks 0, parks, re-enables).
- Router unit tests for `print_time_to_host_secs` (matches clock conversion; unsynced returns None).
- Verified on the Neptune bench: `G28 Y` → idle wait → `M84` drops servo torque without crashing klippy.