### PR TITLE
fix(klippy): keep printer alive on failed connect — teardown only at exit

### DIFF
--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -424,19 +424,16 @@ class Printer:
         except (self.config_error, pins.error) as e:
             logging.exception("Config error")
             self._set_state("%s\n%s" % (str(e), message_restart))
-            self._dispatch_disconnect()
             return
         except msgproto.error as e:
             logging.exception("Protocol error")
             self._set_state(self._build_protocol_error_message(e))
             util.dump_mcu_build()
-            self._dispatch_disconnect()
             return
         except mcu.error as e:
             logging.exception("MCU error during connect")
             self._set_state("%s%s" % (str(e), message_mcu_connect_error))
             util.dump_mcu_build()
-            self._dispatch_disconnect()
             return
         except Exception as e:
             logging.exception("Unhandled exception during connect")
@@ -447,7 +444,6 @@ class Printer:
                     message_restart,
                 )
             )
-            self._dispatch_disconnect()
             return
         try:
             self._set_state(message_ready)
@@ -571,11 +567,13 @@ class Printer:
         # Scoped to this one dispatch on purpose: other send_event callers rely
         # on exceptions propagating.
         #
-        # One-shot per Printer lifetime: the failed-connect except arms call this
-        # and so does the post-run path, so without a latch every disconnect
-        # handler (heaters, fans, webhooks, gcode, mcu._disconnect →
-        # serialhdl.disconnect) would run twice on that path. bridge.shutdown()
-        # is idempotent, but the broader handlers are not contractually so.
+        # Fired only from the post-run exit path — never on a failed connect.
+        # A connect error (config/protocol/mcu) must leave the printer alive in
+        # its error state so webhooks keeps serving it to moonraker; bridge
+        # resources are reclaimed when the process actually exits. One-shot:
+        # bridge.shutdown() is idempotent, but the broader disconnect handlers
+        # (heaters, fans, webhooks, gcode, mcu._disconnect) are not
+        # contractually so.
         if self._disconnect_dispatched:
             return
         self._disconnect_dispatched = True

--- a/klippy/printer.py
+++ b/klippy/printer.py
@@ -559,21 +559,6 @@ class Printer:
         return [cb(*params) for cb in self.event_handlers.get(event, [])]
 
     def _dispatch_disconnect(self):
-        # Per-handler-guarded klippy:disconnect dispatch. Unlike the bare
-        # send_event (which aborts the whole list on the first raising handler),
-        # this guarantees every disconnect handler runs — critically
-        # MotionToolhead._handle_disconnect → bridge.shutdown(), which releases
-        # the pts fd. A sibling handler raising must never starve teardown.
-        # Scoped to this one dispatch on purpose: other send_event callers rely
-        # on exceptions propagating.
-        #
-        # Fired only from the post-run exit path — never on a failed connect.
-        # A connect error (config/protocol/mcu) must leave the printer alive in
-        # its error state so webhooks keeps serving it to moonraker; bridge
-        # resources are reclaimed when the process actually exits. One-shot:
-        # bridge.shutdown() is idempotent, but the broader disconnect handlers
-        # (heaters, fans, webhooks, gcode, mcu._disconnect) are not
-        # contractually so.
         if self._disconnect_dispatched:
             return
         self._disconnect_dispatched = True

--- a/rust/motion-bridge/src/bridge/tests.rs
+++ b/rust/motion-bridge/src/bridge/tests.rs
@@ -687,11 +687,14 @@ fn register_ethercat_mcu_seeds_nominal_clock_freq() {
     );
 }
 
-/// Failed-connect partial teardown: one serial MCU attached, the (would-be)
-/// second never attached. `shutdown()` must release the one attached MCU's fd —
-/// mirroring the `printer._connect` except-arm firing a guarded disconnect.
+/// Partial-state teardown: one serial MCU attached, the (would-be) second
+/// never attached. `shutdown()` must release the one attached MCU's fd —
+/// mirroring klippy's post-run exit dispatch after a connect failed partway.
+/// (A failed connect itself no longer tears anything down: the printer stays
+/// alive in its error state so moonraker can display it; shutdown() runs only
+/// when the process actually exits.)
 #[test]
