### PR TITLE
stepper: emit full step pulses unless TMC dedge is active

### DIFF
--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -16,6 +16,9 @@ class error(Exception):
 # Steppers
 ######################################################################
 
+MAX_BOTH_EDGE_PULSE_DURATION = 0.000000500
+DEFAULT_STEP_PULSE_DURATION = 0.000002
+
 
 class MCU_stepper:
     def __init__(
@@ -45,8 +48,7 @@ class MCU_stepper:
             )
         self._dir_pin = dir_pin_params["pin"]
         self._invert_dir = self._orig_invert_dir = dir_pin_params["invert"]
-        # Step-on-both-edges is the only mode the Rust runtime emits.
-        self._step_both_edge = True
+        self._step_both_edge = False
         self._req_step_both_edge = False
         self._active_callbacks = []
         self._bridge_active_axes = b""
@@ -86,13 +88,21 @@ class MCU_stepper:
                 break
 
     def _build_config(self):
-        # The runtime toggles step_pin once per step (every edge counts), so the
-        # TMC driver needs DEDGE=1. invert_step / step_pulse_ticks are sent for
-        # ABI compatibility but ignored on the MCU.
-        self._step_both_edge = True
-        self._step_pulse_duration = 0.0
-        invert_step = -1
-        step_pulse_ticks = 0
+        if self._step_pulse_duration is None:
+            self._step_pulse_duration = DEFAULT_STEP_PULSE_DURATION
+        self._step_both_edge = (
+            self._req_step_both_edge
+            and self._step_pulse_duration <= MAX_BOTH_EDGE_PULSE_DURATION
+        )
+        if self._step_both_edge:
+            self._step_pulse_duration = 0.0
+            invert_step = -1
+            step_pulse_ticks = 0
+        else:
+            invert_step = self._invert_step
+            step_pulse_ticks = self._mcu.seconds_to_clock(
+                self._step_pulse_duration
+            )
         self._mcu.add_config_cmd(
             "config_stepper oid=%d step_pin=%s dir_pin=%s invert_step=%d"
             " step_pulse_ticks=%u"

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -18,6 +18,8 @@
 
 struct stepper {
     struct gpio_out step_pin, dir_pin;
+    uint32_t step_pulse_ticks;
+    uint8_t step_both_edge, step_idle_level;
     struct trsync_signal stop_signal;
 };
 
@@ -39,7 +41,11 @@ command_config_stepper(uint32_t *args)
         runtime_diag_progress(0xCD, args[0] & 0xFFu, exp_lo);
     }
     struct stepper *s = oid_alloc(args[0], command_config_stepper, sizeof(*s));
