### PR TITLE
fix(ecrt): cure ErC1.1 sync-loss at boot — RT scheduling + RxPDO 0x1701

### DIFF
--- a/bench/libecrt.c
+++ b/bench/libecrt.c
@@ -70,12 +70,6 @@ static void dc_sync(int64_t reftime, int64_t cycletime, int64_t *offset) {
     *offset = -(delta / 100) - (g_integral / 20);
 }
 
-/*
- * RT hardening is mandatory, not best-effort: without SCHED_FIFO on an
- * isolated core the DC loop misses SYNC0 under boot load and the drive
- * latches ErC1.1 (sync loss). A missing capability fails loudly here rather
- * than masquerading as a drive fault at the SAFE-OP->OP transition later.
- */
 static int go_realtime(int cpu, int prio) {
     if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
         fprintf(stderr, "ec_rt: mlockall failed: %s — grant CAP_IPC_LOCK\n",
@@ -161,10 +155,6 @@ static int remap_volatile_tx_pdo_1a00(void) {
     return rewrite_1a00_entry_table();
 }
 
-/* The fixed RxPDO 1701h is the 12-byte CSP output out_t mirrors. The drive
- * otherwise powers up with a wider RxPDO assigned to 1C12h, whose byte count
- * disagrees with out_t and aborts bringup at EC_RT_ERR_PDO_SIZE. Pin it
- * explicitly, the same group-then-count order as the TxPDO assignment. */
 static int assign_fixed_rx_pdo_0x1701(void) {
     uint8_t  no_pdos  = 0;
     uint8_t  one_pdo  = 1;

--- a/bench/libecrt.c
+++ b/bench/libecrt.c
@@ -2,6 +2,7 @@
 #include "libecrt.h"
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <time.h>
 #include <sched.h>
 #include <sys/mman.h>
@@ -70,17 +71,30 @@ static void dc_sync(int64_t reftime, int64_t cycletime, int64_t *offset) {
 }
 
 /*
- * Best-effort RT hardening. Failures are non-fatal (the caller may lack
- * CAP_IPC_LOCK / CAP_SYS_NICE) but they ARE reported on stderr: without RT
- * scheduling the DC loop jitters and the drive throws Er74.1 / misses SYNC0,
- * which looks like a drive bug rather than a missing-capability problem.
+ * RT hardening is mandatory, not best-effort: without SCHED_FIFO on an
+ * isolated core the DC loop misses SYNC0 under boot load and the drive
+ * latches ErC1.1 (sync loss). A missing capability fails loudly here rather
+ * than masquerading as a drive fault at the SAFE-OP->OP transition later.
  */
-static void go_realtime(int cpu, int prio) {
-    if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) perror("ec_rt: mlockall (continuing)");
+static int go_realtime(int cpu, int prio) {
+    if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
+        fprintf(stderr, "ec_rt: mlockall failed: %s — grant CAP_IPC_LOCK\n",
+                strerror(errno));
+        return EC_RT_ERR_RT_MLOCK;
+    }
     cpu_set_t set; CPU_ZERO(&set); CPU_SET(cpu, &set);
-    if (sched_setaffinity(0, sizeof(set), &set) != 0) perror("ec_rt: setaffinity (continuing)");
+    if (sched_setaffinity(0, sizeof(set), &set) != 0) {
+        fprintf(stderr, "ec_rt: pin to CPU %d failed: %s — isolate the core "
+                "and grant the endpoint access to it\n", cpu, strerror(errno));
+        return EC_RT_ERR_RT_AFFINITY;
+    }
     struct sched_param sp; sp.sched_priority = prio;
-    if (sched_setscheduler(0, SCHED_FIFO, &sp) != 0) perror("ec_rt: SCHED_FIFO (continuing)");
+    if (sched_setscheduler(0, SCHED_FIFO, &sp) != 0) {
+        fprintf(stderr, "ec_rt: SCHED_FIFO(prio %d) failed: %s — grant "
+                "CAP_SYS_NICE\n", prio, strerror(errno));
+        return EC_RT_ERR_RT_SCHED;
+    }
+    return 0;
 }
 
 #define COE_ENTRY(index, sub, bits) \
@@ -147,6 +161,19 @@ static int remap_volatile_tx_pdo_1a00(void) {
     return rewrite_1a00_entry_table();
 }
 
+/* The fixed RxPDO 1701h is the 12-byte CSP output out_t mirrors. The drive
+ * otherwise powers up with a wider RxPDO assigned to 1C12h, whose byte count
+ * disagrees with out_t and aborts bringup at EC_RT_ERR_PDO_SIZE. Pin it
+ * explicitly, the same group-then-count order as the TxPDO assignment. */
+static int assign_fixed_rx_pdo_0x1701(void) {
+    uint8_t  no_pdos  = 0;
+    uint8_t  one_pdo  = 1;
+    uint16_t pdo_1701 = 0x1701;
+    if (remap_write(0x1C12, 0x00, &no_pdos,  sizeof(no_pdos))  != 0) return -1;
+    if (remap_write(0x1C12, 0x01, &pdo_1701, sizeof(pdo_1701)) != 0) return -1;
+    return remap_write(0x1C12, 0x00, &one_pdo, sizeof(one_pdo));
+}
+
 static int rt_exchange(int64_t *toff) {
     int64_t off = 0;
     add_ts(&g_ts, g_cycle_ns + (toff ? *toff : 0));
@@ -183,7 +210,8 @@ int ec_rt_bringup(const char *ifname, int64_t cycle_ns, int rt_cpu, int rt_prio)
     g_cycle_ns = cycle_ns < 250000 ? 250000 : cycle_ns;
     g_integral = 0;
     g_enabled  = 0;
-    go_realtime(rt_cpu, rt_prio);
+    int rt_rc = go_realtime(rt_cpu, rt_prio);
+    if (rt_rc != 0) return rt_rc;
 
     if (!ec_init(ifname)) return EC_RT_ERR_EC_INIT;
     if (ec_config_init(FALSE) <= 0) { ec_close(); return EC_RT_ERR_NO_SLAVES; }
@@ -192,6 +220,7 @@ int ec_rt_bringup(const char *ifname, int64_t cycle_ns, int rt_cpu, int rt_prio)
     if (reset_rc != 0) { ec_close(); return reset_rc; }
 
     if (remap_volatile_tx_pdo_1a00() != 0) { ec_close(); return EC_RT_ERR_PDO_REMAP; }
+    if (assign_fixed_rx_pdo_0x1701() != 0) { ec_close(); return EC_RT_ERR_RXPDO_ASSIGN; }
 
     /* Write order matters: mode, both sync types, then cycle times. The
      * drive requires SYNC0 active before SAFE-OP (else AL 0x0030 / Er74.1). */

--- a/bench/libecrt.h
+++ b/bench/libecrt.h
@@ -11,6 +11,10 @@
 #define EC_RT_ERR_PDO_SIZE        (-7)
 #define EC_RT_ERR_PREOP_TIMEOUT   (-8)
 #define EC_RT_ERR_INIT_TIMEOUT    (-9)
+#define EC_RT_ERR_RT_MLOCK        (-10)
+#define EC_RT_ERR_RT_AFFINITY     (-11)
+#define EC_RT_ERR_RT_SCHED        (-12)
+#define EC_RT_ERR_RXPDO_ASSIGN    (-13)
 
 /* Brings slave 1 to OPERATIONAL and parks it at CiA402 Ready-to-Switch-On
  * (no torque); ec_rt_enable() applies torque. 0 or an EC_RT_ERR_* above. */

--- a/docs/kalico-rewrite/ethercat-bench-bringup.md
+++ b/docs/kalico-rewrite/ethercat-bench-bringup.md
@@ -214,7 +214,10 @@ endpoint: rust/target/release/kalico-ethercat-rt-stub
   capture.
 - Do a small supervised jog. Watch for:
   - `engine_state == Fault (3)` in the `StatusHeartbeat` → the host pump fell behind >2 ms (`PieceStartInPast`). The endpoint latches the fault and propagates it so the host can shut down; the hw binary also disables the drive. This is expected on a gross stall, not on a healthy stream.
-  - `wkc != 3` → EtherCAT bus working-counter fault (drive comms), the endpoint halts.
+  - `wkc != 3` → EtherCAT bus working-counter fault (drive comms), the endpoint
+    halts and dumps `al=0x…`. `al=0x001a` is a DC sync loss (ErC1.1) — see the
+    real-time scheduling section; the usual cause is the loop not running
+    `SCHED_FIFO` on the isolated core.
 
 ### 5. Recovery
 - Any fault or claim failure is recovered the same way: fix the cause, then
@@ -223,6 +226,83 @@ endpoint: rust/target/release/kalico-ethercat-rt-stub
   cleanup, or endpoint restart to do by hand.
 - The old `bench-hw-up.sh` choreography is **obsolete** — klippy owns the endpoint
   lifecycle now. Delete that script from the bench host if it's still there.
+- **A latched `0x8700` / ErC1.1 is the exception:** `FIRMWARE_RESTART` re-spawns
+  the endpoint but does **not** clear the drive's stored sync-loss fault (the
+  EtherCAT INIT bounce resets the network state machine, not the CiA402 fault).
+  With the drive on its own supply it stays faulted across host restarts —
+  **power-cycle the drive** to clear it, then fix the root cause (almost always
+  RT scheduling; see that section) so it does not re-latch on the next boot.
+
+## Real-time scheduling — mandatory (the ErC1.1 / "ErC11" trap)
+
+The endpoint's 1 kHz DC loop **must** run `SCHED_FIFO` on an isolated CPU. This
+is not best-effort. If it runs `SCHED_OTHER`, the loop keeps cadence on a warm,
+idle Pi but misses SYNC0 under boot load — and the drive latches **ErC1.1
+"synchronization loss"** (panel reads `ErC11`; CoE error register `0x8700`;
+EtherCAT AL status `0x001a`, visible in the endpoint's `ec_rt: slave1 …
+al=0x001a` dump on a working-counter halt). Because the drive is usually on its
+own always-on supply, that latch **survives every host reboot**, so klippy's
+auto-restart keeps re-claiming an already-faulted drive — only a **drive
+power-cycle** clears `0x8700`. Classic signature: fails on cold boot / right
+after a flash, "works once it's connected."
+
+All three of the following are required, or `go_realtime()` aborts the claim
+loudly — `rc=-10` (mlockall / `CAP_IPC_LOCK`), `rc=-11` (CPU pin), `rc=-12`
+(`SCHED_FIFO` / `CAP_SYS_NICE`), each naming the missing capability. There is no
+silent `SCHED_OTHER` fallback any more; that fallback was the original ErC11
+heisenbug.
+
+1. **`cap_sys_nice`** (for `SCHED_FIFO`) and **`cap_ipc_lock`** (for `mlockall`)
+   on the endpoint binary: `make -f Makefile.kalico setcap-ethercat`. **A
+   `cargo build` writes a fresh inode and drops file-caps**, so re-run setcap
+   after *every* endpoint rebuild — the flash script re-applies it, a bare
+   rebuild does not. Skipping it is the direct cause of "ErC11 after flashing".
+2. **An isolated core to pin to.** The bench reserves CPUs 2-3 on the kernel
+   cmdline (`isolcpus=domain,managed_irq,2-3 nohz_full=2-3 rcu_nocbs=2-3`); the
+   endpoint pins to CPU `--rt-cpu` (default 3). An isolated core stays
+   contention-free even while the rest of the Pi is saturated booting — that is
+   what holds cadence through the cold-boot window that used to fault.
+3. **`SCHED_FIFO`** at priority `--rt-prio` (default 80).
+
+**Robust alternative to per-rebuild setcap** (ambient caps survive rebuilds; the
+file-cap does not): grant the caps on the systemd service via a drop-in
+`/etc/systemd/system/klipper.service.d/10-ethercat-rt.conf`, then
+`systemctl daemon-reload`:
+
+    [Service]
+    AmbientCapabilities=CAP_SYS_NICE CAP_IPC_LOCK
+    LimitRTPRIO=infinity
+    LimitMEMLOCK=infinity
+
+The spawned endpoint inherits the ambient caps from klippy. (If the binary also
+carries file-caps, those take precedence and the ambient set reads back empty —
+harmless, since file-caps already include `cap_sys_nice`.)
+
+**Verify it is actually in force** — a green *warm* restart only proves the cap
+took; only a **cold reboot** proves the loop holds cadence under boot load:
+
+    pid=$(pgrep -f release/kalico-ethercat-rt)
+    chrt -p $pid                                     # want: SCHED_FIFO priority 80
+    grep Cpus_allowed_list /proc/$pid/status         # want: 3 (the isolated core)
+    /usr/sbin/getcap rust/target/release/kalico-ethercat-rt   # want: ...cap_sys_nice=ep
+    sudo journalctl -b | grep -c 'al=0x001a'         # want: 0
+
+`SCHED_OTHER` + `cpus 0-1` on the live endpoint is the bug, not health — the cap
+is not reaching it. (Endpoints sampled in their first ~200 ms read `SCHED_OTHER`
+because `go_realtime()` runs just after `main()` startup; sample the
+steady-state pid.)
+
+## Fixed RxPDO assignment (rc=-7)
+
+`out_t` mirrors the drive's fixed 12-byte RxPDO **`0x1701`** (`6040` controlword,
+`607A` target position, `60B8` touch-probe function, `60FE:01` forced-DO). The
+drive can power up with a *wider* RxPDO assigned to `0x1C12` (e.g. 18 bytes),
+whose byte count disagrees with `out_t` and aborts bringup at
+`EC_RT_ERR_PDO_SIZE` (`rc=-7`, `ec_rt: PDO size mismatch — mapped out=18 …`).
+Bringup now **forces** `0x1C12 → 0x1701` before mapping (mirroring the existing
+`0x1C13 → 0x1A00` TxPDO assignment), so a clean map no longer depends on the
+drive's retained state. A failure to write that assignment is `rc=-13`
+(`EC_RT_ERR_RXPDO_ASSIGN`).
 
 ## Fault-response reference
 - **`PieceStartInPast`** (a piece adopted >2 ms late = 2× the 1 ms DC period): the walker faults, the endpoint latches it (allocation-free atomic) and reports `engine_state=Fault` to the host. Primary response is host-coordinated shutdown (mirrors the MCU model); the hw binary additionally disables the drive as a local backstop. It does **not** silently hold the last position.

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -137,6 +137,12 @@ fn message_for_claim_error(label: &str, interface: &str, e: &EndpointClaimError)
                 "ethercat {label}: EtherCAT bus on {interface}: no slaves responding \
                  (bringup rc=-{fault_code}) — check cable and drive power, then FIRMWARE_RESTART"
             ),
+            // 10/11/12 are host-side RT-acquisition failures, not the drive.
+            10 | 11 | 12 => format!(
+                "ethercat {label}: realtime endpoint could not acquire RT scheduling \
+                 (bringup rc=-{fault_code}) — grant CAP_SYS_NICE + CAP_IPC_LOCK to \
+                 klipper.service and isolate a CPU core, then FIRMWARE_RESTART"
+            ),
             // 0 = no bringup rc (e.g. the stub's simulated failure) — omit the suffix.
             0 => format!(
                 "ethercat {label}: drive (slave {slave_idx}) offline \
@@ -212,6 +218,24 @@ mod claim_error_message_tests {
             msg,
             "ethercat node_x: drive (slave 1) offline \
              (bringup rc=-5) — check drive power, then FIRMWARE_RESTART"
+        );
+    }
+
+    #[test]
+    fn rt_acquisition_failure_names_the_capability() {
+        let msg = message_for_claim_error(
+            "node_x",
+            "eth0",
+            &EndpointClaimError::DriveOffline {
+                slave_idx: 1,
+                fault_code: 12,
+            },
+        );
+        assert_eq!(
+            msg,
+            "ethercat node_x: realtime endpoint could not acquire RT scheduling \
+             (bringup rc=-12) — grant CAP_SYS_NICE + CAP_IPC_LOCK to \
+             klipper.service and isolate a CPU core, then FIRMWARE_RESTART"
         );
     }
 

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -137,8 +137,8 @@ fn message_for_claim_error(label: &str, interface: &str, e: &EndpointClaimError)
                 "ethercat {label}: EtherCAT bus on {interface}: no slaves responding \
                  (bringup rc=-{fault_code}) — check cable and drive power, then FIRMWARE_RESTART"
             ),
-            // 10/11/12 are host-side RT-acquisition failures, not the drive.
-            10 | 11 | 12 => format!(
+            // 10..=12 are host-side RT-acquisition failures, not the drive.
+            10..=12 => format!(
                 "ethercat {label}: realtime endpoint could not acquire RT scheduling \
                  (bringup rc=-{fault_code}) — grant CAP_SYS_NICE + CAP_IPC_LOCK to \
                  klipper.service and isolate a CPU core, then FIRMWARE_RESTART"

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -137,7 +137,6 @@ fn message_for_claim_error(label: &str, interface: &str, e: &EndpointClaimError)
                 "ethercat {label}: EtherCAT bus on {interface}: no slaves responding \
                  (bringup rc=-{fault_code}) — check cable and drive power, then FIRMWARE_RESTART"
             ),
-            // 10..=12 are host-side RT-acquisition failures, not the drive.
             10..=12 => format!(
                 "ethercat {label}: realtime endpoint could not acquire RT scheduling \
                  (bringup rc=-{fault_code}) — grant CAP_SYS_NICE + CAP_IPC_LOCK to \


### PR DESCRIPTION
## Problem

The A6-EC servo drive on the Neptune bench fell into **ErC11 / ErC1.1 "synchronization loss"** (`0x8700`, EtherCAT AL status `0x001a`) on almost every cold boot and after every flash, recoverable only by power-cycling **both** the Pi and the drive — and not always then.

## Root cause

The endpoint's 1 kHz DC loop was running **`SCHED_OTHER`**, not `SCHED_FIFO`. `go_realtime()` swallowed `SCHED_FIFO` / CPU-pin / `mlockall` failures with `perror(...continuing)`. The endpoint's `cap_sys_nice` file-cap had been wiped (a `cargo build` writes a fresh inode and drops file-caps; only a full flash re-applies setcap), so the loop silently fell back to normal scheduling on the busy cores. On a warm idle Pi CFS kept up — jogging/printing were fine — but **under boot load the loop missed SYNC0 and the drive latched ErC1.1**. The drive being on its own always-on supply meant the latch survived every host reboot, so auto-restart kept re-claiming an already-faulted drive.

Two adjacent latent bugs surfaced during the investigation: a state-dependent **rc=-7 RxPDO size mismatch** (drive powers up with a wider RxPDO on `0x1C12`), and the `al=0x001a` discriminator only living in the volatile journal.

## Fix

- **`go_realtime()` fails loudly** — `SCHED_FIFO` / CPU-pin / `mlockall` denial now aborts the claim with `rc=-10/-11/-12`, each naming the missing capability, instead of limping as `SCHED_OTHER`. (`bench/libecrt.c`, `libecrt.h`)
- **Force RxPDO `0x1C12 → 0x1701`** (manual-confirmed 12-byte fixed RPDO) before mapping, mirroring the existing TxPDO assignment — kills rc=-7. New `rc=-13` `EC_RT_ERR_RXPDO_ASSIGN`.
- **Bridge** maps the RT-acquisition codes to a host-side message naming the capability to grant, not the misleading "drive offline". (`rust/motion-bridge/src/bridge.rs`)
- **Docs** — `docs/kalico-rewrite/ethercat-bench-bringup.md` gains the RT-scheduling requirement, the cap-wipe-on-rebuild trap, a rebuild-proof systemd `AmbientCapabilities` drop-in, the RxPDO note, the latched-fault recovery (power-cycle the drive), and cold-reboot verification commands.

## Validation (on the ethercatpi5 bench)

Re-applied the cap, rebuilt, and **cold-rebooted** — the scenario that always produced ErC11:

```
klippy: active    printer: "ready"
endpoint: SCHED_FIFO prio 80, CPU 3 (isolated), CapEff=cap_sys_nice+ipc_lock+net_raw
al=0x001a count this boot: 0    bringup failures: 0    DC loop: wkc=3 steady
```

The DC loop took a disturbance early in boot (`toff` swung ~-4500) and **rode through it without dropping sync** — the RT priority on the isolated core doing its job.

Bench-side: `klipper.service` now carries the `AmbientCapabilities` drop-in (documented in the bringup doc).

`cargo nextest -p motion-bridge` green (incl. new RT-message test); `cargo fmt --all --check` clean.