-fn failed_connect_partial_teardown() {
+fn partial_state_teardown_at_exit() {
     let bridge = PyMotionBridge::new();
     let (master_fd, slave_path) = open_pty();
     let (io_arc, io_weak) = host_io_on_pty(&slave_path);

--- a/rust/motion-bridge/src/bridge/tests.rs
+++ b/rust/motion-bridge/src/bridge/tests.rs
@@ -687,27 +687,19 @@ fn register_ethercat_mcu_seeds_nominal_clock_freq() {
     );
 }
 
-/// Partial-state teardown: one serial MCU attached, the (would-be) second
-/// never attached. `shutdown()` must release the one attached MCU's fd —
-/// mirroring klippy's post-run exit dispatch after a connect failed partway.
-/// (A failed connect itself no longer tears anything down: the printer stays
-/// alive in its error state so moonraker can display it; shutdown() runs only
-/// when the process actually exits.)
 #[test]
 fn partial_state_teardown_at_exit() {
     let bridge = PyMotionBridge::new();
     let (master_fd, slave_path) = open_pty();
     let (io_arc, io_weak) = host_io_on_pty(&slave_path);
     insert_mcu(&bridge, 1, serial_mcu_conn("mcu0", &slave_path, io_arc));
-    // MCU handle 2 was never attached (simulated claim failure) — nothing to
-    // insert. shutdown() must still cleanly release handle 1.
 
     bridge.shutdown();
 
     assert!(
         io_weak.upgrade().is_none(),
-        "the one attached MCU's host_io fd must be released even on the \
-         partial/failed-connect teardown path"
+        "the one attached MCU's host_io fd must be released even when the \
+         bridge was only partially attached"
     );
     assert!(mcus_is_empty(&bridge));
 

--- a/test/test_printer_connect_error.py
+++ b/test/test_printer_connect_error.py
@@ -1,0 +1,79 @@
+import contextlib
+
+import klippy.printer
+
+
+class FakeReactor:
+    NOW = 0.0
+    NEVER = 9999999999.0
+
+    def register_callback(self, callback, waketime=NOW):
+        return None
+
+    def register_async_callback(self, callback, waketime=NOW):
+        return None
+
+    def register_fd(self, fd, read_callback, write_callback=None):
+        return object()
+
+    def unregister_fd(self, handle):
+        return None
+
+    def register_timer(self, callback, waketime=NEVER):
+        return object()
+
+    def unregister_timer(self, handle):
+        return None
+
+    def mutex(self, is_locked=False):
+        return contextlib.nullcontext()
+
+    def monotonic(self):
+        return 0.0
+
+    def run(self):
+        return None
+
+    def get_gc_stats(self):
+        return (0, 0, 0)
+
+
+def make_failed_connect_printer(monkeypatch):
+    printer = klippy.printer.Printer(FakeReactor(), None, {})
+    disconnects = []
+    printer.register_event_handler(
+        "klippy:disconnect", lambda: disconnects.append(1)
+    )
+
+    def raise_config_error():
+        raise printer.config_error(
+            "Option 'velocity_ff' is not valid in section 'servo_x'"
+        )
+
+    monkeypatch.setattr(printer, "_read_config", raise_config_error)
+    return printer, disconnects
+
+
+def test_config_error_keeps_printer_alive_and_reporting(monkeypatch):
+    printer, disconnects = make_failed_connect_printer(monkeypatch)
+
+    printer._connect(0.0)
+
+    assert "velocity_ff" in printer.state_message
+    assert not disconnects, (
+        "a config error must not dispatch klippy:disconnect — webhooks must "
+        "keep serving the error state to moonraker"
+    )
+
+
+def test_exit_after_failed_connect_dispatches_disconnect_once(monkeypatch):
+    printer, disconnects = make_failed_connect_printer(monkeypatch)
+    printer._connect(0.0)
+
+    run_result = printer.run()
+
+    assert run_result is None
+    assert disconnects == [1]
+
+    printer._dispatch_disconnect()
+    assert disconnects == [1]


### PR DESCRIPTION
## Problem

Any config error on current sota-motion presents as klippy **disconnected** — moonraker can't connect at all and no error is shown. Mainline behavior is to stay alive in an error state and report it in the console. Hit on the Neptune bench: a stale `velocity_ff` option in `[servo_x]` (removed by the declarative drive-params refactor, fc5d9418a) read as "not booting" instead of a one-line config error.

## Cause

405347a88 added `_dispatch_disconnect()` to all four failed-connect arms of `printer._connect` to guarantee `bridge.shutdown()` releases the linux-MCU pty and reaps the ethercat endpoint child. But the global `klippy:disconnect` also runs the webhooks handler, which closes the moonraker-facing socket — tearing down the very channel that would report the error.

## Fix

The error-arm dispatches were redundant: the same commit added the guarded, latched `_dispatch_disconnect()` to the post-run exit path, and every exit route (RESTART, FIRMWARE_RESTART, fatal exception) funnels through it. Teardown at actual process exit is all the pty-leak fix needs.

- Drop the four error-arm dispatches; a failed connect now leaves the printer alive with webhooks serving the error state, matching mainline.
- Bridge resources (pty fd, endpoint child, planner/pump threads) are reclaimed by the post-run dispatch when the process actually exits — the EBUSY-on-restart fix from 405347a88 is preserved.
- `failed_connect_partial_teardown` → `partial_state_teardown_at_exit`: same assertions, re-documented as the exit-path contract.
- New `test/test_printer_connect_error.py`: a config error dispatches no `klippy:disconnect`; the exit path afterward dispatches it exactly once.

## Verified

- `cargo nextest run -p motion-bridge`: 261 passed, 1 skipped
- `python3 -m pytest test/`: 198 passed, 77 skipped, 1 xfailed
- `cargo fmt --all --check` and `ruff format --check` clean