-    s->step_pin = gpio_out_setup(args[1], 0);
+    int_fast8_t invert_step = (int_fast8_t)args[3];
+    s->step_both_edge = invert_step < 0;
+    s->step_idle_level = invert_step > 0;
+    s->step_pulse_ticks = args[4];
+    s->step_pin = gpio_out_setup(args[1], s->step_idle_level);
     s->dir_pin = gpio_out_setup(args[2], 0);
 }
 DECL_COMMAND(command_config_stepper, "config_stepper oid=%c step_pin=%c"
@@ -56,7 +62,7 @@ stepper_stop(struct trsync_signal *tss, uint8_t reason)
 {
     struct stepper *s = container_of(tss, struct stepper, stop_signal);
     gpio_out_write(s->dir_pin, 0);
-    gpio_out_write(s->step_pin, 0);
+    gpio_out_write(s->step_pin, s->step_idle_level);
 }
 
 void
@@ -92,6 +98,12 @@ command_diag_stepper_buzz(uint32_t *args)
     uint32_t deadline = timer_read_time();
     for (uint32_t i = 0; i < step_count; i++) {
         gpio_out_toggle(s->step_pin);
+        if (!s->step_both_edge) {
+            uint32_t fall_deadline = timer_read_time() + s->step_pulse_ticks;
+            while (timer_is_before(timer_read_time(), fall_deadline))
+                ;
+            gpio_out_toggle(s->step_pin);
+        }
         deadline += period_ticks;
         while (timer_is_before(timer_read_time(), deadline))
             ;
@@ -126,6 +138,8 @@ struct runtime_motor_stepper {
 static struct runtime_motor_stepper runtime_motor_steppers[RUNTIME_MOTOR_COUNT]
                                                           [RUNTIME_MAX_STEPPERS_PER_MOTOR];
 static uint8_t runtime_motor_stepper_count[RUNTIME_MOTOR_COUNT];
+static uint8_t runtime_motor_both_edge[RUNTIME_MOTOR_COUNT];
+static uint32_t runtime_motor_pulse_ticks[RUNTIME_MOTOR_COUNT];
 static int8_t runtime_motor_last_dir[RUNTIME_MOTOR_COUNT] = { -1, -1, -1, -1 };
 
 volatile uint32_t runtime_emit_calls __attribute__((used, externally_visible));
@@ -206,11 +220,23 @@ command_kalico_configure_axis(uint32_t *args)
     if (rc != 0)
         shutdown("configure_axis rejected by runtime");
 
+    uint8_t motor_both_edge = stepper_count ? staged[0].stepper->step_both_edge
+                                            : 1;
+    uint32_t motor_pulse_ticks = 0;
+    for (uint8_t i = 0; i < stepper_count; i++) {
+        if (staged[i].stepper->step_both_edge != motor_both_edge)
+            shutdown("configure_axis mixed step edge modes on one axis");
+        if (staged[i].stepper->step_pulse_ticks > motor_pulse_ticks)
+            motor_pulse_ticks = staged[i].stepper->step_pulse_ticks;
+    }
+
     runtime_motor_stepper_count[axis_idx] = stepper_count;
     for (uint8_t i = 0; i < stepper_count; i++) {
         runtime_motor_steppers[axis_idx][i].stepper = staged[i].stepper;
         runtime_motor_steppers[axis_idx][i].invert_dir = staged[i].invert_dir;
     }
+    runtime_motor_both_edge[axis_idx] = motor_both_edge;
+    runtime_motor_pulse_ticks[axis_idx] = motor_pulse_ticks;
     runtime_motor_last_dir[axis_idx] = -1;
     (void)extrusion_bits;
 
@@ -394,6 +420,8 @@ runtime_emit_step_pulses(uint8_t motor_idx, int32_t n_steps)
 
     extern uint32_t runtime_cyccnt_read(void);
     uint32_t last = step_last_edge_dwt[motor_idx];
+    uint8_t both_edge = runtime_motor_both_edge[motor_idx];
+    uint32_t pulse_ticks = runtime_motor_pulse_ticks[motor_idx];
 
     for (uint32_t i = 0; i < count; i++) {
         uint32_t now = runtime_cyccnt_read();
@@ -405,6 +433,14 @@ runtime_emit_step_pulses(uint8_t motor_idx, int32_t n_steps)
         }
         for (uint8_t j = 0; j < cnt; j++)
             gpio_out_toggle_noirq(runtime_motor_steppers[motor_idx][j].stepper->step_pin);
+        if (!both_edge) {
+            uint32_t fall_at = runtime_cyccnt_read() + pulse_ticks;
+            while ((int32_t)(runtime_cyccnt_read() - fall_at) < 0)
+                ;
+            for (uint8_t j = 0; j < cnt; j++)
+                gpio_out_toggle_noirq(
+                    runtime_motor_steppers[motor_idx][j].stepper->step_pin);
+        }
         last = runtime_cyccnt_read();
     }
 


### PR DESCRIPTION
## Problem

On boards with standalone step/dir drivers (no `[tmc*]` UART/SPI section — e.g. the Neptune 3 Pro's onboard drivers), every axis moved exactly half the commanded distance.

The runtime unconditionally used both-edge stepping: `klippy/stepper.py` always sent `config_stepper invert_step=-1`, and `runtime_emit_step_pulses` toggled the step pin once per step. That is only valid when the driver has DEDGE=1, which the host can only program over UART/SPI. Standalone drivers count rising edges only, so two commanded steps produced one driver step.

## Fix

Mirror mainline Klipper's behavior — both-edge stepping is opt-in by the TMC driver section:

- **`klippy/stepper.py`**: `_build_config` resolves the mode per stepper. A TMC section requesting both-edge (via `setup_default_pulse_duration(100ns, True)`, with pulse ≤ 500ns) sends `invert_step=-1 step_pulse_ticks=0` — byte-identical to before, so TMC/DEDGE axes are unchanged. Otherwise it sends the real invert flag plus `step_pulse_ticks` (default 2µs, `step_pulse_duration` config respected).
- **`src/stepper.c`**: `config_stepper` now reads `invert_step`/`step_pulse_ticks` (negative invert = both-edge, mainline's wire convention) and sets the step pin's idle level from the invert flag. `kalico_configure_axis` derives a per-motor edge mode and shuts down loudly on mixed modes within one motor. For non-DEDGE motors, `runtime_emit_step_pulses` emits rise → hold `step_pulse_ticks` → fall; the existing 1µs inter-edge spacing now guarantees the minimum low time between pulses. `diag_stepper_buzz` and the trsync stop path get the same treatment.

Worst-case cost on the pulse path: a 32-step catch-up burst adds ~100µs of spin in the step-output path at the default 2µs pulse; `step_pulse_duration` can shrink it 10x for drivers that only need ~100ns.

## Verification

- Full-stack simulator, default config (no TMC sections — exercises the new full-pulse path): boots, homes, prints — PASS. Sim homing counts rising edges on the step pin, so half-rate emission cannot pass it.
- Sim phase-stepping variant (TMC5160 X + standalone Y/Z in one printer): output identical to the parent commit, including one pre-existing init warning verified present before this change.
- Flashed to the Neptune 3 Pro bench (F401): klippy ready.
- `ruff format`/`ruff check` clean; no Rust changes.