### PR TITLE
Fix sensorless-homing crashes on the EtherCAT servo bench

### DIFF
--- a/klippy/rail.py
+++ b/klippy/rail.py
@@ -41,6 +41,9 @@ class BaseRail:
     def get_range(self):
         return self.position_min, self.position_max
 
+    def get_tmc_current_helpers(self):
+        return []
+
     def get_homing_info(self):
         return HomingInfo(
             speed=self.homing_speed,

--- a/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt-stub.rs
+++ b/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt-stub.rs
@@ -14,9 +14,9 @@ use kalico_ethercat_rt::torque::{
 };
 use kalico_ethercat_rt::wire::{
     claim_handshake_reply_frame, identify_response_frame, push_pieces_response_frame,
-    restore_drive_limits_response_frame, runtime_caps_response_frame, sdo_read_response_frame,
-    sdo_write_response_frame, set_drive_limits_response_frame, set_torque_response_frame,
-    status_heartbeat_frame, stop_response_frame, Command,
+    restore_drive_limits_response_frame, resume_stream_response_frame, runtime_caps_response_frame,
+    sdo_read_response_frame, sdo_write_response_frame, set_drive_limits_response_frame,
+    set_torque_response_frame, status_heartbeat_frame, stop_response_frame, Command,
 };
 use kalico_protocol::messages::{SdoReadResponse, SlaveState};
 
@@ -210,6 +210,9 @@ fn main() {
                     ring.reset();
                     eprintln!("ec-rt-stub: Stop — ring discarded, discard_clock={now_ns}");
                     server.respond(&stop_response_frame(correlation_id, 0, now_ns));
+                }
+                Command::ResumeStream { correlation_id } => {
+                    server.respond(&resume_stream_response_frame(correlation_id, 0));
                 }
                 Command::ClaimHandshake { .. } => {
                     eprintln!(

--- a/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt.rs
+++ b/rust/kalico-ethercat-rt/src/bin/kalico-ethercat-rt.rs
@@ -17,9 +17,9 @@ use kalico_ethercat_rt::torque::{
 };
 use kalico_ethercat_rt::wire::{
     claim_handshake_reply_frame, identify_response_frame, push_pieces_response_frame,
-    restore_drive_limits_response_frame, runtime_caps_response_frame, sdo_read_response_frame,
-    sdo_write_response_frame, set_drive_limits_response_frame, set_torque_response_frame,
-    status_heartbeat_frame, stop_response_frame, Command,
+    restore_drive_limits_response_frame, resume_stream_response_frame, runtime_caps_response_frame,
+    sdo_read_response_frame, sdo_write_response_frame, set_drive_limits_response_frame,
+    set_torque_response_frame, status_heartbeat_frame, stop_response_frame, Command,
 };
 use kalico_protocol::messages::{SlaveState, ERR_SDO_TRANSPORT, ERR_SDO_UNSUPPORTED_SIZE};
 
@@ -319,6 +319,9 @@ fn main() {
                     cmap = None;
                     eprintln!("ec-rt: Stop — ring discarded, discard_clock={now_ns}");
                     server.respond(&stop_response_frame(correlation_id, 0, now_ns));
+                }
+                Command::ResumeStream { correlation_id } => {
+                    server.respond(&resume_stream_response_frame(correlation_id, 0));
                 }
                 Command::ClaimHandshake { .. } => {
                     eprintln!(

--- a/rust/kalico-ethercat-rt/src/wire.rs
+++ b/rust/kalico-ethercat-rt/src/wire.rs
@@ -6,8 +6,9 @@ use kalico_protocol::bootstrap::{IdentifyResponse, IDENTIFY_RESPONSE_BODY_LEN};
 use kalico_protocol::codec::{Decode, Encode};
 use kalico_protocol::messages::{
     ClaimHandshakeReply, MessageKind, PushPieces, PushPiecesResponse, RestoreDriveLimitsResponse,
-    RuntimeCapsResponse, SdoRead, SdoReadResponse, SdoWrite, SdoWriteResponse, SetDriveLimits,
-    SetDriveLimitsResponse, SetTorque, SetTorqueResponse, StatusHeartbeat, StopResponse,
+    ResumeStreamResponse, RuntimeCapsResponse, SdoRead, SdoReadResponse, SdoWrite,
+    SdoWriteResponse, SetDriveLimits, SetDriveLimitsResponse, SetTorque, SetTorqueResponse,
+    StatusHeartbeat, StopResponse,
 };
 use kalico_protocol::KALICO_CHANNEL_PIECES;
 
@@ -32,6 +33,9 @@ pub enum Command {
         msg: SetTorque,
     },
     Stop {
+        correlation_id: u32,
+    },
+    ResumeStream {
         correlation_id: u32,
     },
     SetDriveLimits {
@@ -97,6 +101,9 @@ pub fn decode_command(channel: u8, payload: &[u8]) -> Result<Command, DecodeCmdE
         Some(MessageKind::Stop) => Ok(Command::Stop {
             correlation_id: cid,
         }),
+        Some(MessageKind::ResumeStream) => Ok(Command::ResumeStream {
+            correlation_id: cid,
+        }),
         Some(MessageKind::SetDriveLimits) => {
             let msg = SetDriveLimits::decode(body).map_err(|_| DecodeCmdError::BadBody)?;
             Ok(Command::SetDriveLimits {
@@ -150,6 +157,11 @@ pub fn stop_response_frame(cid: u32, result: i32, discard_clock: u64) -> Vec<u8>
     }
     .encoded_to_vec();
     control_frame(MessageKind::StopResponse, cid, &body)
+}
+
+pub fn resume_stream_response_frame(cid: u32, result: i32) -> Vec<u8> {
+    let body = ResumeStreamResponse { result }.encoded_to_vec();
+    control_frame(MessageKind::ResumeStreamResponse, cid, &body)
 }
 
 pub fn set_torque_response_frame(cid: u32, result: i32) -> Vec<u8> {

--- a/rust/kalico-ethercat-rt/src/wire/tests.rs
+++ b/rust/kalico-ethercat-rt/src/wire/tests.rs
@@ -2,8 +2,9 @@ use super::*;
 use kalico_native_transport::demux::{Demuxer, Frame};
 use kalico_native_transport::frame::decode_frame;
 use kalico_protocol::messages::{
-    RestoreDriveLimitsResponse, SdoRead, SdoReadResponse, SdoWrite, SdoWriteResponse,
-    SetDriveLimits, SetDriveLimitsResponse, SlaveState, SlaveStatus, StopResponse,
+    RestoreDriveLimitsResponse, ResumeStreamResponse, SdoRead, SdoReadResponse, SdoWrite,
+    SdoWriteResponse, SetDriveLimits, SetDriveLimitsResponse, SlaveState, SlaveStatus,
+    StopResponse,
 };
 
 #[test]
@@ -152,6 +153,29 @@ fn decodes_stop_command() {
         Command::Stop { correlation_id: 11 } => {}
         other => panic!("expected Stop, got {other:?}"),
     }
+}
+
+#[test]
+fn decodes_resume_stream_command() {
+    let payload = frame_payload(MessageKind::ResumeStream, 12, &[]);
+    match decode_command(0, &payload).unwrap() {
+        Command::ResumeStream { correlation_id: 12 } => {}
+        other => panic!("expected ResumeStream, got {other:?}"),
+    }
+}
+
+#[test]
+fn resume_stream_response_frame_round_trips() {
+    let frame = resume_stream_response_frame(7, 0);
+    let (chan, payload) = decode_frame(&frame).unwrap();
+    assert_eq!(chan, CHANNEL_CONTROL);
+    let (hdr, body) = decode_message_header(payload).unwrap();
+    assert_eq!(hdr.correlation_id, 7);
+    assert_eq!(
+        MessageKind::from_u16(hdr.kind_raw),
+        Some(MessageKind::ResumeStreamResponse)
+    );
+    assert_eq!(ResumeStreamResponse::decode(body).unwrap().result, 0);
 }
 
 #[test]

--- a/rust/kalico-ethercat-rt/tests/real_socket_streaming.rs
+++ b/rust/kalico-ethercat-rt/tests/real_socket_streaming.rs
@@ -79,6 +79,7 @@ fn run_endpoint(socket_path: String, faulted: Arc<AtomicBool>) {
                 Command::ClaimHandshake { .. } => {}
                 Command::SetTorque { .. } => {}
                 Command::Stop { .. } => {}
+                Command::ResumeStream { .. } => {}
                 Command::SetDriveLimits { .. } | Command::RestoreDriveLimits { .. } => {}
                 Command::SdoRead { .. } | Command::SdoWrite { .. } => {
                     todo!("wired in the endpoint task")

--- a/rust/kalico-ethercat-rt/tests/stub_loop.rs
+++ b/rust/kalico-ethercat-rt/tests/stub_loop.rs
@@ -164,6 +164,7 @@ fn push_pieces_and_heartbeat_closes_the_loop() {
                     Command::ClaimHandshake { .. } => {}
                     Command::SetTorque { .. } => {}
                     Command::Stop { .. } => {}
+                    Command::ResumeStream { .. } => {}
                     Command::SetDriveLimits { .. } | Command::RestoreDriveLimits { .. } => {}
                     Command::SdoRead { .. } | Command::SdoWrite { .. } => {
                         todo!("wired in the endpoint task")
@@ -187,6 +188,7 @@ fn push_pieces_and_heartbeat_closes_the_loop() {
                     | Command::ClaimHandshake { .. }
                     | Command::SetTorque { .. }
                     | Command::Stop { .. }
+                    | Command::ResumeStream { .. }
                     | Command::SetDriveLimits { .. }
                     | Command::RestoreDriveLimits { .. }
                     | Command::SdoRead { .. }

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -18,7 +18,7 @@ use trajectory::{AxisShaper, ShaperConfig};
 
 use crate::classify;
 use crate::config::{self, PlannerConfig, PlannerLimits, parse_axis_shaper};
-use crate::dispatch::{McuAxisConfig, McuCaps, build_mcu_configs};
+use crate::dispatch::{AXIS_E, McuAxisConfig, McuCaps, build_mcu_configs};
 use crate::planner::{DispatchError, PlannerError, PlannerHandle};
 use crate::types::{cq_id_from_raw, mcu_handle_from_raw, stats_to_pydict};
 
@@ -532,6 +532,63 @@ pub(crate) fn build_configure_axes_body(
 
 pub(crate) fn axis_ring_depth(total_pieces: u32, num_axes: u32) -> u32 {
     (total_pieces / num_axes.max(1)).max(1)
+}
+
+pub(crate) fn drip_cohort_participants(configs: &[McuAxisConfig]) -> Vec<crate::pump::AxisKey> {
+    configs
+        .iter()
+        .flat_map(|cfg| {
+            cfg.axes
+                .iter()
+                .filter(|&&a| a < AXIS_E)
+                .map(move |&a| crate::pump::AxisKey {
+                    mcu_id: cfg.mcu_id,
+                    axis: a as u8,
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod drip_cohort_participants_tests {
+    use super::drip_cohort_participants;
+    use crate::dispatch::{AXIS_E, AXIS_X, AXIS_Y, AXIS_Z, McuAxisConfig, McuCaps};
+    use crate::pump::AxisKey;
+
+    fn cfg(mcu_id: u32, axes: Vec<usize>) -> McuAxisConfig {
+        McuAxisConfig {
+            mcu_id,
+            axes,
+            caps: McuCaps {
+                total_piece_memory: 0,
+            },
+            kinematics: 1,
+        }
+    }
+
+    #[test]
+    fn excludes_the_extruder_so_the_homing_floor_can_advance() {
+        let configs = vec![cfg(0, vec![AXIS_Y, AXIS_Z, AXIS_E]), cfg(1, vec![AXIS_X])];
+        let participants = drip_cohort_participants(&configs);
+        assert_eq!(
+            participants,
+            vec![
+                AxisKey {
+                    mcu_id: 0,
+                    axis: AXIS_Y as u8
+                },
+                AxisKey {
+                    mcu_id: 0,
+                    axis: AXIS_Z as u8
+                },
+                AxisKey {
+                    mcu_id: 1,
+                    axis: AXIS_X as u8
+                },
+            ]
+        );
+        assert!(participants.iter().all(|k| k.axis != AXIS_E as u8));
+    }
 }
 
 #[cfg(test)]
@@ -3024,21 +3081,11 @@ impl PyMotionBridge {
                 .lock()
                 .unwrap_or_else(|p| p.into_inner());
 
-            let mut all_keys: Vec<crate::pump::AxisKey> = Vec::new();
-            let mut found_mcu: Option<u32> = None;
-            for cfg in configs.iter() {
-                for &a in &cfg.axes {
-                    if a <= 3 {
-                        all_keys.push(crate::pump::AxisKey {
-                            mcu_id: cfg.mcu_id,
-                            axis: a as u8,
-                        });
-                    }
-                    if a == axis as usize {
-                        found_mcu = Some(cfg.mcu_id);
-                    }
-                }
-            }
+            let all_keys = drip_cohort_participants(&configs);
+            let found_mcu = configs
+                .iter()
+                .find(|cfg| cfg.axes.iter().any(|&a| a == axis as usize))
+                .map(|cfg| cfg.mcu_id);
 
             let mcu = found_mcu.ok_or_else(|| {
                 PyRuntimeError::new_err(format!(


### PR DESCRIPTION
Three independent bugs surfaced homing on the Neptune EtherCAT servo bench (X = A6-EC servo on its own MCU, Y/Z/E = steppers). Each was found from the structured logs and fixed at root cause; all were introduced by the sensorless-homing work and only bit once a non-stepper axis / servo MCU was present.

## 1. `G28` crashed on a servo rail — `AttributeError: 'ServoRail' object has no attribute 'get_tmc_current_helpers'`
The pre/post-homing current step calls `rail.get_tmc_current_helpers()`, defined only on `PrinterRail`. An EtherCAT `ServoRail` inherits the shared `BaseRail`, which lacked it, so `G28` blew up before any motion. A servo has no host-side TMC run-current to reduce (its torque limit is pushed to the drive over SDO), so `BaseRail` now returns `[]` by default and the current step is a no-op for it.

## 2. Homing any axis hung on the servo MCU — `ResumeStream call failed for mcu 1: Timeout`
The homing Stop/ResumeStream gating broadcasts to every MCU in the move, including the servo. The EtherCAT endpoint handled `Stop` but `ResumeStream` fell through to `Command::Unknown`, which logs and sends no response — so the host's `kalico_call` timed out and every home failed at the post-trip resume, *after* the endstop had already tripped. The endpoint's `Stop` sets no persistent piece-commit gate (`ring.reset` already discards in-flight pieces; host-side pump flush/disarm fences the window), so the correct `ResumeStream` handler is a plain ack. Wired through the decoder, `Command` enum, response-frame helper, and both the hw and stub binaries.

## 3. Homing aborted mid-move — `EXIT_ON_FAULT — drip cohort stalled; floor stalled at 0 for 5s`
During homing the planner drips every participating axis in lockstep and a 5 s watchdog aborts if the cohort floor (`min(executed)`) doesn't advance. The participant set took every configured axis with index ≤ 3, including the extruder — but `home_drip` only emits pieces for kinematic axes 0/1/2, so the never-dripped extruder pinned the floor at 0 forever and the watchdog fired on any home longer than 5 s. Restricted cohort participants to the kinematic axes that actually drip; extracted `drip_cohort_participants()` so the extruder-exclusion invariant is unit-tested.

## Testing
- `cargo nextest run -p motion-bridge -p kalico-ethercat-rt` — all green; new regression tests for the ResumeStream ack and the extruder exclusion.
- `ruff format` / `ruff check` clean on `klippy/rail.py`; `cargo fmt --all --check` clean.
- Flashed to the Neptune bench; klippy reaches `ready` on all three fixes. Live `G28` not yet run on hardware.