### PR TITLE
fix(trajectory): extrapolate replan left-pad at entry velocity, not constant position

### DIFF
--- a/rust/trajectory/src/emit_shaped/tests.rs
+++ b/rust/trajectory/src/emit_shaped/tests.rs
@@ -269,13 +269,16 @@ fn pad_segment_axis_with_history_seam_reads_history_tail() {
         .find(|p| 0.8 >= p.u_start - 1e-12 && 0.8 <= p.u_end + 1e-12)
         .expect("padded curve should cover t = 0.8")
         .evaluate(0.8);
+    // With no history the left pad continues at the segment's entry velocity (slope 20 through
+    // position 10 at the t=1.0 seam) rather than holding the start position: at t=0.8 that is
+    // 10 + 20*(0.8 - 1.0) = 6.0.
     assert!(
-        (val_08_no_history - 10.0).abs() < 1e-9,
-        "no-history path should read constant start_val (10.0) at t=0.8, got {val_08_no_history}",
+        (val_08_no_history - 6.0).abs() < 1e-9,
+        "no-history path should extrapolate at entry velocity to 6.0 at t=0.8, got {val_08_no_history}",
     );
     assert!(
         (val_08 - val_08_no_history).abs() > 1.0,
-        "history vs no-history must disagree at t=0.8 (history 8.0 vs constant 10.0)",
+        "history vs no-history must disagree at t=0.8 (history 8.0 vs vel-extrapolated 6.0)",
     );
 }
 

--- a/rust/trajectory/src/pad.rs
+++ b/rust/trajectory/src/pad.rs
@@ -190,10 +190,17 @@ fn collect_left_padding(
     }
 
     if cursor > pad_target {
-        let start_val = first_axis_value(seg_idx, axis, fitted);
+        let (t0, start_val, start_slope) = first_axis_boundary(seg_idx, axis, fitted);
         let ext_start = pad_target.max(batch_t_start - t_sm_half);
         if cursor > ext_start {
-            pieces.push(constant_piece(start_val, ext_start, cursor, target_degree));
+            let value_at_ext_start = start_val + start_slope * (ext_start - t0);
+            pieces.push(linear_piece(
+                value_at_ext_start,
+                start_slope,
+                ext_start,
+                cursor,
+                target_degree,
+            ));
         }
     }
 
@@ -331,14 +338,36 @@ fn find_halos_in_range(e_halos: &[EHalo], t_lo: f64, t_hi: f64) -> Vec<&EHalo> {
         .collect()
 }
 
-fn first_axis_value(seg_idx: usize, axis: usize, fitted: &[FittedSegment]) -> f64 {
+fn first_axis_boundary(seg_idx: usize, axis: usize, fitted: &[FittedSegment]) -> (f64, f64, f64) {
     for i in (0..=seg_idx).rev() {
         let pieces = extract_bezier_pieces(&fitted[i].axes[axis]);
         if let Some(first) = pieces.first() {
-            return first.evaluate(first.u_start);
+            let t0 = first.u_start;
+            let value = first.evaluate(t0);
+            let slope = first.differentiate().evaluate(t0);
+            return (t0, value, slope);
         }
     }
-    0.0
+    (fitted[seg_idx].t_start, 0.0, 0.0)
+}
+
+fn linear_piece(
+    value_at_start: f64,
+    slope: f64,
+    t_start: f64,
+    t_end: f64,
+    degree: usize,
+) -> BezierPiece<f64> {
+    let mut coeffs = vec![0.0; degree + 1];
+    coeffs[0] = value_at_start;
+    if degree >= 1 {
+        coeffs[1] = slope;
+    }
+    BezierPiece {
+        u_start: t_start,
+        u_end: t_end,
+        coeffs,
+    }
 }
 
 fn last_axis_value(seg_idx: usize, axis: usize, fitted: &[FittedSegment]) -> f64 {

--- a/rust/trajectory/src/pad/tests.rs
+++ b/rust/trajectory/src/pad/tests.rs
@@ -27,7 +27,7 @@ fn linear_segment(x_start: f64, x_end: f64, t_start: f64, t_end: f64) -> FittedS
 }
 
 #[test]
-fn pad_single_segment_extends_with_constants() {
+fn pad_single_segment_extends_left_by_velocity_right_by_constant() {
     let fitted = vec![linear_segment(0.0, 10.0, 0.0, 1.0)];
     let t_sm_half = 0.1;
 
@@ -52,12 +52,22 @@ fn pad_single_segment_extends_with_constants() {
         pieces.last().unwrap().u_end
     );
 
-    let left_val = pieces[0].evaluate(pieces[0].u_start);
+    // The left pad is a constant-velocity continuation of the entry motion (slope 10 through
+    // position 0 at the t=0 seam), NOT a constant-position hold: holding position injects a
+    // phantom velocity step that the shaper convolves into a spurious acceleration spike.
+    let left = &pieces[0];
     assert!(
-        left_val.abs() < 1e-10,
-        "left pad should hold 0.0, got {left_val}"
+        left.evaluate(0.0).abs() < 1e-9,
+        "left pad must meet the segment start at position 0, got {}",
+        left.evaluate(0.0),
+    );
+    let left_slope = left.differentiate().evaluate(left.u_start);
+    assert!(
+        (left_slope - 10.0).abs() < 1e-6,
+        "left pad must continue at the entry velocity 10, got slope {left_slope}",
     );
 
+    // The trailing edge faces an unknown future, so it still holds the end position constant.
     let right_val = pieces
         .last()
         .unwrap()

--- a/rust/trajectory/tests/live_jog_velocity_probe.rs
+++ b/rust/trajectory/tests/live_jog_velocity_probe.rs
@@ -1,0 +1,455 @@
+use geometry::segment::{CubicSegment, EMode, SourceRange};
+use nurbs::algebra::PiecewisePolynomialKernel;
+use nurbs::VectorNurbs;
+use trajectory::plan_velocity::{PlanShaper, SafetyMode};
+use trajectory::streaming::{EmitContext, ReplanContext, ShaperState};
+use trajectory::{AxisShaper, ELimits, ShapedSegment};
+
+fn live_shapers() -> [Option<AxisShaper>; 4] {
+    [
+        Some(AxisShaper::SmoothMzv {
+            frequency_hz: 186.0,
+        }),
+        Some(AxisShaper::SmoothMzv {
+            frequency_hz: 122.0,
+        }),
+        Some(AxisShaper::Passthrough),
+        None,
+    ]
+}
+
+fn live_ctx() -> ReplanContext {
+    ReplanContext {
+        limits: temporal::Limits::new(
+            [1000.0, 1000.0, 5.0],
+            [70000.0, 70000.0, 100.0],
+            [140000.0, 140000.0, 200.0],
+            70000.0,
+        ),
+        kernels: [
+            Some(PlanShaper::SmoothMzv {
+                frequency_hz: 186.0,
+            }),
+            Some(PlanShaper::SmoothMzv {
+                frequency_hz: 122.0,
+            }),
+            Some(PlanShaper::Passthrough),
+            None,
+        ],
+        fit_tolerance_mm: 0.005,
+        beta_max_iters: 5,
+        beta_convergence_ratio: 1.02,
+        e_limits: ELimits {
+            v_max: 100.0,
+            a_max: 5000.0,
+        },
+        junction_chord_tolerance_mm: 0.05,
+        worker_threads: 1,
+        grid_strategy: temporal::multi::GridStrategy::Adaptive {
+            min_n: 20,
+            max_n: 200,
+            target_grid_spacing_mm: 0.5,
+        },
+        fallback_initial_v: 0.0,
+        safety_mode: SafetyMode::WorstCaseFuture,
+    }
+}
+
+fn emit_kernels() -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
+    [
+        AxisShaper::SmoothMzv {
+            frequency_hz: 186.0,
+        }
+        .to_kernel(),
+        AxisShaper::SmoothMzv {
+            frequency_hz: 122.0,
+        }
+        .to_kernel(),
+        None,
+        None,
+    ]
+}
+
+fn passthrough_shapers() -> [Option<AxisShaper>; 4] {
+    [
+        Some(AxisShaper::Passthrough),
+        Some(AxisShaper::Passthrough),
+        Some(AxisShaper::Passthrough),
+        None,
+    ]
+}
+
+fn passthrough_ctx() -> ReplanContext {
+    let mut ctx = live_ctx();
+    ctx.kernels = [
+        Some(PlanShaper::Passthrough),
+        Some(PlanShaper::Passthrough),
+        Some(PlanShaper::Passthrough),
+        None,
+    ];
+    ctx
+}
+
+fn passthrough_emit_kernels() -> [Option<PiecewisePolynomialKernel<f64>>; 4] {
+    [None, None, None, None]
+}
+
+fn run_jog_experiment(
+    label: &str,
+    shapers: &[Option<AxisShaper>; 4],
+    ctx: &ReplanContext,
+    emit: &[Option<PiecewisePolynomialKernel<f64>>; 4],
+    strokes: &[(f64, f64)],
+    feedrate: f64,
+) -> Vec<bool> {
+    let mut state = ShaperState::new([0.0; 4], shapers);
+    let halos = Vec::new();
+    let ctx_emit = EmitContext {
+        kernels: emit,
+        e_halos: &halos,
+    };
+    let mut converged = Vec::with_capacity(strokes.len());
+    eprintln!("--- {label} ---");
+    for (i, (from, to)) in strokes.iter().enumerate() {
+        let report = state
+            .append_and_replan(linear_x_segment(*from, *to, feedrate), ctx)
+            .unwrap_or_else(|e| panic!("{label} stroke {i} ({from}->{to}) failed: {e:?}"));
+        eprintln!(
+            "[{label}] stroke {i} {from:>4}->{to:<4} window_segs={} beta_iters={} converged={} solve_us={}",
+            report.window_segments,
+            report.plan.beta_iterations,
+            report.plan.beta_converged,
+            report.solve_us,
+        );
+        converged.push(report.plan.beta_converged);
+        state
+            .emit_committed(&ctx_emit)
+            .unwrap_or_else(|e| panic!("{label} stroke {i} emit failed: {e:?}"));
+    }
+    converged
+}
+
+/// Mid-flight replan of back-to-back fast moves used to drive the jerk-relaxation
+/// derate loop to its iteration cap without converging: the feasibility emit padded
+/// the first window segment's left edge against empty shaper history, fabricating a
+/// velocity step at the dispatch seam whose convolution looked like a ~2x acceleration
+/// spike. Derating planning accel could not move a boundary artifact, so the loop spun
+/// to the cap (~294 ms on the Pi) and starved playback. With the left pad extrapolated
+/// at the entry velocity instead, the phantom is gone and every regime converges in one
+/// iteration — regardless of direction reversal, segment length, or feedrate-to-vmax ratio.
+#[test]
+fn mid_flight_fast_jog_replan_converges_across_regimes() {
+    let feedrate = 1000.0;
+    let reversal = [(0.0, 30.0), (30.0, 0.0), (0.0, 30.0), (30.0, 0.0)];
+    let continuation = [(0.0, 30.0), (30.0, 60.0), (60.0, 90.0), (90.0, 120.0)];
+    let long_continuation = [(0.0, 200.0), (200.0, 400.0), (400.0, 600.0), (600.0, 800.0)];
+
+    let mut ctx_vmax2000 = live_ctx();
+    ctx_vmax2000.limits = temporal::Limits::new(
+        [2000.0, 2000.0, 5.0],
+        [70000.0, 70000.0, 100.0],
+        [140000.0, 140000.0, 200.0],
+        70000.0,
+    );
+
+    let scenarios: [(
+        &str,
+        &[Option<AxisShaper>; 4],
+        &ReplanContext,
+        &[Option<PiecewisePolynomialKernel<f64>>; 4],
+        &[(f64, f64)],
+        f64,
+    ); 6] = [
+        (
+            "shaped+reversal",
+            &live_shapers(),
+            &live_ctx(),
+            &emit_kernels(),
+            &reversal,
+            feedrate,
+        ),
+        (
+            "shaped+continuation",
+            &live_shapers(),
+            &live_ctx(),
+            &emit_kernels(),
+            &continuation,
+            feedrate,
+        ),
+        (
+            "shaped+continuation_long_200mm",
+            &live_shapers(),
+            &live_ctx(),
+            &emit_kernels(),
+            &long_continuation,
+            feedrate,
+        ),
+        (
+            "shaped+continuation_500mms",
+            &live_shapers(),
+            &live_ctx(),
+            &emit_kernels(),
+            &continuation,
+            500.0,
+        ),
+        (
+            "shaped+continuation_1000mms_of_vmax2000",
+            &live_shapers(),
+            &ctx_vmax2000,
+            &emit_kernels(),
+            &continuation,
+            feedrate,
+        ),
+        (
+            "passthrough+reversal",
+            &passthrough_shapers(),
+            &passthrough_ctx(),
+            &passthrough_emit_kernels(),
+            &reversal,
+            feedrate,
+        ),
+    ];
+
+    for (label, shapers, ctx, emit, strokes, fr) in scenarios {
+        let converged = run_jog_experiment(label, shapers, ctx, emit, strokes, fr);
+        assert!(
+            converged.iter().all(|&c| c),
+            "{label}: a mid-flight replan failed to converge — the empty-history boundary \
+             phantom has regressed (see {label} trace above)",
+        );
+    }
+}
+
+fn linear_x_segment(start_x: f64, end_x: f64, feedrate: f64) -> CubicSegment {
+    let p0 = [start_x, 0.0, 0.0];
+    let p3 = [end_x, 0.0, 0.0];
+    let lerp = |t: f64| -> [f64; 3] {
+        [
+            p0[0] + (p3[0] - p0[0]) * t,
+            p0[1] + (p3[1] - p0[1]) * t,
+            p0[2] + (p3[2] - p0[2]) * t,
+        ]
+    };
+    let cps = vec![p0, lerp(1.0 / 3.0), lerp(2.0 / 3.0), p3];
+    let xyz = VectorNurbs::<f64, 3>::try_new(3, vec![0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0], cps)
+        .unwrap();
+    CubicSegment::try_new(
+        xyz,
+        EMode::Travel,
+        0.0,
+        None,
+        feedrate,
+        SourceRange {
+            start_line: 0,
+            end_line: 0,
+        },
+        None,
+    )
+    .unwrap()
+}
+
+fn cross_axis_contamination(label: &str, segments: &[ShapedSegment], moving_axis: usize) {
+    let dt = 2e-4;
+    for axis in 0..3 {
+        if axis == moving_axis {
+            continue;
+        }
+        let mut max_v: f64 = 0.0;
+        let mut max_v_t = 0.0;
+        let mut max_excursion: f64 = 0.0;
+        let mut p_ref: Option<f64> = None;
+        for seg in segments {
+            let view = seg.axes[axis].as_view();
+            let mut t = seg.t_start;
+            while t < seg.t_end - 1e-12 {
+                let p0 = nurbs::eval::eval(&view, t);
+                let p1 = nurbs::eval::eval(&view, (t + dt).min(seg.t_end));
+                let v = ((p1 - p0) / ((t + dt).min(seg.t_end) - t)).abs();
+                if v > max_v {
+                    max_v = v;
+                    max_v_t = t;
+                }
+                let r = *p_ref.get_or_insert(p0);
+                max_excursion = max_excursion.max((p0 - r).abs());
+                t += dt;
+            }
+        }
+        eprintln!(
+            "[probe] {label}: axis{axis} (should be still) max_v={max_v:.6} at t={max_v_t:.5} max_excursion={max_excursion:.6}",
+        );
+    }
+}
+
+fn probe_stream(label: &str, segments: &[ShapedSegment]) {
+    let dt = 2e-4;
+    let mut prev_v: Option<f64> = None;
+    let mut max_v: f64 = 0.0;
+    let mut min_cruise_v = f64::MAX;
+    let mut max_dv: f64 = 0.0;
+    let mut max_dv_t: f64 = 0.0;
+    let mut samples: Vec<(f64, f64)> = Vec::new();
+
+    for seg in segments {
+        let view = seg.axes[0].as_view();
+        let mut t = seg.t_start;
+        while t < seg.t_end - 1e-12 {
+            let p0 = nurbs::eval::eval(&view, t);
+            let p1 = nurbs::eval::eval(&view, (t + dt).min(seg.t_end));
+            let v = (p1 - p0) / ((t + dt).min(seg.t_end) - t);
+            samples.push((t, v));
+            if let Some(pv) = prev_v {
+                let dv = (v - pv).abs();
+                if dv > max_dv {
+                    max_dv = dv;
+                    max_dv_t = t;
+                }
+            }
+            prev_v = Some(v);
+            max_v = max_v.max(v.abs());
+            t += dt;
+        }
+    }
+
+    let cruise_threshold = 0.5 * max_v;
+    let mut in_cruise = false;
+    for &(_, v) in &samples {
+        if v.abs() >= cruise_threshold {
+            in_cruise = true;
+        }
+        if in_cruise && v.abs() > 1.0 {
+            min_cruise_v = min_cruise_v.min(v.abs());
+        }
+    }
+
+    let t_total =
+        segments.last().map_or(0.0, |s| s.t_end) - segments.first().map_or(0.0, |s| s.t_start);
+    eprintln!(
+        "[probe] {label}: segs={} t_total={t_total:.5} max_v={max_v:.3} \
+         min_cruise_v={min_cruise_v:.3} max_step_dv={max_dv:.4} at t={max_dv_t:.5}",
+        segments.len(),
+    );
+
+    let mut dips: Vec<(f64, f64)> = Vec::new();
+    for w in samples.windows(3) {
+        let (t1, v1) = w[1];
+        if v1.abs() > 1.0
+            && v1.abs() < 0.6 * max_v
+            && w[0].1.abs() >= v1.abs()
+            && w[2].1.abs() >= v1.abs()
+        {
+            dips.push((t1, v1));
+        }
+    }
+    if !dips.is_empty() {
+        let worst = dips
+            .iter()
+            .min_by(|a, b| a.1.abs().partial_cmp(&b.1.abs()).unwrap())
+            .unwrap();
+        eprintln!(
+            "[probe] {label}: {} interior velocity dips below 60% of peak; worst v={:.3} at t={:.5}",
+            dips.len(),
+            worst.1,
+            worst.0,
+        );
+    }
+}
+
+/// Regression for the 2026-06-11 Trident crash: back-to-back +30/-30 mm jogs at the
+/// 1000 mm/s axis limit. Each mid-flight replan must converge within the iteration cap;
+/// non-convergence is what blew the real-time budget (294 ms solve for 30 ms of motion)
+/// and tripped the SegmentLate fatal abort.
+#[test]
+fn back_to_back_fast_jogs_replan_stays_realtime() {
+    let mut state = ShaperState::new([0.0; 4], &live_shapers());
+    let ctx = live_ctx();
+    let kernels = emit_kernels();
+    let halos = Vec::new();
+    let ctx_emit = EmitContext {
+        kernels: &kernels,
+        e_halos: &halos,
+    };
+
+    let feedrate = 1000.0;
+    let jog_mm = 30.0;
+    let strokes = [
+        (0.0, jog_mm),
+        (jog_mm, 0.0),
+        (0.0, jog_mm),
+        (jog_mm, 0.0),
+        (0.0, jog_mm),
+        (jog_mm, 0.0),
+    ];
+
+    for (i, (from, to)) in strokes.iter().enumerate() {
+        let report = state
+            .append_and_replan(linear_x_segment(*from, *to, feedrate), &ctx)
+            .unwrap_or_else(|e| panic!("stroke {i} ({from}->{to}) replan failed: {e:?}"));
+        let plan = report.plan;
+        eprintln!(
+            "stroke {i} {from:>4}->{to:<4} window_segs={} beta_iters={} converged={} solve_us={}",
+            report.window_segments, plan.beta_iterations, plan.beta_converged, report.solve_us,
+        );
+        assert!(
+            plan.beta_converged,
+            "stroke {i} ({from}->{to}): mid-flight replan failed to converge in {} iters — \
+             the empty-history boundary phantom that starved playback on Trident has regressed",
+            plan.beta_iterations,
+        );
+        assert!(
+            plan.beta_iterations < ctx.beta_max_iters,
+            "stroke {i}: converged only by exhausting the iteration cap ({} iters)",
+            plan.beta_iterations,
+        );
+        state
+            .emit_committed(&ctx_emit)
+            .unwrap_or_else(|e| panic!("stroke {i} emit_committed failed: {e:?}"));
+    }
+}
+
+#[test]
+fn live_jog_sequence_velocity_probe() {
+    let mut state = ShaperState::new([0.0; 4], &live_shapers());
+    let ctx = live_ctx();
+    let kernels = emit_kernels();
+    let halos = Vec::new();
+    let ctx_emit = EmitContext {
+        kernels: &kernels,
+        e_halos: &halos,
+    };
+
+    let mut all: Vec<ShapedSegment> = Vec::new();
+
+    state
+        .append_and_replan(linear_x_segment(0.0, 5.0, 100.0), &ctx)
+        .expect("retract 5mm");
+    all.extend(state.emit_committed(&ctx_emit).expect("emit 1"));
+
+    state
+        .append_and_replan(linear_x_segment(5.0, 100.0, 100.0), &ctx)
+        .expect("jog 95mm");
+    all.extend(state.emit_committed(&ctx_emit).expect("emit 2"));
+
+    state
+        .append_and_replan(linear_x_segment(100.0, 200.0, 100.0), &ctx)
+        .expect("jog 100mm spliced");
+    all.extend(state.emit_committed(&ctx_emit).expect("emit 3"));
+
+    all.extend(state.commit_decel_to_zero(&ctx_emit).expect("final commit"));
+
+    probe_stream("jog-sequence", &all);
+    cross_axis_contamination("jog-sequence", &all, 0);
+
+    let mut state2 = ShaperState::new([0.0; 4], &live_shapers());
+    let mut homing: Vec<ShapedSegment> = Vec::new();
+    state2
+        .append_and_replan(linear_x_segment(0.0, -258.0, 40.0), &ctx)
+        .expect("homing drip move");
+    homing.extend(state2.emit_committed(&ctx_emit).expect("emit drip"));
+    homing.extend(
+        state2
+            .commit_decel_to_zero(&ctx_emit)
+            .expect("drip decel commit"),
+    );
+    probe_stream("homing-drip", &homing);
+    cross_axis_contamination("homing-drip", &homing, 0);
+}


### PR DESCRIPTION
## Symptom

Back-to-back fast jogs on Trident crashed the planner (2026-06-11). The structured logs showed a `replan_overrun` (294 ms solve for a 30 ms move, `beta_converged=false`, `beta_iters=5`) immediately followed by `SegmentLate` and a `planner_fatal` stream-starvation abort. A single jog was fine; the *second* jog onward (toolhead already moving) wedged the solver.

## Root cause

The β jerk-relaxation **derate loop** plans with a trial `planning_a_max`, measures the post-shaper acceleration peak, and shrinks the planning accel if the shaped peak exceeds the machine limit. On a mid-flight replan it saw a post-shaper peak ~1.9× the limit and derated to the floor without ever clearing it — because the peak was **not** caused by the planned accel.

The β feasibility emit pads the first window segment's left edge against `PerAxisHistory::empty()`. The no-history fallback in `collect_left_padding` held the **start position constant**, so a mid-flight entry at velocity `v` produced a phantom `0→v` velocity step at the dispatch seam. Convolved with the smoothing kernel that became a fabricated acceleration spike pinned at the first sample (measured up to 26 000× the command accel on a pure-cruise entry). Derating planning accel can't move a boundary artifact, so the loop spun to its iteration cap, blew the real-time budget, and starved playback.

Confirmed independently three ways: production logs, an offline harness that reproduces the exact `window_segs=2 / beta_iters=5 / non-converged` signature, and the live bench (the crash vanishes with the shaper disabled — consistent with a convolution artifact, since the smooth-MZV/ZV kernel is a strictly positive bell so post-shaper accel can never exceed the command peak with valid history).

## Fix

Pad the leading edge with a **constant-velocity ray** at the segment's entry slope instead of a constant-position hold. From rest (slope 0) this is byte-identical to the old behavior, so cold-start and normal dispatch are unchanged; at a high-velocity seam the phantom step is gone.

`rust/trajectory/src/pad.rs` — `collect_left_padding` final fallback now uses `first_axis_boundary` (value + slope) and a `linear_piece` matching `target_degree`.

## Verification

- Offline: every previously non-converging regime (reversal, continuation, 200 mm long, 500 mm/s, 1000-of-vmax-2000) now converges in **1 iteration**; solve ~294 ms → ~50 ms on the Pi.
- Full Rust suite green (1680/1680), fmt + clippy clean.
- Regression coverage added in `tests/live_jog_velocity_probe.rs` (`back_to_back_fast_jogs_replan_stays_realtime`, `mid_flight_fast_jog_replan_converges_across_regimes`); two pad tests updated to assert the corrected constant-velocity continuation.
- **Bench: flashed both MCUs (H723 + F446) and confirmed by the user — the back-to-back fast jogs that crashed now run clean.**