### PR TITLE
Planner extension: follower rows, PA cuts, shaper folding (plan 3)

### DIFF
--- a/docs/research/topp-frozen-timemap-shaping-fixedpoint.md
+++ b/docs/research/topp-frozen-timemap-shaping-fixedpoint.md
@@ -1,0 +1,197 @@
+---
+topic: TOPP frozen-time-map fixed-point iteration for convolution/input-shaping constraints
+created: 2026-06-12
+last_updated: 2026-06-12
+verified_claims:
+  - 2026-06-12 INCONCLUSIVE (leaning conditionally-true with no global guarantee) — "Fixed-point iteration over a frozen time map (re-freeze t̄ from current b̄, rebuild averaging-kernel convolution constraint rows, re-solve) converges for averaging-type kernels in TOPP." No published convergence proof exists for this exact scheme; structural analysis shows it is a non-expansive-but-not-contractive map in general, with concrete divergence/oscillation regimes (kernel support spanning a stop-to-stop chain; near-singular b near stops).
+sources:
+  - https://arxiv.org/pdf/1707.07239
+  - https://arxiv.org/pdf/1312.6533
+  - https://www.sciencedirect.com/science/article/pii/S0005109824003583
+  - https://arxiv.org/pdf/2312.02944
+  - https://arxiv.org/abs/2404.16826
+  - https://www.semanticscholar.org/paper/Time-Optimal-Path-Following-for-Robots-With-Using-Debrouwere-Loock/5dfe332771b4fa75f46a399ddf1242fa57586901
+---
+
+# TOPP frozen-time-map fixed-point iteration for convolution/shaping constraints
+
+## Summary
+
+The kalico scheme — freeze sample times t̄_i from the current iterate b̄ (b = ṡ²), rebuild
+convolution-window constraint rows W_ij = K(t̄_i − t̄_j)·q_j for an averaging-type kernel
+(compact support, integral 1) on those frozen times, re-solve the SOCP, repeat — has **no
+published convergence proof** for this exact construction. The closest prior art (TOPP-RA
+finite-N non-monotonicity; Verscheure/Debrouwere velocity-dependent constraints that destroy
+convexity; alternating segment-time-vs-coefficient quadrotor schemes) establishes that maps of
+this shape are **non-expansive in benign regimes but neither globally contractive nor
+guaranteed-monotone**. Averaging kernels help (they are smoothing, low-pass, and the time map
+is monotone in b), but they do not close the gap to a contraction. Concrete divergence regimes
+exist: kernel support wider than a stop-to-stop chain, and near-singular b near rest points
+where t̄ is hypersensitive to b. The verdict is therefore: **the claim is plausibly true in the
+common regime but is not provably true in general, and the "known counterexample shapes" half of
+the disjunction is correct.** Retry-cap-then-fail-loud is an acceptable *safety* posture but is
+**not** an acceptable *throughput* posture as a permanent design, because the divergence regimes
+are not exotic — they coincide with short moves between full stops, which are common in real
+slicer output (small perimeters, retraction-bracketed travels).
+
+## Verified claim — 2026-06-12
+
+**Claim (verbatim):** "Fixed-point iteration over a frozen time map — re-freezing sample times
+t̄_i from the current iterate b̄ (b = ṡ²), rebuilding convolution-window constraint rows
+(input-shaper kernels, averaging-type, compact support, integral 1) on those times, and
+re-solving — converges for averaging-type kernels in time-optimal path parameterization; or,
+known counterexample shapes exist (e.g. kernel support wider than a chain between stops)."
+
+**Verdict:** INCONCLUSIVE for the unconditional first disjunct; the disjunction as a whole holds
+because the second disjunct (counterexample shapes exist) is **confirmed**.
+
+### Verification approach
+
+1. Surveyed existing kalico research: `jerk-constrained-socp-relaxation-tightness.md` (SLP outer
+   iteration — a *different* iteration: linearizes 1/√b at a fixed grid, time map is not
+   re-frozen), `condensed-smooth-chain-socp-junction.md` (records the TOPP-RA finite-N
+   non-monotonicity caveat), `bspline-polynomial-convolution.md` (convolution support widens by
+   kernel support — directly relevant to the counterexample geometry).
+2. Web survey for the exact scheme. No paper iterates a *frozen time map* to handle
+   convolution/shaping constraints inside TOPP. The structurally-adjacent results are TOPP-RA
+   (Pham, arXiv:1707.07239), velocity-dependent-constraint TOPP (Verscheure/Debrouwere), the
+   jerk-convexity result (Consolini-Locatelli, S0005109824003583), and alternating
+   time/coefficient trajectory schemes (arXiv:2312.02944, arXiv:2404.16826).
+3. Analyzed the fixed-point map structure directly.
+
+### The map, made explicit
+
+Define the iteration operator T: b̄ ↦ b̄'.
+
+- **Time map** (trapezoid quadrature on b): t̄_i(b̄) = Σ_{j<i} 2·Δs_j / (√b̄_j + √b̄_{j+1}).
+  This is the dominant nonlinearity. ∂t̄_i/∂b̄_k = −Δs·b̄_k^{−1/2}/(√b̄_j+√b̄_{j+1})² type terms;
+  as b̄_k → 0 (a stop), ∂t̄_i/∂b̄_k → ∞. The time map is **monotone** (more speed ⇒ less time)
+  and **smooth on b > 0**, but its Lipschitz constant blows up as any b̄_k → 0.
+- **Window rebuild:** W_ij = K(t̄_i − t̄_j)·q_j with K averaging (K ≥ 0, ∫K = 1, compact
+  support [−h, h]). The constraint rows cap |r|·‖(W q)_i‖ etc. K being an averaging kernel makes
+  W a row-stochastic-like smoothing operator: ‖W‖_∞ ≤ 1, and small perturbations in t̄ produce
+  perturbations in W bounded by (Lipschitz-K)·(perturbation in t̄). For a trapezoid/box kernel,
+  K is Lipschitz with constant ~1/h².
+- **Solve:** the SOCP that maps the frozen W to b̄' is a continuous (piecewise-smooth) selection.
+
+### Why averaging kernels help but do not guarantee contraction
+
+The favorable facts for the first disjunct:
+
+1. **Averaging kernels are non-expansive smoothers.** ‖W‖ ≤ 1 means the shaped-velocity
+   constraint never amplifies; it can only relax or tighten by a bounded amount. This rules out
+   the simplest blow-up mode.
+2. **Monotone time map + monotone constraint dependence** gives the iteration a
+   partial-order/Tarski flavor: tighter shaped-velocity caps ⇒ smaller b̄' ⇒ larger t̄ ⇒ (for an
+   averaging kernel) the difference t̄_i − t̄_j over a fixed index gap grows, which generally
+   *loosens* the cap (the kernel sees a wider spread). That is a **negative feedback** sign,
+   which is exactly the condition under which fixed-point iteration tends to converge. This is the
+   strongest argument for the first disjunct and is why the scheme converges in the common regime.
+
+The facts that defeat a *global* guarantee:
+
+3. **The Lipschitz constant of T is unbounded** as b̄ → 0 near stops. Composition
+   (time map ∘ kernel ∘ solve) has Lipschitz constant L_t · L_K · L_solve; L_t → ∞ near stops and
+   L_K ~ 1/h². There is no a-priori bound < 1, so Banach fixed-point does not apply and no
+   contraction certificate exists. The negative-feedback sign in (2) is a *tendency*, not a
+   *bound*: a single index pair straddling a stop can flip the sign locally when the kernel
+   support [−h,h] reaches across the stop into a neighboring chain moving in a different
+   direction, because then increasing t̄-spread pulls in *opposite-sign* axis velocity and the cap
+   tightens instead of loosening — destroying the monotone negative feedback.
+
+4. **Finite-N non-monotonicity (Pham/TOPP-RA caveat, already in the corpus).** At finite grid the
+   maximal-transition map is "not monotonic over the whole controllable set." The frozen-time
+   rebuild inherits this: the discrete optimum the iteration chases can itself shift
+   non-monotonically with N, so the iterate can chatter between two grid-adjacent optima without
+   settling — an oscillation, not a divergence, but it still trips an 8-refreeze cap.
+
+### Known counterexample shapes (second disjunct — CONFIRMED)
+
+Adversarial constructions where T is not a contraction:
+
+- **Kernel support wider than a stop-to-stop chain.** If h (half-support of K) exceeds the time
+  length of a chain bounded by two full stops, the window at an interior sample reaches across the
+  stop into the neighboring chain. The shaped-velocity at that sample then depends on motion in a
+  segment that the current chain's b̄ does not control, and whose direction may oppose it. The
+  negative-feedback sign of (2) is lost; the rebuilt W can tighten the cap when the iterate slows
+  down, which slows it further, until the iterate collapses toward b = 0 (chatter or monotone
+  collapse). This is the user's own example and it is mathematically real. (Supported by
+  `bspline-polynomial-convolution.md`: convolution support genuinely widens by kernel support, so
+  "support reaches the neighbor" is not hypothetical — it is the generic short-move case.)
+
+- **Near-singular b at a stop.** A rest-to-rest move with a very short fast middle: b̄ is ~0 at
+  both ends and the time map's Jacobian is enormous there. A small change in the interior b̄
+  produces a large change in t̄ at the far end, which moves a far window's contents discontinuously
+  (a sample crosses a kernel breakpoint), producing a large jump in W and hence in b̄'. This is a
+  Lipschitz-constant-blow-up oscillation independent of kernel width. Short perimeters and
+  retraction-bracketed travels in real slicer output land here.
+
+- **Two near-equal grid optima (finite-N chatter).** Per Pham's caveat, two grid-adjacent feasible
+  parameterizations with near-equal objective can alternate under refreeze. Bounded, but
+  non-converging within a small cap.
+
+None of these requires pathological geometry; the first two are common short-move printing cases.
+
+### Recommendation for the divergence posture
+
+- **Retry-cap-then-fail-loud is correct as a safety net and must stay.** It satisfies the
+  CLAUDE.md "fail loudly" rule and catches genuinely ill-posed inputs. Keep it.
+- **It is NOT acceptable as the *only* posture**, because the divergence regimes coincide with
+  common print features (short moves between stops, retraction travels). A permanent "8 refreezes
+  then die" on those would surface as intermittent print-time failures on ordinary G-code, which
+  violates the "throughput is non-negotiable / never ship a measurably slower (here: failing)
+  trajectory" constraint by failing outright. A fallback is needed for the non-converging branch.
+- **Recommended fallback (literature-grounded), in priority order:**
+  1. **Damped / averaged update (Mann–Krasnoselskii iteration):** b̄^{k+1} = (1−α) b̄^k + α T(b̄^k)
+     with α ∈ (0,1). For a non-expansive T on a convex set, the averaged iteration converges to a
+     fixed point even when T itself is not a contraction (Krasnoselskii–Mann theorem). Since
+     averaging kernels make the constraint operator non-expansive (fact 1), this is the principled
+     fix and is cheap — it only changes the update rule, not the SOCP. This is the single most
+     defensible recommendation.
+  2. **Anderson acceleration** over the refreeze fixed-point map to damp chatter and accelerate
+     the benign regime; falls back to Picard if the mixing is rejected.
+  3. **Treat the shaping constraint via SLP/SCvx instead of frozen-time refreeze** for the chains
+     that fail to converge — linearize the t̄-dependence of W once per outer iteration (a Taylor
+     cut on t̄_i − t̄_j w.r.t. b̄) and add it as a cut, rather than fully re-freezing. This converts
+     the discontinuous "recompute which kernel piece each sample falls in" into a smooth local
+     model and is the same architecture already endorsed for the jerk relaxation
+     (Lee 2024 SLP / SCvx, arXiv:2404.16826), so it reuses machinery.
+  4. **Detect the support-spans-a-stop geometry up front** (h > chain time length) and split the
+     window at stop boundaries (zero-pad past the stop, since a full stop genuinely decouples the
+     two chains' shaping) rather than letting the kernel reach across. This removes the primary
+     counterexample class structurally.
+
+### Sources
+
+- https://arxiv.org/pdf/1707.07239 — Pham, TOPP-RA — retrieved 2026-06-12 — finite-N
+  non-monotonicity of the maximal-transition map; basis for the chatter counterexample.
+- https://www.sciencedirect.com/science/article/pii/S0005109824003583 — Consolini-Locatelli, "Is
+  time-optimal speed planning under jerk constraints a convex problem?" — retrieved 2026-06-12 —
+  non-convexity of velocity-coupled constraints; context for why no single convex solve fixes it.
+- https://arxiv.org/pdf/1312.6533 — Pham, general TOPP implementation — retrieved 2026-06-12 —
+  robustness/failure-mode framing.
+- https://arxiv.org/pdf/2312.02944 — alternating peak-optimization (fix segment times, optimize
+  coefficients, then update times) — retrieved 2026-06-12 — closest published alternating-time
+  scheme; uses damped gradient updates on the time variable, not raw Picard refreeze.
+- https://arxiv.org/abs/2404.16826 — Successive Convexification with continuous-time constraint
+  satisfaction — retrieved 2026-06-12 — basis for the SCvx-cut fallback (3).
+- https://www.semanticscholar.org/paper/Time-Optimal-Path-Following-for-Robots-With-Using-Debrouwere-Loock/5dfe332771b4fa75f46a399ddf1242fa57586901
+  — Debrouwere et al., convex-concave TOPP via SCP — retrieved 2026-06-12 — velocity-dependent
+  constraints destroy convexity; SCP (not Picard) is the published remedy.
+
+### Caveats / unchecked assumptions
+
+- I did not see kalico's exact constraint-row algebra (per the verifier rule against reading
+  source). The sign analysis in fact (3)/(counterexample 1) assumes the cap is
+  |r|·‖W·(axis velocity)‖ ≤ const with W an averaging operator; if the actual rows have a
+  different sign structure the "negative feedback" argument may strengthen or weaken.
+- The Krasnoselskii–Mann argument requires T non-expansive on a *convex* domain and the
+  shaped-constraint operator non-expansive. The latter holds for averaging kernels in the t̄-frozen
+  step; whether the *composed* map (including the SOCP solve selection) is non-expansive is not
+  proven here — it is the natural next verification target.
+- No numerical reproduction was run. The counterexample shapes are analytically argued, not
+  simulated. A fixture (h > chain-time short move between two stops) would confirm divergence
+  empirically and is the recommended follow-up.
+- "Converges" was read as "the Picard refreeze iterate settles within the 8-cap." If the intended
+  meaning is "a fixed point exists" (weaker), that is more defensible — Brouwer gives existence on
+  the compact feasible set — but existence of a fixed point does not imply Picard reaches it.

--- a/docs/superpowers/plans/2026-06-12-per-axis-emission-chain.md
+++ b/docs/superpowers/plans/2026-06-12-per-axis-emission-chain.md
@@ -1,0 +1,506 @@
+# Per-Axis Emission Chain Implementation Plan (Plan 4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every axis runs the same emission chain — input track → post-processor chain → fit — with the follower's input track built by odometer quadrature over the followed axes' realized curves; `[post_processor]` config objects unify shaper kernels and linear pressure advance with runtime-tunable parameters; the live-path `ExtrusionNotSupported` rejection dies and follower pieces flow down the already-existing lane 3.
+
+**Architecture:** Spec: `docs/superpowers/specs/2026-06-12-follower-axes-and-limits-design.md` §4 (post-processor abstraction, post-chain limits) and §5 (emission chain, two ledgers). `trajectory` gains a `post_processor` module (trait + `smooth_zv`/`smooth_mzv`/`linear_pressure_advance` types, per-axis compiled chains) and an `odometer` module (Gauss–Legendre arc length over exact polynomial derivatives); `emit_shaped` becomes a two-pass per-axis loop over registry-indexed tracks (`ShapedSegment.axes: Vec<_>`). `motion-bridge` parses `[post_processor]` sections, compiles chains, generalizes `update_shaper` → `update_post_processor`, and lifts the classify rejection. klippy parses the sections, rejects `[input_shaper]`, and gains `SET_POST_PROCESSOR`.
+
+**Tech stack:** Rust (`trajectory`, `motion-bridge`, `geometry` crates), pyo3 bridge (`bridge.rs`), klippy Python (`motion_toolhead.py`, `motion_bridge.py`). Tests: `cargo nextest run` from `rust/` (never bare `cargo test`); Python via `./scripts/ci.sh py`.
+
+**PRECONDITION: Plan 3 (`docs/superpowers/plans/2026-06-12-planner-extension-follower-rows.md`) is fully landed.** Executors verify before starting: `git log --oneline | head` shows plan 3's final commit, `rg "follower_pa" rust/trajectory/src/lib.rs` hits (`ShapeBatchInput.follower_pa: [f64; temporal::MAX_AXES]`), and `cargo nextest run` from `rust/` is green. Plan 3 was in flight while this plan was written — **all code excerpts here are anchors, not gospel; anchor by symbol name and the given grep commands, never by line, and re-read every touched file before editing.**
+
+**Out of scope (later plans/deferred):** kinematics modules beyond the existing corexy special-case (plan 5); binding-constraint reporting (plan 6); windowed post-chain rows for *spatial* axes (deferred tightening, spec §6); nonlinear post-processor types; `SET_PRESSURE_ADVANCE` / `[input_shaper]` compat shims; the published `toolhead` status shim (plan 5). Mixed spatial+follower limit sets stay rejected.
+
+**Merge ordering:** this plan's branch lands only after plan 3 is merged — Task 9 (rejection lift) must never ship against a solver that doesn't constrain follower demands.
+
+**Repo rules for every task:** unit tests in separate files from tested code; no explanatory comments — name/extract instead; fail loudly (no silent fallbacks); commit after every task; no Claude/Anthropic commit trailers; `cargo fmt --all --check` before any PR push; `./scripts/ci.sh quick` green before opening/updating the PR, plus `./scripts/ci.sh py` because klippy changes.
+
+---
+
+## Design decisions this plan makes (agreed with the user 2026-06-12)
+
+1. **One abstraction, normalized execution order.** Shaper kernels and linear PA are both linear time-invariant operators (spec §4). The trait's single source of truth is `action()` returning a `PlanAction`: `Kernel(PiecewisePolynomialKernel<f64>)` or `DerivativeGain { k }` (PA = `track + k·track′`). Because linear operators commute, the emission runner normalizes any chain to: exact derivative-gain ops applied symbolically on the NURBS first, then kernel convolutions on the sampled signal, then one `fit_c2_cubic_with_bc`. Mathematically identical to declared order, computationally exact for the PA half. A future nonlinear type breaks commutativity and must bring its own runner mode — until then nothing is order-sensitive.
+
+2. **v1 chain-compilation boundary (loud).** The landed temporal API accepts per axis: one kernel (`ReplanContext.kernels` / `ShapeBatchInput.shaper`) and one PA gain (`ShapeBatchInput.follower_pa`). Therefore: a chain compiles to `CompiledChain { kernel: Option<...>, gain: f64 }`; **more than one kernel or more than one derivative-gain on a single axis is a config-load error naming the limitation** (two gains compose to a second-derivative term `k₁k₂·F″` no row family expresses; two kernels would need a composed plan window nothing builds yet). Purely additive to lift later.
+
+3. **Registry-indexed tracks.** `ShapedSegment.axes: [ScalarNurbs; 3]` becomes `Vec<ScalarNurbs<f64>>`, index = axis registry index (0..2 spatial, 3.. followers). `enqueue_segment` already guards `axis_idx >= seg.axes.len()` and `McuAxisConfig.axes` already lists per-MCU axis indices, so lane 3 dispatch is wiring, not protocol work.
+
+4. **Odometer mirrors plan 3's rows.** Realized speed is `‖v(t)‖` over the followed axes' *post-chain* tracks; follower velocity is `ratio(t)·‖v(t)‖` with `ratio(t)` piecewise per segment — exactly the solver's row definition, so plan and emission agree by construction. Distance via Gauss–Legendre over exact polynomial derivatives per Bézier piece, host f64.
+
+5. **Runtime tuning generalizes the existing path.** `Planner::update_shaper` / `PlannerMsg::UpdateShaper` (see `rust/motion-bridge/src/planner.rs`, `grep -n "fn update_shaper" rust/motion-bridge/src/planner.rs`) becomes `update_post_processor(name, param, value)`; the change lands in the planner thread's config and takes effect at the next replan — committed trajectory is never rewritten. klippy command: `SET_POST_PROCESSOR NAME=<instance> <PARAM>=<value>`.
+
+6. **Two ledgers need no new machinery.** Nominal: klippy's existing absolute→delta normalization (plan 2) is untouched. Physical: once lane 3 flows, `HistoryStore` (`rust/motion-bridge/src/motion_history.rs`) records follower pieces per `AxisKey` like any axis; the physical endpoint is its per-axis endpoint. Plan 4 adds tests, not surface.
+
+7. **Follower-only moves** (`CubicSegment.virtual_path_mm: Some(len)`): the follower track comes straight from the plan — `track = start + ratio × s(t)` with `s(t)` the planned path progress; no odometer (the spatial curve is identically zero). This retires `ShapeError::VirtualPathUnrouted`.
+
+---
+
+## Task 1: `trajectory::post_processor` — trait, types, compiled chains
+
+**Files:**
+- Create: `rust/trajectory/src/post_processor.rs`
+- Create: `rust/trajectory/src/post_processor/tests.rs`
+- Modify: `rust/trajectory/src/lib.rs` (declare module, re-export)
+
+- [ ] **Step 1: Write failing tests** in `post_processor/tests.rs`:
+
+```rust
+use super::*;
+
+fn pa(k: f64) -> PostProcessorInstance {
+    PostProcessorInstance::new("pa", PostProcessorType::LinearPressureAdvance { k })
+}
+fn zv(hz: f64) -> PostProcessorInstance {
+    PostProcessorInstance::new("is", PostProcessorType::SmoothZv { frequency_hz: hz })
+}
+
+#[test]
+fn compile_empty_chain_is_identity() {
+    let c = CompiledChain::compile(&[]).unwrap();
+    assert!(c.kernel.is_none());
+    assert_eq!(c.gain, 0.0);
+}
+
+#[test]
+fn compile_kernel_plus_gain() {
+    let c = CompiledChain::compile(&[zv(50.0), pa(0.04)]).unwrap();
+    assert!(c.kernel.is_some());
+    assert_eq!(c.gain, 0.04);
+}
+
+#[test]
+fn compile_order_irrelevant_for_linear_ops() {
+    let a = CompiledChain::compile(&[zv(50.0), pa(0.04)]).unwrap();
+    let b = CompiledChain::compile(&[pa(0.04), zv(50.0)]).unwrap();
+    assert_eq!(a.gain, b.gain);
+    assert_eq!(a.kernel.is_some(), b.kernel.is_some());
+}
+
+#[test]
+fn compile_two_kernels_rejected() {
+    let err = CompiledChain::compile(&[zv(50.0), zv(40.0)]).unwrap_err();
+    assert!(matches!(err, PostProcessorError::UnsupportedComposition { .. }));
+}
+
+#[test]
+fn compile_two_gains_rejected() {
+    let err = CompiledChain::compile(&[pa(0.04), pa(0.01)]).unwrap_err();
+    assert!(matches!(err, PostProcessorError::UnsupportedComposition { .. }));
+}
+
+#[test]
+fn set_param_updates_gain() {
+    let mut inst = pa(0.04);
+    inst.set_param("k", 0.06).unwrap();
+    let c = CompiledChain::compile(std::slice::from_ref(&inst)).unwrap();
+    assert_eq!(c.gain, 0.06);
+}
+
+#[test]
+fn set_param_unknown_key_fails() {
+    let mut inst = zv(50.0);
+    assert!(inst.set_param("k", 1.0).is_err());
+}
+
+fn t_squared_cubic() -> nurbs::ScalarNurbs<f64> {
+    // t² degree-elevated to a cubic on [0,1]: Bernstein control points [0, 0, 1/3, 1].
+    nurbs::ScalarNurbs::try_new(
+        3,
+        vec![0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+        vec![0.0, 0.0, 1.0 / 3.0, 1.0],
+    )
+    .unwrap()
+}
+
+#[test]
+fn derivative_gain_applied_exactly_on_nurbs() {
+    // PA k=0.5 on track(t)=t² ⇒ out(t) = t² + 0.5·2t = t² + t.
+    let out = apply_derivative_gain(&t_squared_cubic(), 0.5);
+    for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
+        assert!((nurbs::eval::eval(&out, t) - (t * t + t)).abs() < 1e-12);
+    }
+}
+```
+
+(If `ScalarNurbs::try_new` is spelled differently, match the constructor used in `rust/trajectory/src/beta.rs`'s `constant_cubic_nurbs`.)
+
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p trajectory -E 'test(post_processor)'` → FAIL (module missing)
+
+- [ ] **Step 3: Implement** `post_processor.rs`:
+
+```rust
+use nurbs::algebra::PiecewisePolynomialKernel;
+use nurbs::ScalarNurbs;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PostProcessorType {
+    SmoothZv { frequency_hz: f64 },
+    SmoothMzv { frequency_hz: f64 },
+    LinearPressureAdvance { k: f64 },
+}
+
+#[derive(Debug, Clone)]
+pub struct PostProcessorInstance {
+    name: String,
+    ty: PostProcessorType,
+}
+
+#[derive(Debug, Clone)]
+pub enum PlanAction {
+    Kernel(PiecewisePolynomialKernel<f64>),
+    DerivativeGain { k: f64 },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CompiledChain {
+    pub kernel: Option<PiecewisePolynomialKernel<f64>>,
+    pub gain: f64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PostProcessorError {
+    #[error("post_processor '{name}': unknown parameter '{key}'")]
+    UnknownParam { name: String, key: String },
+    #[error(
+        "axis chain unsupported: {detail}. v1 allows at most one kernel and one \
+         derivative-gain post-processor per axis"
+    )]
+    UnsupportedComposition { detail: String },
+}
+
+impl PostProcessorInstance {
+    pub fn new(name: &str, ty: PostProcessorType) -> Self { /* ... */ }
+    pub fn name(&self) -> &str { /* ... */ }
+    pub fn action(&self) -> PlanAction {
+        // SmoothZv/SmoothMzv → PlanAction::Kernel via the existing builders in
+        // rust/trajectory/src/kernel.rs (grep -n "smooth_zv\|0.8025" rust/trajectory/src/kernel.rs);
+        // LinearPressureAdvance → DerivativeGain
+    }
+    pub fn set_param(&mut self, key: &str, value: f64) -> Result<(), PostProcessorError> {
+        // "frequency_hz" for kernel types, "k" for PA; anything else → UnknownParam
+    }
+}
+
+impl CompiledChain {
+    pub fn compile(chain: &[PostProcessorInstance]) -> Result<Self, PostProcessorError> {
+        // fold actions; second kernel or second gain → UnsupportedComposition
+    }
+}
+
+pub fn apply_derivative_gain(track: &ScalarNurbs<f64>, k: f64) -> ScalarNurbs<f64> {
+    // exact: track + k·derivative(track), via nurbs::eval::derivative,
+    // nurbs::algebra::scalar_multiply, nurbs::algebra::add_with_knot_union.
+    // NOTE: derivative drops degree 3→2; degree-elevate back to 3 before the add
+    // (grep -rn "degree_elev\|elevate" rust/nurbs/src/) so the result stays uniform-cubic.
+}
+```
+
+Move/reuse the frequency→kernel construction from `rust/trajectory/src/kernel.rs` rather than duplicating constants. In `lib.rs`: `pub mod post_processor;` and re-export `PostProcessorInstance, PostProcessorType, CompiledChain, PostProcessorError`.
+
+- [ ] **Step 4: Run** — `cargo nextest run -p trajectory` → PASS
+- [ ] **Step 5: Commit** — `feat(trajectory): post-processor trait, linear PA + kernel types, compiled per-axis chains`
+
+---
+
+## Task 2: `trajectory::odometer` — realized arc length and follower track
+
+**Files:**
+- Create: `rust/trajectory/src/odometer.rs`
+- Create: `rust/trajectory/src/odometer/tests.rs`
+- Modify: `rust/trajectory/src/lib.rs` (declare module)
+
+- [ ] **Step 1: Write failing tests:**
+
+```rust
+use super::*;
+
+fn linear_cubic(p0: f64, p1: f64, t0: f64, t1: f64) -> nurbs::ScalarNurbs<f64> {
+    // straight line as a cubic: equally spaced Bernstein control points on [t0, t1]
+    nurbs::ScalarNurbs::try_new(
+        3,
+        vec![t0, t0, t0, t0, t1, t1, t1, t1],
+        vec![p0, p0 + (p1 - p0) / 3.0, p0 + 2.0 * (p1 - p0) / 3.0, p1],
+    )
+    .unwrap()
+}
+fn constant_cubic(v: f64, t0: f64, t1: f64) -> nurbs::ScalarNurbs<f64> {
+    linear_cubic(v, v, t0, t1)
+}
+
+#[test]
+fn straight_line_distance_is_exact() {
+    // x(t)=120t, y(t)=50t, z(t)=0 on [0,2] as cubics ⇒ distance(t) = 130t.
+    let axes = vec![linear_cubic(0.0, 240.0, 0.0, 2.0), linear_cubic(0.0, 100.0, 0.0, 2.0),
+                    constant_cubic(0.0, 0.0, 2.0)];
+    let odo = Odometer::build(&axes, 0.0, 2.0, 64).unwrap();
+    assert!((odo.distance_at(1.0) - 130.0).abs() < 1e-9);
+    assert!((odo.distance_at(2.0) - 260.0).abs() < 1e-9);
+}
+
+#[test]
+fn curved_path_matches_dense_reference() {
+    // quarter-turn-ish Bezier in XY; reference = trapezoid over 100_000 samples of ‖v‖.
+    // assert relative error < 1e-7
+}
+
+#[test]
+fn follower_track_pays_out_ratio_times_distance() {
+    // ratio(t) piecewise: 0.05 on [0,1), 0.0 on [1,2). start=7.0.
+    // track(2.0) == 7.0 + 0.05·distance_at(1.0); track is monotone on [0,1).
+}
+
+#[test]
+fn ratio_discontinuity_lands_at_segment_boundary_sample() {
+    // boundary between ratios must be a quadrature breakpoint, not interpolated across.
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p trajectory -E 'test(odometer)'` → FAIL
+
+- [ ] **Step 3: Implement** `odometer.rs`:
+
+```rust
+pub struct Odometer { /* cumulative arc-length table: knots t_i, distance_i, per-interval GL nodes */ }
+
+impl Odometer {
+    /// axes: post-chain spatial tracks sharing one time domain [t_start, t_end].
+    /// Breakpoints = union of all axes' Bézier piece boundaries (extract via
+    /// nurbs::bezier::extract_bezier_pieces — same call enqueue_segment uses).
+    /// Per interval: 8-point Gauss–Legendre on ‖(x′,y′,z′)(t)‖ with exact
+    /// polynomial derivatives (nurbs::eval::derivative once per axis, then eval).
+    pub fn build(axes: &[ScalarNurbs<f64>], t_start: f64, t_end: f64, min_intervals: usize)
+        -> Result<Self, OdometerError>;
+    pub fn distance_at(&self, t: f64) -> f64; // monotone piecewise interpolation on the table
+}
+
+/// ratio_spans: (t_span_end, ratio) per source segment, covering [t_start, t_end] exactly —
+/// gaps or overlap are a loud OdometerError, not patched.
+pub fn follower_track(
+    odo: &Odometer,
+    start: f64,
+    ratio_spans: &[(f64, f64)],
+    t_start: f64,
+    t_end: f64,
+) -> impl Fn(f64) -> f64 + '_;
+```
+
+`follower_track` evaluates `start + Σ ratioᵢ·(distance_at(min(t, spanᵢ_end)) − distance_at(spanᵢ_start)))` — splitting at span boundaries so a ratio change never bleeds across. 8-point GL is exact for polynomials to degree 15; `‖v‖` is a square root of a degree-4 polynomial, not itself polynomial, hence the dense-reference test rather than an exactness claim.
+
+- [ ] **Step 4: Run** — `cargo nextest run -p trajectory` → PASS
+- [ ] **Step 5: Commit** — `feat(trajectory): odometer quadrature over realized spatial tracks`
+
+---
+
+## Task 3: `ShapedSegment.axes` goes registry-wide (`Vec`), mechanical sweep
+
+Pure representation change, no behavior: `[ScalarNurbs<f64>; 3]` → `Vec<ScalarNurbs<f64>>` (always length ≥ 3; followers appended by Task 4).
+
+**Files:**
+- Modify: `rust/trajectory/src/lib.rs` (`ShapedSegment`)
+- Modify: every consumer — find them all: `rg -ln "ShapedSegment" rust/` (expect: `trajectory/src/{emit_shaped,beta,streaming/*}`, `motion-bridge/src/{planner,enqueue,dispatch}` + tests)
+
+- [ ] **Step 1: Write failing test** (in `rust/trajectory/src/tests.rs`): construct a `ShapedSegment` with 4 axes; assert `seg.axes.len() == 4`. → does not compile against the array type.
+- [ ] **Step 2: Change the field, chase compiler errors.** `emit_shaped` builds `vec![x, y, z]`; `enqueue_segment`'s existing `axis_idx >= seg.axes.len()` guard and corexy indexing (`rust/motion-bridge/src/enqueue.rs`) survive unchanged. No site may silently truncate or pad — where a consumer assumed exactly 3, keep the assumption as an explicit `assert!`/error if it is real, otherwise generalize.
+- [ ] **Step 3: Run** — `cargo nextest run` (workspace) → PASS, zero behavior change.
+- [ ] **Step 4: Commit** — `refactor(trajectory): ShapedSegment carries registry-indexed track vector`
+
+---
+
+## Task 4: per-axis emission chain in `emit_shaped` (two passes)
+
+The core. `emit_shaped_with_left_bc` (`rust/trajectory/src/emit_shaped.rs`) becomes a two-pass loop driven by per-axis `CompiledChain`s instead of bare kernels.
+
+**Files:**
+- Modify: `rust/trajectory/src/emit_shaped.rs`
+- Modify: `rust/trajectory/src/emit_shaped/tests.rs`
+- Modify: `rust/trajectory/src/lib.rs` (`ShapeBatchInput` gains `chains`; `ShapeError::VirtualPathUnrouted` deleted)
+
+New signature (kernels parameter replaced; `FollowerSpec` tells pass two what to build):
+
+```rust
+pub struct AxisChainSet {
+    /// index = axis registry index; spatial 0..3 then followers.
+    pub chains: Vec<CompiledChain>,
+    /// (follower_axis_index, followed_axis_indices) — from AxisRegistry.follows.
+    pub followers: Vec<(usize, Vec<usize>)>,
+}
+
+pub fn emit_shaped_with_left_bc(
+    planned: &[FittedSegment],
+    meta: &[EmitSegmentMeta],
+    chains: &AxisChainSet,
+    history: &PerAxisHistory<'_>,
+    follower_start: &[f64],          // physical start position per follower axis
+    batch_t_start: f64,
+    batch_t_end: f64,
+    first_seg_left_bc: &[Option<f64>],
+) -> Result<Vec<ShapedSegment>, ShapeError>
+```
+
+**Pass one** (axes with no `follows` entry): exactly today's per-axis body — constant short-circuit, kernel convolution via `pad_segment_axis_with_history` + `ShapedSignal`, or passthrough refit — except the kernel comes from `chains.chains[axis].kernel` and a nonzero `gain` applies `apply_derivative_gain` to the *fitted input* before convolution (decision 1's normalized order: gain symbolically first, kernel on samples second).
+
+**Pass two** (followers, after pass one finished the axes they follow): per batch, build one `Odometer` over the followed axes' pass-one output curves (knot-unioned time domain across segments); per segment, assemble `ratio_spans` from `meta[seg].followers` (a follower absent from a segment's demands has ratio 0 for that span); the input track is `follower_track(...)`; then the follower's own chain: gain applies as `track(t) + k·track′(t)` where `track′(t) = ratio(t)·‖v(t)‖` is available in closed form from the odometer integrand — no numerical differentiation; kernel (rare) convolves the sampled closure; finally `fit_c2_cubic_with_bc` with the same C1 left-BC threading the spatial axes use (`prev_right_bc` per axis, now sized `n_axes`).
+
+**Virtual-path segments** (`FittedSegment` whose source had `virtual_path_mm`): pass one emits constant tracks for spatial axes; pass two uses planned path progress `s(t)` directly — the fitted "spatial" curve is zero-displacement, so thread `s(t)` through `EmitSegmentMeta` (add `virtual_path: Option<f64>` plus whatever the plan-velocity layer already retains for it — `rg -n "virtual_path" rust/trajectory/src/` for plan 3's plumbing) and pay out `start + ratio·s(t)`. Delete `ShapeError::VirtualPathUnrouted` and route the streaming-path rejection (grep its raise site) into this path.
+
+- [ ] **Step 1: Write failing tests:**
+
+```rust
+#[test]
+fn passthrough_chains_reproduce_legacy_output_bitwise() {
+    // Build a 3-segment batch; run old-style (no chains, no followers) and assert each
+    // spatial axis's control points and knots are bit-identical to a golden capture
+    // taken at the previous commit. THE regression gate for approach A.
+}
+
+#[test]
+fn follower_track_integral_matches_ratio_times_arclength() {
+    // one straight XY segment, follower ratio 0.05, passthrough everywhere:
+    // follower end == start + 0.05·segment_length (1e-9); C1 at segment seams.
+}
+
+#[test]
+fn follower_samples_post_kernel_path() {
+    // 90° corner, smooth_mzv on x and y: follower end < start + ratio·nominal_length
+    // (the kernel shortcuts the corner); equality on a straight line.
+}
+
+#[test]
+fn pa_gain_boosts_follower_during_accel() {
+    // gain k on follower axis: emitted follower velocity at mid-accel ≈ ratio·ṡ·(1) + k·ratio·s̈
+    // sampled via finite difference of the fitted track against the plan profile (1e-3 rel).
+}
+
+#[test]
+fn follower_only_move_emits_planned_track() {
+    // virtual_path segment: spatial tracks constant, follower track == start + ratio·s(t).
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p trajectory -E 'test(emit_shaped)'` → FAIL
+- [ ] **Step 3: Implement** as specified above. Keep `SMOOTH_FIT_TOLERANCE_MM` for followers too.
+- [ ] **Step 4: Run** — `cargo nextest run -p trajectory` → PASS including the bitwise gate.
+- [ ] **Step 5: Commit** — `feat(trajectory): two-pass per-axis emission chain with odometer follower tracks`
+
+---
+
+## Task 5: streaming integration — chains and follower history through replan
+
+**Files:**
+- Modify: `rust/trajectory/src/streaming/mod.rs` (`ReplanContext` gains `chains: AxisChainSet`; `EmitContext`/`AxisShaperQueue` sized by `n_axes`), `streaming/state.rs`, `streaming/emit.rs` (freeze-zone `max_h` over **all** axes' kernels incl. followers; `pending_freeze`/history trimming per axis generalizes — `PerAxisHistory` already carries 4 lanes, widen to `n_axes`), `streaming/tests.rs`
+- Modify: `rust/trajectory/src/beta.rs` call sites (`rg -n "emit_shaped" rust/trajectory/src/`)
+
+- [ ] **Step 1: Write failing test** in `streaming/tests.rs`: streaming replan over an extruding two-batch sequence emits follower pieces whose value at the batch seam is continuous (1e-9) and whose final value equals `start + Σ ratio·realized_distance`; a second test: follower history at the seam feeds pass two (no jump when the freeze zone splits a segment).
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p trajectory -E 'test(streaming)'` → FAIL
+- [ ] **Step 3: Implement.** Thread `chains` from `ReplanContext` into both `plan_velocity` input assembly (the solver side already takes `follower_pa` + `shaper` — populate them **from the same `CompiledChain`s**, deleting any separate plumbing so plan and emission cannot disagree) and the Task-4 emission call. Track follower physical start across replans (the `follower_start` argument) in `ShaperState` next to where per-axis emit history already lives.
+- [ ] **Step 4: Run** — `cargo nextest run -p trajectory` → PASS
+- [ ] **Step 5: Commit** — `feat(trajectory): streaming replan threads post-processor chains and follower state`
+
+---
+
+## Task 6: motion-bridge config — `[post_processor]` sections, chain compilation, planner init
+
+**Files:**
+- Modify: `rust/motion-bridge/src/config.rs` (+ `config/tests.rs`): `AxisDecl` gains `post_processors: Vec<String>`; new `PostProcessorDecl { name, ty: String, params: Vec<(String, f64)> }`; `AxisRegistry::try_new` (or a sibling `compile_chains`) validates — every referenced name declared, unknown `type:` rejected (`UnsupportedKind` exists, repoint its message at `[post_processor]`), `CompiledChain::compile` errors surfaced verbatim at load
+- Modify: `rust/motion-bridge/src/planner.rs`: `PlannerConfig` drops `shaper: ShaperConfig` for `chains: AxisChainSet` + named instances `Vec<PostProcessorInstance>`; `build_replan_context` / `shaper_config_to_plan_shapers` / `emit_kernels` derive from chains (`grep -n "shaper" rust/motion-bridge/src/planner.rs`); `update_shaper`/`PlannerMsg::UpdateShaper` → `update_post_processor(name: &str, key: &str, value: f64)` / `PlannerMsg::UpdatePostProcessor` — handler mutates the named instance, recompiles chains, rebuilds the replan context **for subsequent replans only**; unknown name/key → loud `PlannerError`
+- Modify: `rust/motion-bridge/src/bridge.rs`: pyo3 `init_planner` (grep `fn init_planner`) replaces `shaper_type_x/freq_x/y` args with `post_processors: Vec<(String, String, Vec<(String, f64)>)>` and per-axis `post_processors` lists arriving inside the existing `axes` arg; `update_shaper` pyfunction → `update_post_processor(name, key, value)`
+
+- [ ] **Step 1: Write failing tests** in `config/tests.rs` (axis with unknown chain name; duplicate `[post_processor]` name; two kernels on one axis → `UnsupportedComposition` text mentions "v1"; happy path compiles `is`+`pa` on axis `e`).
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p motion-bridge -E 'test(post_processor)'` → FAIL
+- [ ] **Step 3: Implement**, deleting `ShaperConfig`/`AxisShaper` from `trajectory/src/lib.rs` once nothing references them (`rg -ln "ShaperConfig|AxisShaper" rust/` must come back empty outside git history).
+- [ ] **Step 4: Run** — `cargo nextest run` (workspace) → PASS
+- [ ] **Step 5: Commit** — `feat(motion-bridge): [post_processor] chains replace ShaperConfig; runtime update_post_processor`
+
+---
+
+## Task 7: klippy — sections, rejection, `SET_POST_PROCESSOR`
+
+**Files:**
+- Modify: `klippy/motion_toolhead.py` — next to the existing `[axis]`/`[limit]` parsing (`grep -n "axis_sections\|limit_sections" klippy/motion_toolhead.py`): parse `[post_processor <name>]` (`type:` + numeric params, pass through verbatim — klippy validates nothing the bridge already validates); axis sections gain `post_processors:`; `_init_planner` ships both through the new `init_planner` signature
+- Modify: `klippy/motion_bridge.py` — `init_planner` wrapper matches Task 6's signature; `update_shaper` wrapper → `update_post_processor`
+- Modify/Delete: `klippy/extras/input_shaper.py` — the section joins the rejected-legacy list: loading `[input_shaper]` raises a config error pointing at `[post_processor]` (follow the existing legacy-rejection pattern, `grep -n "is not supported" klippy/motion_toolhead.py`)
+- Add: `SET_POST_PROCESSOR NAME=<name> <PARAM>=<VALUE>` gcode command in `motion_toolhead.py` → `bridge.update_post_processor(name, param.lower(), float(value))`; errors propagate to the console verbatim
+- Modify: config fixtures — `rg -l "input_shaper" test/ config/ printer*.cfg` and the fixtures plan 2 touched (`git show cc8d5167e --stat` for the list); declare `[post_processor]` sections where shapers were configured
+- Test: extend the Python suite where `[axis]`/`[limit]` parsing is tested (`rg -ln "axis_sections\|limit" test/klippy/ klippy/test* 2>/dev/null` — anchor to wherever plan 2's config tests live)
+
+- [ ] **Step 1: Write failing Python tests** (same file as plan 2's section-parsing tests): missing-type `[post_processor]` fails; `[input_shaper]` rejected with message naming `[post_processor]`; axis referencing undeclared post-processor fails at connect; happy path reaches `init_planner` with the sections.
+- [ ] **Step 2: Run to verify failure** — `./scripts/ci.sh py` → FAIL on the new tests
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run** — `./scripts/ci.sh py` → PASS
+- [ ] **Step 5: Commit** — `feat(klippy): [post_processor] sections + SET_POST_PROCESSOR; [input_shaper] rejected`
+
+---
+
+## Task 8: runtime tuning end-to-end test
+
+**Files:**
+- Modify: `rust/motion-bridge/src/planner/tests.rs` (or the integration-test home `rust/tests/` — match where planner-thread tests live: `rg -ln "update_shaper" rust/motion-bridge/src/planner/tests.rs rust/tests/`)
+
+- [ ] **Step 1: Write failing test:** start a planner with `pa` gain 0.0; submit extruding batch A; `update_post_processor("pa", "k", 0.05)`; submit batch B. Assert batch A's emitted follower pieces show no PA boost and batch B's do (compare follower velocity at mid-accel between batches); assert nothing already dispatched was re-emitted (piece counts/ids stable). Unknown name errors loudly.
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p motion-bridge -E 'test(update_post_processor)'` → FAIL
+- [ ] **Step 3: Implement** whatever plumbing gaps the test exposes (expected: none beyond Task 6).
+- [ ] **Step 4: Run** — `cargo nextest run -p motion-bridge` → PASS
+- [ ] **Step 5: Commit** — `test(motion-bridge): runtime post-processor tuning applies to new plans only`
+
+---
+
+## Task 9: lift `ExtrusionNotSupported`; follower demands and virtual paths in classify
+
+**Files:**
+- Modify: `rust/motion-bridge/src/classify.rs` + `classify/tests.rs`
+- Modify: `rust/motion-bridge/src/bridge.rs` `submit_move` (grep `fn submit_move`) — resolve the follower axis index from the planner's `AxisRegistry` instead of assuming; `de ≠ 0` with no declared follower axis is a loud error (the registry rule, not a silent drop)
+
+New classify contract:
+
+```rust
+pub fn classify_and_build(
+    start: [f64; 3],
+    dx: f64, dy: f64, dz: f64,
+    followers: &[(usize, f64)],   // (axis_index, delta) — resolved by the caller from the registry
+    feedrate_mm_s: f64,
+) -> Result<ClassifiedMove, ClassifyError>
+```
+
+- spatial displacement present → ratio = `delta / distance_3d` per follower; `CubicSegment::try_new(xyz, followers, ...)` with `virtual_path_mm: None`
+- no spatial displacement, follower delta present → virtual path: zero-displacement curve, `virtual_path_mm: Some(max |delta|)`, ratio = `delta / virtual_path` (spec §2's fallback line) — `MoveClass` gains `FollowerOnly` (or dies entirely if, after grepping consumers, nothing branches on it: `rg -n "MoveClass" rust/ klippy/`)
+- no displacement at all → `ZeroDisplacement` unchanged
+- `ClassifyError::ExtrusionNotSupported` deleted; the enum variant's absence must break every reference (`rg -n "ExtrusionNotSupported" rust/ klippy/` → empty after)
+
+- [ ] **Step 1: Write failing tests** (extruding XY move carries ratio `de/dist`; retract-with-hop carries negative ratio over 3D length; follower-only move builds virtual path; `de≠0` without follower axis errors).
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p motion-bridge -E 'test(classify)'` → FAIL
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run** — `cargo nextest run` (workspace) → PASS
+- [ ] **Step 5: Commit** — `feat(motion-bridge): extruding and follower-only moves flow; ExtrusionNotSupported dies`
+
+---
+
+## Task 10: lane-3 end-to-end + two-ledger assertions
+
+**Files:**
+- Modify: the end-to-end home `rust/runtime/tests/e2e_trajectory.rs` or `rust/tests/` (match existing extrusionless e2e idioms: `rg -ln "submit_move" rust/runtime/tests/ rust/tests/`)
+- Modify: `rust/motion-bridge/src/motion_history/tests.rs`
+
+- [ ] **Step 1: Write failing tests:**
+  - e2e: configured follower axis `e` follows x,y,z with a `pa` chain; submit a corner print path; assert `PushPieces` arrive with `axis_idx == 3`, the follower lane's `HistoryStore` endpoint equals the odometer prediction, and with a smoothing kernel on x/y the physical endpoint is **less** than the nominal ledger total (the accepted shortfall, spec §5) — assert the inequality and that nobody "corrects" it.
+  - history: `state_at_clock` on the follower axis mid-move returns position between start and end, monotone for positive ratio.
+- [ ] **Step 2: Run to verify failure** — `cargo nextest run -E 'test(e2e) and test(follower)'` → FAIL
+- [ ] **Step 3: Implement** remaining wiring gaps (expected: MCU axis config for lane 3 in test harness fixtures — `rg -n "axes" rust/motion-bridge/src/test_support.rs`).
+- [ ] **Step 4: Run** — `cargo nextest run` → PASS
+- [ ] **Step 5: Commit** — `test: follower lane end-to-end; physical-vs-nominal ledger shortfall asserted`
+
+---
+
+## Task 11: offline validation + gates
+
+- [ ] **Step 1:** `./scripts/ci.sh quick` → green; `./scripts/ci.sh py` → green; `cargo test --doc` if any doc examples were touched.
+- [ ] **Step 2:** klipper-sim sanity (see the `kalico-sim` skill): run a real sliced G-code file (G5-converted via `compat`) through the simulator on this branch; confirm follower lane pieces appear and total extrusion ≈ slicer total minus shaping shortfall. Record numbers in the PR description.
+- [ ] **Step 3:** `cargo fmt --all --check`, then commit any stragglers and open/update the PR (base: `sota-motion`).
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §5 chain stages map: Task 4 (input track + chain + fit), Task 2 (odometer), Task 1+6 (post-processor registry), Task 9 (follower-only fallback line), Task 10 (two ledgers, MCU untouched — no MCU files appear anywhere in this plan).
+- Plan/emission single-source rule (decision 5 of plan 3 + decision 1 here): Task 5 explicitly deletes separate `follower_pa`/`shaper` plumbing in favor of deriving both from `CompiledChain`.
+- `ShaperConfig`/`AxisShaper`/`update_shaper`/`ExtrusionNotSupported`/`VirtualPathUnrouted` all have explicit deletion steps with grep-empty checks.

--- a/docs/superpowers/plans/2026-06-12-planner-extension-follower-rows.md
+++ b/docs/superpowers/plans/2026-06-12-planner-extension-follower-rows.md
@@ -80,7 +80,7 @@ Axis indices 0–2 stay the spatial frame; 3..MAX_AXES are follower axes. A set 
 - Modify: `rust/temporal/src/limits/tests.rs`
 - Modify: every `Limits::try_new` / `AxisSet::all` caller — `grep -rn "Limits::try_new\|AxisSet::all" rust/`
 
-- [ ] **Step 1: Write failing tests** (append to `limits/tests.rs`):
+- [x] **Step 1: Write failing tests** (append to `limits/tests.rs`):
 
 ```rust
 #[test]
@@ -125,9 +125,9 @@ fn spatial_helpers_reject_follower_sets() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(limits)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(limits)'` → FAIL
 
-- [ ] **Step 3: Implement.** In `limits.rs`:
+- [x] **Step 3: Implement.** In `limits.rs`:
   - `pub const N_SPATIAL: usize = 3;` `pub const MAX_AXES: usize = 8;` (the `AxisSet(u8)` bitmask already holds 8).
   - `AxisSet`: add `pub fn is_spatial(self) -> bool { self.0 < (1 << N_SPATIAL) }` and `pub fn is_follower(self) -> bool { self.0 >> N_SPATIAL != 0 && self.0 & ((1 << N_SPATIAL) - 1) == 0 }`; rename `AxisSet::all()` → `AxisSet::spatial()` (it means "all spatial" everywhere it is used — fix callers, `grep -rn "AxisSet::all" rust/`).
   - `Limits::try_new(sets: &[LimitSet], n_axes: usize)`: assert `N_SPATIAL <= n_axes && n_axes <= MAX_AXES`; reject any set that is neither `is_spatial` nor `is_follower` with new `LimitsError::MixedSpatialFollower { set: usize }`; run the existing per-derivative coverage loop over `0..n_axes` instead of `0..MAX_AXES`. Store `n_axes: u8` on `Limits` with a getter.
@@ -137,8 +137,8 @@ fn spatial_helpers_reject_follower_sets() {
   - `scale_limits` in `scaling.rs` rebuilds via `try_new(_, limits.n_axes())` — port.
   - Every existing `try_new` caller gains `, 3` (or `N_SPATIAL`) — mechanical, `grep -rn "Limits::try_new" rust/`.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal` → PASS (zero behavioral change for 3-axis limits).
-- [ ] **Step 5: Commit** — `feat(temporal): follower axes in the limit axis space; mixed sets rejected`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal` → PASS (zero behavioral change for 3-axis limits).
+- [x] **Step 5: Commit** — `feat(temporal): follower axes in the limit axis space; mixed sets rejected`
 
 ---
 
@@ -152,7 +152,7 @@ fn spatial_helpers_reject_follower_sets() {
 - Modify: callers — `grep -rn "SegmentInput {" rust/`
 - Test: `rust/temporal/src/topp/chain/tests.rs` (or wherever `from_segment_grids` tests live — `grep -rln "from_segment_grids" rust/temporal/`)
 
-- [ ] **Step 1: Write failing test** — a two-segment chain built from inputs with different follower ratios exposes them per grid point:
+- [x] **Step 1: Write failing test** — a two-segment chain built from inputs with different follower ratios exposes them per grid point:
 
 ```rust
 #[test]
@@ -167,9 +167,9 @@ fn chain_carries_per_segment_follower_demands() {
 
 (Flesh out with the existing harness idioms in the chain tests — grid construction is already demonstrated there.)
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(follower_demands)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(follower_demands)'` → FAIL
 
-- [ ] **Step 3: Implement.** In `lib.rs`:
+- [x] **Step 3: Implement.** In `lib.rs`:
 
 ```rust
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -182,8 +182,8 @@ pub struct FollowerDemand {
 
 `SegmentInput` gains `pub followers: &'a [FollowerDemand]`. `ChainGrid` gains `pub followers: Vec<Vec<FollowerDemand>>` indexed like `limits` (one entry per limits_idx / segment), plus `pub fn followers_at(&self, i: usize) -> &[FollowerDemand]` mirroring `limits_at`. `from_segment_grids` threads the slices through; the single-segment constructors take `&[FollowerDemand]` (existing callers pass `&[]`). Validate at chain construction: every `axis` must be `>= N_SPATIAL`, `< limits.n_axes()`, `ratio` finite, `pa_k` finite and `>= 0.0` — violation is a panic-free constructor error (fail loudly, new `ChainError` variant or extend the existing one — `grep -n "enum.*Error" rust/temporal/src/topp/chain.rs`).
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
-- [ ] **Step 5: Commit** — `feat(temporal): segments carry follower demands into the chain`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
+- [x] **Step 5: Commit** — `feat(temporal): segments carry follower demands into the chain`
 
 ---
 
@@ -195,7 +195,7 @@ The reusable core: time map from an iterate, kernel sampling, history folding, i
 - Create: `rust/temporal/src/topp/window.rs` (+ `mod window;` in `topp/mod.rs`)
 - Create: `rust/temporal/src/topp/window/tests.rs`
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```rust
 use super::*;
@@ -261,9 +261,9 @@ fn right_edge_extends_with_terminal_hold() {
 
 (`test_bell_kernel` builds the same `w(t) = c·(h²−t²)²` kernel as `trajectory/src/kernel.rs::build_smooth_zv_kernel` — copy the five coefficients into the test helper; `temporal` already depends on `nurbs`, which owns `PiecewisePolynomialKernel`.)
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(window)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(window)'` → FAIL
 
-- [ ] **Step 3: Implement** in `window.rs`:
+- [x] **Step 3: Implement** in `window.rs`:
 
 ```rust
 pub fn frozen_time_map(b: &[f64], h_intervals: &[f64]) -> Vec<f64> {
@@ -301,8 +301,8 @@ pub struct WindowHistory {
 
 Resolve the exact shape during implementation — the tests above pin the semantics (constant reproduction at interior, left edge with history, right edge with terminal hold); adjust the test helper calls to the final signature, never weaken the assertions.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal -E 'test(window)'` → PASS
-- [ ] **Step 5: Commit** — `feat(temporal): frozen-time-map window operator with history folding`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal -E 'test(window)'` → PASS
+- [x] **Step 5: Commit** — `feat(temporal): frozen-time-map window operator with history folding`
 
 ---
 
@@ -316,7 +316,7 @@ Convex case first: `|r|·√b ≤ v_max` is a `b`-cap row; `|r|·|a_i| ≤ a_max
 - Modify: `rust/temporal/src/topp/constraints.rs` (`build_chain` calls the new emitter; find the velocity block with `grep -n "v_max" rust/temporal/src/topp/constraints.rs`)
 - Modify: `rust/temporal/src/lib.rs` / `rust/temporal/src/topp/verify.rs` (`BindingConstraint`, `ratios_at`)
 
-- [ ] **Step 1: Write failing solver-level tests** in `follower/tests.rs` (use the existing single-segment scheduling harness idioms — `grep -rn "schedule_segment_with_tolerance" rust/temporal/` for examples):
+- [x] **Step 1: Write failing solver-level tests** in `follower/tests.rs` (use the existing single-segment scheduling harness idioms — `grep -rn "schedule_segment_with_tolerance" rust/temporal/` for examples):
 
 ```rust
 #[test]
@@ -345,9 +345,9 @@ fn binding_tag_names_the_follower_set() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(follower)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(follower)'` → FAIL
 
-- [ ] **Step 3: Implement emission** in `follower.rs`:
+- [x] **Step 3: Implement emission** in `follower.rs`:
 
 ```rust
 pub(crate) fn emit_base_follower_rows(
@@ -390,8 +390,8 @@ Wire into `build_chain` next to the existing velocity family (inside the Nonneg 
 
 **verify.rs:** extend `ratios_at` inputs with the point's `&[FollowerDemand]`; for each demand and covering follower set push entries `(r·ṡ / v_max, Velocity { set })`, `(r·|s̈| / a_max, AccelNorm { set })`, `(r·|s⃛| / j_max, JerkNorm { set })`. The existing variants carry set indices already (plan 1) — no new variants needed for the base rows. `check_chain` passes `chain.followers_at(i)` through.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
-- [ ] **Step 5: Commit** — `feat(temporal): base follower velocity/accel rows with binding attribution`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
+- [x] **Step 5: Commit** — `feat(temporal): base follower velocity/accel rows with binding attribution`
 
 ---
 
@@ -404,7 +404,7 @@ Wire into `build_chain` next to the existing velocity family (inside the Nonneg 
 - Modify: `rust/temporal/src/topp/solver.rs` (`find_jerk_violators_chain`, `append_path_jerk_cut_weights` — these consume `j_path`)
 - Test: `rust/temporal/src/topp/follower/tests.rs`
 
-- [ ] **Step 1: Write failing test:**
+- [x] **Step 1: Write failing test:**
 
 ```rust
 #[test]
@@ -416,9 +416,9 @@ fn follower_jerk_cap_binds_through_the_slp() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(follower_jerk)'` → FAIL (cap ignored)
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(follower_jerk)'` → FAIL (cap ignored)
 
-- [ ] **Step 3: Implement.** Replace the scalar `j_path` with a per-point vector `j_path_at: Vec<f64>`:
+- [x] **Step 3: Implement.** Replace the scalar `j_path` with a per-point vector `j_path_at: Vec<f64>`:
 
 ```rust
 let j_path_at: Vec<f64> = (0..n)
@@ -441,8 +441,8 @@ let j_path_at: Vec<f64> = (0..n)
 
 Thread it through the bundle to `find_jerk_violators_chain` (violation test uses `j_path_at[i]`) and `append_path_jerk_cut_weights` (cut target uses the same). Where the auxiliary `t_k` rows in `build_chain` divide by `j_path`, use `j_path_at[k + 1]` (the interior point the row anchors). The all-spatial case reduces to the old scalar at every point — the existing suite must pass unchanged.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
-- [ ] **Step 5: Commit** — `feat(temporal): per-point path-jerk envelope; follower jerk caps join the SLP`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
+- [x] **Step 5: Commit** — `feat(temporal): per-point path-jerk envelope; follower jerk caps join the SLP`
 
 ---
 
@@ -455,7 +455,7 @@ Thread it through the bundle to `find_jerk_violators_chain` (violation test uses
 - Modify: stencil tests — `grep -rln "b_dd_weights" rust/temporal/` for where they live
 - Modify: `rust/temporal/src/topp/verify.rs` (expose `s_ddddot_at` for later consumers)
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```rust
 #[test]
@@ -474,9 +474,9 @@ fn s_snap_on_constant_jerk_profile() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(snap) or test(b_ddd)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(snap) or test(b_ddd)'` → FAIL
 
-- [ ] **Step 3: Implement** in `stencil.rs`: a small Fornberg weight generator
+- [x] **Step 3: Implement** in `stencil.rs`: a small Fornberg weight generator
 
 ```rust
 pub fn fornberg_weights(x0: f64, xs: &[f64], order: usize) -> Vec<Vec<f64>>
@@ -501,8 +501,8 @@ pub fn s_ddddot_at_weights(b: &[f64], a_i: f64, i: usize, s: &[f64], h_intervals
 
 Verify the existing `b_dd_weights` against `fornberg_weights` in a test (they must agree to 1e-12) — if they do, optionally collapse the old closed form onto Fornberg in a follow-up, not now.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
-- [ ] **Step 5: Commit** — `feat(temporal): path snap via Fornberg third-difference weights`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal` → PASS
+- [x] **Step 5: Commit** — `feat(temporal): path snap via Fornberg third-difference weights`
 
 ---
 
@@ -516,7 +516,7 @@ PA shifts each demand one derivative up: `|r|(ṡ + k·s̈) ≤ v_max`, `|r|(s̈
 - Modify: `rust/temporal/src/lib.rs` (`BindingConstraint` gains `PaVelocity { set }`, `PaAccel { set }`, `PaJerk { set }`), `verify.rs` (`ratios_at` PA entries — demand formulas above, `s⁗` via Task 6)
 - Test: `rust/temporal/src/topp/follower/tests.rs`
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```rust
 #[test]
@@ -546,9 +546,9 @@ fn verify_tags_pa_rows() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(pa_)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(pa_)'` → FAIL
 
-- [ ] **Step 3: Implement.**
+- [x] **Step 3: Implement.**
   - **Demand evaluation at the iterate** (shared with verify): for point `i`, `d_v = r·(√b̄ + k·ā)`, `d_a = r·(ā + k·s⃛(b̄))`, `d_j = r·(s⃛(b̄) + k·s⁗(b̄, ā))`. Ratios against the covering follower sets' caps.
   - **Violator scan** `find_follower_violators(chain, b̄, ā) -> Vec<FollowerViolator { i, set, family, ratio }>` — same shape as `find_jerk_violators_chain`, threshold `1 + SLP9_EPS_FEAS`.
   - **Cut builder**: linearize each demand at the iterate. Every term is already linearized elsewhere in the codebase — reuse the gradient pieces: `√b → b/(2√b̄) + √b̄/2`; `s⃛ → (√b̄·δb″ + b̄″·δb_i/(2√b̄))/2` expanded over the `b_dd` stencil exactly as `append_path_jerk_cut_weights` does; `s⁗` gradient over the 4-point `b_ddd` stencil plus the `a·b″/2` cross terms (gradient w.r.t. `a_i` is `b̄″/2`; w.r.t. stencil `b`s via the two weight sets). Emit two Nonneg rows (±) per violator with the same `row_scale` conditioning as `append_axis_jerk_cut_to_clarabel` — follow that function's structure literally, swapping the gradient terms.
@@ -556,8 +556,8 @@ fn verify_tags_pa_rows() {
   - **Loop placement**: extend the SLP9 outer loop's cut-collection step to also call `find_follower_violators`/`build_follower_cuts` and merge the cut lists; the existing trust-region, backtracking, target-decay, and divergence machinery applies unchanged. Worst-ratio bookkeeping takes the max over axis-jerk and follower families.
   - **verify.rs**: PA entries per demand with the new `BindingConstraint` variants; tie-break order: existing classes first, then `PaVelocity > PaAccel > PaJerk`; PA-jerk joins the jerk class (`max_jerk`), PA-velocity/accel the non-jerk class.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p temporal` → PASS (including all pre-existing SLP tests — the follower scan returns empty when no demands exist).
-- [ ] **Step 5: Commit** — `feat(temporal): pressure-advance rows as SLP cuts with snap-backed jerk`
+- [x] **Step 4: Run** — `cargo nextest run -p temporal` → PASS (including all pre-existing SLP tests — the follower scan returns empty when no demands exist).
+- [x] **Step 5: Commit** — `feat(temporal): pressure-advance rows as SLP cuts with snap-backed jerk`
 
 ---
 
@@ -581,9 +581,9 @@ pub struct FollowerHistory {
 - Modify: `rust/temporal/src/multi/mod.rs` + `multi/joining.rs` (tail exchange — Step 5)
 - Test: `rust/temporal/src/topp/follower/tests.rs`
 
-- [ ] **Step 0: Dispatch `verify-logic` (background, non-blocking).** Before starting this task's implementation, dispatch the `verify-logic` skill on the claim: *"fixed-point iteration over a frozen time map (re-freezing sample times from the current iterate, rebuilding convolution-window constraint rows, re-solving) converges for averaging-type kernels in time-optimal path parameterization — or known counterexample shapes exist (e.g. kernel support wider than a chain between stops)."* Continue implementing while it runs — the divergence guards below make non-convergence safe regardless; the verification informs whether retry-and-fail is acceptable as the permanent posture or a fallback scheme is needed. Fold any counterexample it finds into `refreeze_divergence_fails_loudly`-style tests.
+- [x] **Step 0: Dispatch `verify-logic` (background, non-blocking).** Before starting this task's implementation, dispatch the `verify-logic` skill on the claim: *"fixed-point iteration over a frozen time map (re-freezing sample times from the current iterate, rebuilding convolution-window constraint rows, re-solving) converges for averaging-type kernels in time-optimal path parameterization — or known counterexample shapes exist (e.g. kernel support wider than a chain between stops)."* Continue implementing while it runs — the divergence guards below make non-convergence safe regardless; the verification informs whether retry-and-fail is acceptable as the permanent posture or a fallback scheme is needed. Fold any counterexample it finds into `refreeze_divergence_fails_loudly`-style tests.
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```rust
 #[test]
@@ -629,15 +629,15 @@ fn refreeze_divergence_fails_loudly() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(folded) or test(refreeze)'` → FAIL
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p temporal -E 'test(folded) or test(refreeze)'` → FAIL
 
-- [ ] **Step 3: Windowed demand machinery** in `follower.rs`:
+- [x] **Step 3: Windowed demand machinery** in `follower.rs`:
   - `build_follower_windows(chain, b̄) -> FollowerWindows`: time map via `frozen_time_map`; per followed axis `α`, `WindowOperator::from_kernel(kernel_α, …)` or `identity`; history terms per signal kind from `FollowerHistory` (velocity history given; accel/jerk histories finite-differenced from the velocity samples — document that choice in the function name, e.g. `history_accel_from_velocity`).
   - Windowed demands at the iterate: `V_α(i)`, `A_α(i)`, `J_α(i)` per the reference section, evaluated numerically from `(b̄, ā)`; demands `d_v = r(‖V‖ + k‖A‖)`, `d_a = r(‖A‖ + k‖J‖)`, `d_j = r(‖J‖ + k|s⁗|)`.
   - Cut builder: hyperplane directions `û = V̄/max(‖V̄‖, FLOOR)` etc.; row entries = `|r|·Σ_α û_α · ∂V_α/∂(b_j, a_j)` over the window's source samples (affine pieces per the reference; `√b` and `s⃛` linearized at `b̄` exactly as in Task 7). One Nonneg row per violator (the hyperplane already encodes the binding side; emit the ± pair only for the scalar `s⁗` tail).
   - When every followed axis is passthrough **and** `pa_k == 0`, Task 4's static rows remain the emission path (they are exact and convex — never replace exact with linearized when the exact form exists). The follower SLP scan skips such demands.
 
-- [ ] **Step 4: Re-freeze outer loop** in `solver.rs`, wrapping the existing phases:
+- [x] **Step 4: Re-freeze outer loop** in `solver.rs`, wrapping the existing phases:
 
 ```text
 solve base+jerk SLP (existing)                       — iterate 0
@@ -654,12 +654,12 @@ fail: ScheduleError::FollowerSlpDiverged { refreezes, worst_ratio }
 
 Chains with no active windows (no kernels, no PA) skip the wrapper entirely — zero cost on today's paths.
 
-- [ ] **Step 5: Cross-chain tail exchange** in `multi/joining.rs`: after `join_until_converged` returns, if any chain has active windows, run up to `TAIL_EXCHANGE_MAX (3)` passes: for each chain, sample its neighbors' solved boundary-window velocity signals (per axis, from the neighbor profile within one kernel width of the shared stop) into a `FollowerHistory` (left neighbor → history; right neighbor → terminal extension samples — add a mirrored `follower_terminal` field alongside `follower_history` if the right side needs more than terminal-hold), re-solve dirty chains, stop when no chain's total time moved by more than 0.1%. Junction velocities stay 0 — only the window constants change. If the pass cap is hit, fail loudly (`BatchError` variant naming the junction). The batch-boundary (streaming) history arrives via `BatchInput` → first chain's `follower_history` (Task 10).
+- [x] **Step 5: Cross-chain tail exchange** in `multi/joining.rs`: after `join_until_converged` returns, if any chain has active windows, run up to `TAIL_EXCHANGE_MAX (3)` passes: for each chain, sample its neighbors' solved boundary-window velocity signals (per axis, from the neighbor profile within one kernel width of the shared stop) into a `FollowerHistory` (left neighbor → history; right neighbor → terminal extension samples — add a mirrored `follower_terminal` field alongside `follower_history` if the right side needs more than terminal-hold), re-solve dirty chains, stop when no chain's total time moved by more than 0.1%. Junction velocities stay 0 — only the window constants change. If the pass cap is hit, fail loudly (`BatchError` variant naming the junction). The batch-boundary (streaming) history arrives via `BatchInput` → first chain's `follower_history` (Task 10).
 
-- [ ] **Step 6: verify.rs** — windowed demands enter `check_chain` through the same evaluation functions (verify receives the final frozen windows from the solve, not a fresh map — expose them on the output bundle), so the report covers folded rows.
+- [x] **Step 6: verify.rs** — windowed demands enter `check_chain` through the same evaluation functions (verify receives the final frozen windows from the solve, not a fresh map — expose them on the output bundle), so the report covers folded rows.
 
-- [ ] **Step 7: Run** — `cargo nextest run -p temporal` → PASS
-- [ ] **Step 8: Commit** — `feat(temporal): shaper-folded follower rows on a frozen time map with history constants`
+- [x] **Step 7: Run** — `cargo nextest run -p temporal` → PASS
+- [x] **Step 8: Commit** — `feat(temporal): shaper-folded follower rows on a frozen time map with history constants`
 
 ---
 
@@ -672,7 +672,7 @@ Plan 2 made these `Fatal::FollowerOnlyMoveUnsupported`. Now: the move's path len
 - Modify: `rust/temporal/src/topp/chain.rs` (virtual-path chain constructor) and `rust/trajectory/src/` plumbing (`grep -rn "FollowerOnlyMoveUnsupported" rust/` for every consumer)
 - Tests: `rust/geometry/src/pipeline/tests.rs`, `rust/temporal/src/topp/follower/tests.rs`
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```rust
 // geometry/pipeline tests: the plan-2 follower_only_move_is_fatal test flips —
@@ -689,17 +689,17 @@ fn virtual_path_plans_under_follower_limits_and_feedrate() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — scoped nextest → FAIL
+- [x] **Step 2: Run to verify failure** — scoped nextest → FAIL
 
-- [ ] **Step 3: Implement.**
+- [x] **Step 3: Implement.**
   - `CubicSegment` gains `pub virtual_path_mm: Option<f64>`; `try_new` validates: if `Some(l)`, `l > 0.0` finite, the xyz curve must have zero displacement (all control points equal within 1e-9 — assert, fail loudly), and `followers` non-empty.
   - `classify_followers`: the `path_len <= EPS_PATH && any_follower_motion` arm returns the virtual classification: `L = max |delta|` over followers, ratios `delta_i / L`, `virtual_path_mm: Some(L)` flagged to the caller (return an enum `Classified::Spatial(Vec<FollowerDemand>) | Classified::VirtualPath { length, followers }` — adjust `handle_curve`).
   - temporal: `ChainGrid::virtual_path(length, n, limits, followers) -> ChainGrid` — uniform `s` grid over `[0, L]`, `PointGeom` all-zero (every spatial row family already skips on `restricted_norm < COMP_FLOOR`; confirm `mvc_b` returns the `b_cap` ceiling, and that the velocity↔accel relation rows are geometry-free — they are), `inter_geom` empty. The feedrate cap is the caller's existing `b_cap` mechanism (`grep -n "b_cap" rust/temporal/src/topp/constraints.rs` — confirm it derives from feedrate; it does via the MVC seed). Follower rows from Tasks 4–8 do the rest.
   - trajectory: where segments are mapped to `temporal::SegmentInput` (`grep -rn "SegmentInput" rust/trajectory/`), route `virtual_path_mm` segments to the virtual-path constructor; they form their own single-segment chain (no fusing with spatial neighbors — tangent continuity is undefined against a zero curve; junction classification treats them as corner stops on both sides).
   - Delete the `Fatal::FollowerOnlyMoveUnsupported` variant and every consumer.
 
-- [ ] **Step 4: Run** — `cargo nextest run -p geometry -p temporal -p trajectory` → PASS
-- [ ] **Step 5: Commit** — `feat: follower-only moves plan on a virtual path (spec §2 degenerate rule)`
+- [x] **Step 4: Run** — `cargo nextest run -p geometry -p temporal -p trajectory` → PASS
+- [x] **Step 5: Commit** — `feat: follower-only moves plan on a virtual path (spec §2 degenerate rule)`
 
 ---
 
@@ -714,7 +714,7 @@ Follower limit sections reach temporal as real sets; segments' `FollowerDemand`s
 - Modify: `rust/trajectory/src/streaming/state.rs` + `streaming/emit.rs` (history extraction)
 - Tests: `rust/motion-bridge/src/config/tests.rs`, trajectory integration test
 
-- [ ] **Step 1: Write failing bridge test:**
+- [x] **Step 1: Write failing bridge test:**
 
 ```rust
 #[test]
@@ -725,26 +725,26 @@ fn follower_sections_become_temporal_sets() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**, implement the config conversion (replace plan 2's "recorded for coverage only" branch: follower section axes map straight into `AxisSet::from_indices`; pass `axis_registry.n_axes()` to `Limits::try_new`). The runtime-caps overlay stays `AxisSet::spatial()`.
+- [x] **Step 2: Run to verify failure**, implement the config conversion (replace plan 2's "recorded for coverage only" branch: follower section axes map straight into `AxisSet::from_indices`; pass `axis_registry.n_axes()` to `Limits::try_new`). The runtime-caps overlay stays `AxisSet::spatial()`.
 
-- [ ] **Step 3: trajectory threading** — at every `temporal::SegmentInput` construction site, attach the segment's followers (mapped, `pa_k` looked up per axis from `ReplanContext.follower_pa`, default `0.0`). Kernels: the followed axes' kernels are exactly the chain's `axis_kernels` — populate from the same `ReplanContext.kernels` used by emission (`grep -n "kernels" rust/trajectory/src/streaming/mod.rs`), converting `PlanShaper`/`AxisShaper` to `PiecewisePolynomialKernel` via the existing `to_kernel` path.
+- [x] **Step 3: trajectory threading** — at every `temporal::SegmentInput` construction site, attach the segment's followers (mapped, `pa_k` looked up per axis from `ReplanContext.follower_pa`, default `0.0`). Kernels: the followed axes' kernels are exactly the chain's `axis_kernels` — populate from the same `ReplanContext.kernels` used by emission (`grep -n "kernels" rust/trajectory/src/streaming/mod.rs`), converting `PlanShaper`/`AxisShaper` to `PiecewisePolynomialKernel` via the existing `to_kernel` path.
 
-- [ ] **Step 4: streaming history** — in `append_and_replan` (streaming/state.rs), when any kernel is active and any uncommitted segment carries followers, sample the realized per-axis velocities over `[t_freeze − max_h, t_freeze]` from the retained shaped pieces (`self.axes[α].pieces` + `pending_freeze` — the same data the freeze zone already preserves; differentiate the Bezier pieces at `HISTORY_DT = max_h / 32` steps) into `temporal`'s `FollowerHistory`, passed through `plan_velocity` → `BatchInput`. When no shaped history exists yet (cold start), the history is all-zero — correct, the machine was at rest.
+- [x] **Step 4: streaming history** — in `append_and_replan` (streaming/state.rs), when any kernel is active and any uncommitted segment carries followers, sample the realized per-axis velocities over `[t_freeze − max_h, t_freeze]` from the retained shaped pieces (`self.axes[α].pieces` + `pending_freeze` — the same data the freeze zone already preserves; differentiate the Bezier pieces at `HISTORY_DT = max_h / 32` steps) into `temporal`'s `FollowerHistory`, passed through `plan_velocity` → `BatchInput`. When no shaped history exists yet (cold start), the history is all-zero — correct, the machine was at rest.
 
-- [ ] **Step 5: Integration test** (new `rust/trajectory/tests/follower_rows.rs`): plan a 3-segment batch (straight, corner stop, straight) with an extruder follower (ratio 0.05, `[limit extruder]` v=75 a=1500), X/Y smooth-zv kernels, `pa_k = 0.04`; assert (a) it solves, (b) brute-force shaped-demand check as in Task 8's test holds over the emitted profile, (c) with `pa_k = 0` total time strictly decreases or stays equal (PA rows only ever tighten).
+- [x] **Step 5: Integration test** (new `rust/trajectory/tests/follower_rows.rs`): plan a 3-segment batch (straight, corner stop, straight) with an extruder follower (ratio 0.05, `[limit extruder]` v=75 a=1500), X/Y smooth-zv kernels, `pa_k = 0.04`; assert (a) it solves, (b) brute-force shaped-demand check as in Task 8's test holds over the emitted profile, (c) with `pa_k = 0` total time strictly decreases or stays equal (PA rows only ever tighten).
 
-- [ ] **Step 6: Run** — `cargo nextest run` from `rust/` → full workspace PASS
-- [ ] **Step 7: Commit** — `feat(trajectory,motion-bridge): follower demands, kernels, and history reach the solver`
+- [x] **Step 6: Run** — `cargo nextest run` from `rust/` → full workspace PASS
+- [x] **Step 7: Commit** — `feat(trajectory,motion-bridge): follower demands, kernels, and history reach the solver`
 
 ---
 
 ### Task 11: fossil sweep and end-to-end verification
 
-- [ ] **Step 1:** `grep -rn "FollowerOnlyMoveUnsupported\|NoFollowerCoverage.*coverage only\|recorded for coverage" rust/ klippy/ --include="*.rs" --include="*.py"` — plan-2 stopgaps must be gone or rewritten; every survivor justified in the commit message.
-- [ ] **Step 2:** `cargo nextest run` from `rust/` → PASS; `cargo test --doc` if doc examples touched; `cargo fmt --all --check` → clean. If `klippy/` was touched (it should not be in this plan — confirm with `git status`), run `./scripts/ci.sh py`.
-- [ ] **Step 3:** kalico-sim sanity: boot a migrated fixture with `[axis e]` + `[limit extruder]`; travel-only prints behave identically to plan-2 (followers empty on live segments — live extrusion is still rejected until plan 4); a fixture whose `[limit extruder]` declares only `max_jerk` errors at startup naming velocity/accel coverage.
-- [ ] **Step 4:** Pure-function check: every new temporal test runs with zero hardware/bridge involvement — the planner remains `(geometry, rows, kernels, history) → profile`. Confirm no new `static`/global entered `temporal` (`grep -rn "static\|lazy_static\|OnceLock" rust/temporal/src/ | grep -v test`).
-- [ ] **Step 5: Commit** — `feat: follower/PA/shaper-folded constraint rows end-to-end (plan 3)`
+- [x] **Step 1:** `grep -rn "FollowerOnlyMoveUnsupported\|NoFollowerCoverage.*coverage only\|recorded for coverage" rust/ klippy/ --include="*.rs" --include="*.py"` — plan-2 stopgaps must be gone or rewritten; every survivor justified in the commit message.
+- [x] **Step 2:** `cargo nextest run` from `rust/` → PASS; `cargo test --doc` if doc examples touched; `cargo fmt --all --check` → clean. If `klippy/` was touched (it should not be in this plan — confirm with `git status`), run `./scripts/ci.sh py`.
+- [x] **Step 3:** kalico-sim sanity: boot a migrated fixture with `[axis e]` + `[limit extruder]`; travel-only prints behave identically to plan-2 (followers empty on live segments — live extrusion is still rejected until plan 4); a fixture whose `[limit extruder]` declares only `max_jerk` errors at startup naming velocity/accel coverage.
+- [x] **Step 4:** Pure-function check: every new temporal test runs with zero hardware/bridge involvement — the planner remains `(geometry, rows, kernels, history) → profile`. Confirm no new `static`/global entered `temporal` (`grep -rn "static\|lazy_static\|OnceLock" rust/temporal/src/ | grep -v test`).
+- [x] **Step 5: Commit** — `feat: follower/PA/shaper-folded constraint rows end-to-end (plan 3)`
 
 ---
 

--- a/docs/superpowers/plans/2026-06-12-planner-extension-follower-rows.md
+++ b/docs/superpowers/plans/2026-06-12-planner-extension-follower-rows.md
@@ -8,7 +8,7 @@
 
 **Tech stack:** Rust (`temporal`, `trajectory`, `motion-bridge`, `geometry` crates; Clarabel SOCP). Tests: `cargo nextest run` from `rust/` (never bare `cargo test`); doc-tests via `cargo test --doc` if touched.
 
-**PRECONDITION: Plan 2 (`docs/superpowers/plans/2026-06-12-axis-registry-reduce-simplification.md`) must be fully landed** — this plan builds on `geometry::FollowerDemand`, `CubicSegment.followers`, trajectory's `ShapeSegmentInput.followers`, and the bridge's `AxisRegistry` + follower-coverage validation. Verify before starting: `git log --oneline | head -20` shows plan 2's final commit (`feat: axis registry + follower segments end-to-end (plan 2)`) and `cargo nextest run` passes from `rust/`.
+**PRECONDITION (satisfied 2026-06-12): Plan 2 is fully landed** — commit `725917f32` (`feat: axis registry + follower segments end-to-end (plan 2)`). This plan builds on `geometry::FollowerDemand`, `CubicSegment.followers`, trajectory's `ShapeSegmentInput.followers`, and the bridge's `AxisRegistry` + follower-coverage validation. Executors still verify `cargo nextest run` passes from `rust/` before starting.
 
 **All line numbers in this plan are pre-plan-2 approximations — anchor by symbol name and the given grep commands, never by line.**
 
@@ -18,13 +18,16 @@
 
 ---
 
-## Design decisions this plan makes (beyond the spec's text — review these first)
+## Design decisions this plan makes (beyond the spec's text)
+
+**All four decisions reviewed and approved with the user, 2026-06-12.** Discussion outcomes folded in below: decision 2 gains a background `verify-logic` dispatch (see Task 8 Step 0); decision 3 gains its tuning posture.
 
 The spec writes the follower rows in scalar path-derivative form (`|ratio|·ṡ ≤ v_max` etc.) and says shaper folding writes them "on the shaped combination of plan variables." Making that executable required four concrete decisions:
 
 1. **Per-axis windowed vectors, norm by supporting hyperplane.** X and Y may run different kernels (different shaper frequencies), and Z is typically passthrough — a single scalar convolution of `ṡ` cannot represent that. So the shaped follower demand is built per followed axis: shaped axis velocity `V_α(i) = Σ_j W^α_ij · c′_α,j·√b_j + hist`, and the speed demand is `|r|·‖V(i)‖`. On straights with one kernel this reduces exactly to the spec's scalar `K∗ṡ`. The norm is handled by supporting-hyperplane cuts at the iterate (the constraint is convex in the affine window expressions, so hyperplanes are valid outer cuts).
 2. **Frozen time map.** Kernel delays are in time; solver samples are in path position; the time of sample `i` depends on the solution. Each follower outer iteration freezes `t̄_i` from the current `b̄`, builds the window weights `W` on it, solves, and re-freezes. Same fixed-point posture as the existing path-jerk and axis-jerk SLP phases, with the same divergence guards — capped iterations, loud `ScheduleError` on non-convergence. Follower cuts are **rebuilt from scratch whenever the time map is re-frozen** (cuts built on a stale `W` constrain the wrong operator).
 3. **PA-jerk row stays in nominal path form.** `|r·(s⃛ + k·s⁗)| ≤ j_max` uses *path* snap with the identity window (no shaper folding on this one row). Folding it would require 4th-order axis geometry (`c⁗`) that nothing else needs. Since the smoothing kernel is an averaging operator, the nominal row is conservative — never under-constrains; it is exact on straights and slightly over-tight inside the shaper window at corners. Accepted for v1; tightening it later is additive.
+   *Tuning posture (agreed):* the row only exists when `pa_k > 0`; the per-machine escape hatch is a generously high `max_jerk` on the follower's `[limit]` section (the config default — 2× the section's accel cap — is moderately tight). Plan 6's binding-constraint reporting will show whether this row ever binds at corners on real prints; only evidence there motivates building the windowed-snap upgrade.
 4. **Cross-chain tails within a batch.** Chain junctions are full stops (plan 1), but the shaper window spans a stop — the neighbor chain's ramp contributes to shaped speed near the boundary. After the existing joining sweeps converge, one tail-exchange pass re-solves each chain with its neighbors' boundary-window velocity samples as constants, iterated to a small cap. The batch-boundary case (committed tail of the previous plan) enters the same way, supplied by trajectory's streaming layer.
 
 A fifth, smaller one: **follower-only moves get a virtual path** — a chain whose spatial geometry is identically zero and whose arc length is the largest follower displacement; only follower rows bind, and the G-code feedrate caps `ṡ` as on any move (spec §2's "fallback line, not a mode").
@@ -577,6 +580,8 @@ pub struct FollowerHistory {
 - Modify: `rust/temporal/src/topp/follower.rs` (windowed demand evaluation + cuts), `rust/temporal/src/topp/solver.rs` (outer re-freeze loop), `rust/temporal/src/topp/window.rs` (whatever Task 3's shape needs to serve per-axis signals)
 - Modify: `rust/temporal/src/multi/mod.rs` + `multi/joining.rs` (tail exchange — Step 5)
 - Test: `rust/temporal/src/topp/follower/tests.rs`
+
+- [ ] **Step 0: Dispatch `verify-logic` (background, non-blocking).** Before starting this task's implementation, dispatch the `verify-logic` skill on the claim: *"fixed-point iteration over a frozen time map (re-freezing sample times from the current iterate, rebuilding convolution-window constraint rows, re-solving) converges for averaging-type kernels in time-optimal path parameterization — or known counterexample shapes exist (e.g. kernel support wider than a chain between stops)."* Continue implementing while it runs — the divergence guards below make non-convergence safe regardless; the verification informs whether retry-and-fail is acceptable as the permanent posture or a fallback scheme is needed. Fold any counterexample it finds into `refreeze_divergence_fails_loudly`-style tests.
 
 - [ ] **Step 1: Write failing tests:**
 

--- a/docs/superpowers/specs/2026-06-12-follower-axes-and-limits-design.md
+++ b/docs/superpowers/specs/2026-06-12-follower-axes-and-limits-design.md
@@ -14,7 +14,8 @@ boundary; everything past that boundary is uniform.
 The system knows exactly two relations between axes, both explicit in config:
 
 - **`follows`** — a follower axis derives its motion from the *realized* path
-  of the axes it follows (downstream of those axes' shapers): it pays out its
+  of the axes it follows (downstream of those axes' filter chains, §4): it
+  pays out its
   commanded displacement proportionally to actual distance traveled along that
   path (the odometer rule). The extruder is the canonical instance: a follower
   of `{x, y, z}`. This is the only directional dependency in the system.
@@ -159,9 +160,10 @@ max_accel: 1500
 - Jerk caps are declared like any other derivative cap, with sensible defaults
   when unset. The `j_max = 2 × a_max` broadcast dies.
 - **Legacy config fields fail loudly.** `max_accel` / `max_velocity` in their
-  old homes, `square_corner_velocity`, `max_z_accel`, and the rest are rejected
-  at load with errors naming the field as unsupported and pointing at the
-  `[limit]` syntax. No silent migration; users rewrite deliberately.
+  old homes, `square_corner_velocity`, `max_z_accel`, `[input_shaper]`, and
+  the rest are rejected at load with errors naming the field as unsupported
+  and pointing at the replacement (`[limit]`, `[filter]`) syntax. No silent
+  migration; users rewrite deliberately.
 
 Today's behavior — global `max_accel` broadcast into per-axis boxes, so
 diagonals reach √2× the configured value — dies with the legacy fields.
@@ -173,7 +175,7 @@ curves) would be additional keys on the same section. Nothing in this work
 depends on either.
 
 Limits are declarative data readable by any component. The planner consuming
-them is a **pure function** — `(geometry, rows, shaper operators) → timed
+them is a **pure function** — `(geometry, rows, filter operators) → timed
 trajectory` — deterministic, unit-testable without hardware, and callable as an
 oracle by any future upstream component. That API shape is a hard requirement
 of this work.
@@ -191,9 +193,9 @@ direction along the move never changes:
 `|ratio|·ṡ ≤ v_max`, `|ratio|·s̈ ≤ a_max` — the same row shape as everything
 else.
 
-**Post-processor (PA) rows.** A post-processor is a per-axis transform applied
-at emission (§5); pressure advance, `F_cmd = F + k·Ḟ`, is the first
-implementation. Its plan-time consequence: PA converts path acceleration into
+**Pressure-advance (PA) rows.** PA, `F_cmd = F + k·Ḟ`, is a per-axis filter
+applied at emission (§5; the unified filter abstraction is defined below).
+Its plan-time consequence: PA converts path acceleration into
 follower velocity demand and path jerk into follower acceleration demand:
 
 ```
@@ -206,21 +208,55 @@ what constrained time-optimal means; nothing is slowed globally. Jerk caps
 under PA require path snap; the planner's derivative order is extended
 accordingly (separately testable). Nonlinear PA makes these rows nonlinear in
 `ṡ`; the SLP linearization already used for the jerk relaxation handles them.
-The post-processor is a trait from day one; linear PA is the first instance.
 
-**Shaper folding.** Each axis's limits apply to that axis's *input* — for
-spatial axes that means pre-shaper, by definition and by tuning convention. A
-follower differs only in where its input is sampled: downstream of the followed
-axes' shapers. Every shaper we have is a **linear operator** on the
-discretization (a convolution: shaped velocity at `t` is a fixed weighted sum
-of nominal velocities at `t − dᵢ`, weights independent of the signal — see
-`rust/trajectory/src/shaper.rs`). So the follower's rows are written on the
-shaped combination of plan variables: known weights, samples a few steps apart.
-The solver picks all N samples at once such that the shaped-then-post-processed
-follower track is in-limit. No feedback, no iteration — the shaper is not
-predicted, it is written into the inequality. Rows coupling nearby samples
-already exist (jerk); the shaper window widens the coupling without changing
-its kind.
+**Filters — one abstraction for shapers and post-processors.** An input
+shaper and pressure advance are the same mathematical object: a linear
+time-invariant operator on a per-axis track (the shaper convolves with a
+unity-integral kernel; linear PA convolves with `δ + k·δ′`). One attenuates
+high frequencies, the other amplifies them; structurally they are identical.
+So there is one config object: `[filter <name>]` declares a named instance
+with a `type:` (`smooth_zv`, `smooth_mzv`, `linear_pressure_advance`, future
+models — other PA formulations, third-party transforms — plug in the same
+way) and that type's parameters. An axis applies an ordered list
+(`filters:` on its `[axis]` section). The planner never knows what a filter
+does or which axes exist — each type exposes exactly two things: its
+emission-time transform and its plan-time linear action on the
+discretization (the window operator `W` for kernels, the mixed-derivative
+shift for PA). Linear filters commute, so list order only acquires meaning
+when a nonlinear type exists.
+
+**Limits constrain the chain output — what the motor feels.** The old
+pre-shaper convention was tradition plus an accident of safety: a smoothing
+kernel is contractive (`‖K∗a‖∞ ≤ ‖a‖∞`), so rows on the nominal signal never
+under-constrain the motor — they merely over-constrain it. PA amplifies, so
+nominal rows there would lie to the motor. One rule covers both: every limit
+row is written on the axis's post-chain signal. For shaped axes this is
+strictly less conservative than the pre-shaper convention — the planner may
+command a sharper nominal corner whose smoothed, realized demand rides the
+cap exactly. Staging: rows on nominal spatial signals ship first (the
+conservative direction — valid, never motor-unsafe); switching spatial rows
+to their windowed post-chain form is a separately planned tightening that
+only speeds prints (§6).
+
+Filter parameters are **runtime-tunable**: a parameter change applies to
+everything planned after it and never rewrites already-planned trajectory —
+that is what makes live tuning possible without replanning. Compatibility
+shims for mainline tuning commands (`SET_PRESSURE_ADVANCE`, the legacy
+`[input_shaper]` section) are deferred, built later on top of the generic
+sections and parameter-update path.
+
+**Shaper folding.** The follower's rows are the first instance of the
+post-chain rule above: its input is sampled downstream of the followed axes'
+filter chains, so its rows are written on the shaped signal. Every kernel we
+have is a **linear operator** on the discretization (a convolution: shaped
+velocity at `t` is a fixed weighted sum of nominal velocities at `t − dᵢ`,
+weights independent of the signal — see `rust/trajectory/src/shaper.rs`). So
+the follower's rows are written on the shaped combination of plan variables:
+known weights, samples a few steps apart. The solver picks all N samples at
+once such that the post-chain follower track is in-limit. No feedback, no
+iteration — the kernel is not predicted, it is written into the inequality.
+Rows coupling nearby samples already exist (jerk); the kernel window widens
+the coupling without changing its kind.
 
 Accepted consequences:
 
@@ -228,10 +264,10 @@ Accepted consequences:
   committed tail of the previous plan enters as constants. Plumbing, not math.
 - Solve cost grows with window width — host compute spent on trajectory
   tightness, per the throughput rule.
-- The shaper trait's contract gains one requirement: expose your action as a
-  linear operator. Every practical shaper is one. A hypothetical nonlinear
-  shaper supplies its own local linearization or forces an outer loop — that
-  fallback is designed by whoever builds such a shaper, not here.
+- The filter trait's contract requires exposing your action as a linear
+  operator. Every practical shaper and linear PA is one. A hypothetical
+  nonlinear filter supplies its own local linearization or forces an outer
+  loop — that fallback is designed by whoever builds such a filter, not here.
 
 Verification: unit tests covering every row family and edge case are the
 backbone. `verify-logic` is dispatched only if plan-writing hits a claim we
@@ -243,27 +279,26 @@ SLP convergence).
 Every axis, at emission, runs the same per-axis chain — no axis-specific code
 paths, only stages that are configured or skipped:
 
-1. **Input track.** Spatial axis: its planned, shaped curve. Follower axis:
-   the odometer — integrate the followed axes' realized speed (downstream of
-   their shapers; quadrature over exact polynomial derivatives, host f64) to
-   get actual distance over time, then `track = start + ratio × distance`.
-   Follower-only moves: the track comes straight from the plan.
-2. **Post-processor** (optional, any axis): the configured transform on the
-   track. PA is the first implementation. Not follower-specific: any axis may
-   declare one; the architecture does not ask whether it makes sense — that is
-   the user's call. Plan-time rows fold it in, so limits hold downstream of it
-   (the motor feels the post-processed demand).
-3. **The axis's own shaper** (optional, any axis — a follower may have one;
-   typically it won't). Limits are pre-own-shaper by the same convention as
-   every axis.
-4. **Fit to cubic pieces**, ship as an ordinary `PushPieces` lane.
+1. **Input track.** Spatial axis: its planned curve. Follower axis: the
+   odometer — integrate the followed axes' realized speed (downstream of
+   their filter chains; quadrature over exact polynomial derivatives, host
+   f64) to get actual distance over time, then
+   `track = start + ratio × distance`. Follower-only moves: the track comes
+   straight from the plan.
+2. **Filter chain** (optional, any axis): the axis's configured `filters`
+   list applied to the track in order — shaper kernels and PA are the same
+   stage (§4). Not follower-specific: any axis may declare any chain; the
+   architecture does not ask whether it makes sense — that is the user's
+   call. Plan-time rows constrain the chain's output, so limits hold where
+   the motor feels them.
+3. **Fit to cubic pieces**, ship as an ordinary `PushPieces` lane.
 
-"After shaping," wherever this document says it, means: a follower samples the
-path it follows after that path's own processing; the follower's own
-processing happens downstream of the sampling, like any axis.
+"After shaping," wherever this document says it, means: a follower samples
+the path it follows downstream of that path's own filter chain; the
+follower's own chain runs downstream of the sampling, like any axis.
 
 The MCU is untouched: per-axis cubic tapes, no knowledge of followers,
-post-processors, or shapers. `docs/kalico-rewrite/mcu-c-rust-boundary.md`
+filters. `docs/kalico-rewrite/mcu-c-rust-boundary.md`
 requires zero edits.
 
 **Two ledgers, by intention** (any follower axis; the extruder is the
@@ -288,7 +323,7 @@ match the road.
 
 **Observability.** The planner knows which constraint row binds at every point
 and reports it through the structured log pipeline ("slowed here by
-`[limit extruder]` accel via post-processor"). The coupling between one axis's
+`[limit extruder]` accel via the PA filter"). The coupling between one axis's
 config and the whole machine's speed becomes discoverable at the moment
 someone asks why.
 
@@ -304,12 +339,14 @@ Separately plannable, separately testable, in dependency order:
    `follows`; 3D arc length; delete `e_mode` / `Independent` / `Travel` /
    `HelicalExtrusionUnsupported`; absolute→delta normalization; follower-only
    moves as regular moves. Mostly deletion.
-3. **Planner extension.** Follower rows, post-processor rows, snap support,
+3. **Planner extension.** Follower rows, PA rows, snap support,
    shaper-operator folding with cross-segment window plumbing. The deep item;
    depends on 1–2.
-4. **Per-axis emission chain.** Odometer quadrature, post-processor trait with
-   linear PA first, own-shaper slot, piece fitting, two-ledger bookkeeping.
-   Depends on 2; testable against 3's output offline (klipper-sim).
+4. **Per-axis emission chain.** Odometer quadrature; filter registry
+   (`[filter]` sections, ordered per-axis chains, runtime-tunable
+   parameters) unifying shaper kernels and linear PA as the first two types;
+   piece fitting; two-ledger bookkeeping. Depends on 2; testable against 3's
+   output offline (klipper-sim).
 5. **Concept removal sweep.** Toolhead and remaining mainline-planner fossils
    out of the Rust side; klippy/bridge seam renamed; thin compat shim for the
    published `toolhead` status object, retired on its own schedule. Includes
@@ -318,11 +355,14 @@ Separately plannable, separately testable, in dependency order:
 6. **Observability.** Binding-constraint reporting via structured logs. Small,
    rides on 3.
 
-Deferred, consciously — door open, nothing built: motor-space limits
-(`motors:` key, syntax reserved), velocity-dependent caps (torque curves),
-nonlinear PA (trait slot exists), exposing a follower's own shaper in config,
-automated limit tuning. All additive rows, keys, or trait implementations; none
-change the architecture.
+Deferred, consciously — door open, nothing built: **windowed post-chain rows
+for spatial axes** (the §4 tightening — spatial rows ship in nominal,
+conservative form first; the upgrade reuses plan 3's cut machinery and only
+speeds prints), motor-space limits (`motors:` key, syntax reserved),
+velocity-dependent caps (torque curves), nonlinear PA (a new filter type),
+mainline-compatible migration shims (`SET_PRESSURE_ADVANCE`, an
+`[input_shaper]` compat flag), automated limit tuning. All additive rows,
+keys, sections, or type implementations; none change the architecture.
 
 Hard requirements carried through every plan: the planner stays a pure
 function (the unit-test surface and the oracle API); fail loudly everywhere;

--- a/docs/superpowers/specs/2026-06-12-follower-axes-and-limits-design.md
+++ b/docs/superpowers/specs/2026-06-12-follower-axes-and-limits-design.md
@@ -14,10 +14,9 @@ boundary; everything past that boundary is uniform.
 The system knows exactly two relations between axes, both explicit in config:
 
 - **`follows`** — a follower axis derives its motion from the *realized* path
-  of the axes it follows (downstream of those axes' filter chains, §4): it
-  pays out its
-  commanded displacement proportionally to actual distance traveled along that
-  path (the odometer rule). The extruder is the canonical instance: a follower
+  of the axes it follows (downstream of those axes' post-processor chains,
+  §4): it pays out its commanded displacement proportionally to actual
+  distance traveled along that path (the odometer rule). The extruder is the canonical instance: a follower
   of `{x, y, z}`. This is the only directional dependency in the system.
 - **`[limit]` membership** — every limit names a set of coordinates and caps
   their combined motion. All limits jointly constrain the one shared clock per
@@ -162,7 +161,7 @@ max_accel: 1500
 - **Legacy config fields fail loudly.** `max_accel` / `max_velocity` in their
   old homes, `square_corner_velocity`, `max_z_accel`, `[input_shaper]`, and
   the rest are rejected at load with errors naming the field as unsupported
-  and pointing at the replacement (`[limit]`, `[filter]`) syntax. No silent
+  and pointing at the replacement (`[limit]`, `[post_processor]`) syntax. No silent
   migration; users rewrite deliberately.
 
 Today's behavior — global `max_accel` broadcast into per-axis boxes, so
@@ -175,7 +174,7 @@ curves) would be additional keys on the same section. Nothing in this work
 depends on either.
 
 Limits are declarative data readable by any component. The planner consuming
-them is a **pure function** — `(geometry, rows, filter operators) → timed
+them is a **pure function** — `(geometry, rows, post-processor operators) → timed
 trajectory` — deterministic, unit-testable without hardware, and callable as an
 oracle by any future upstream component. That API shape is a hard requirement
 of this work.
@@ -193,8 +192,8 @@ direction along the move never changes:
 `|ratio|·ṡ ≤ v_max`, `|ratio|·s̈ ≤ a_max` — the same row shape as everything
 else.
 
-**Pressure-advance (PA) rows.** PA, `F_cmd = F + k·Ḟ`, is a per-axis filter
-applied at emission (§5; the unified filter abstraction is defined below).
+**Pressure-advance (PA) rows.** PA, `F_cmd = F + k·Ḟ`, is a per-axis post-processor
+applied at emission (§5; the unified post-processor abstraction is defined below).
 Its plan-time consequence: PA converts path acceleration into
 follower velocity demand and path jerk into follower acceleration demand:
 
@@ -209,20 +208,20 @@ under PA require path snap; the planner's derivative order is extended
 accordingly (separately testable). Nonlinear PA makes these rows nonlinear in
 `ṡ`; the SLP linearization already used for the jerk relaxation handles them.
 
-**Filters — one abstraction for shapers and post-processors.** An input
+**Post-processors — one abstraction for shapers and PA.** An input
 shaper and pressure advance are the same mathematical object: a linear
 time-invariant operator on a per-axis track (the shaper convolves with a
 unity-integral kernel; linear PA convolves with `δ + k·δ′`). One attenuates
 high frequencies, the other amplifies them; structurally they are identical.
-So there is one config object: `[filter <name>]` declares a named instance
+So there is one config object: `[post_processor <name>]` declares a named instance
 with a `type:` (`smooth_zv`, `smooth_mzv`, `linear_pressure_advance`, future
 models — other PA formulations, third-party transforms — plug in the same
 way) and that type's parameters. An axis applies an ordered list
-(`filters:` on its `[axis]` section). The planner never knows what a filter
+(`post_processors:` on its `[axis]` section). The planner never knows what a post-processor
 does or which axes exist — each type exposes exactly two things: its
 emission-time transform and its plan-time linear action on the
 discretization (the window operator `W` for kernels, the mixed-derivative
-shift for PA). Linear filters commute, so list order only acquires meaning
+shift for PA). Linear post-processors commute, so list order only acquires meaning
 when a nonlinear type exists.
 
 **Limits constrain the chain output — what the motor feels.** The old
@@ -238,7 +237,7 @@ conservative direction — valid, never motor-unsafe); switching spatial rows
 to their windowed post-chain form is a separately planned tightening that
 only speeds prints (§6).
 
-Filter parameters are **runtime-tunable**: a parameter change applies to
+Post-processor parameters are **runtime-tunable**: a parameter change applies to
 everything planned after it and never rewrites already-planned trajectory —
 that is what makes live tuning possible without replanning. Compatibility
 shims for mainline tuning commands (`SET_PRESSURE_ADVANCE`, the legacy
@@ -247,7 +246,7 @@ sections and parameter-update path.
 
 **Shaper folding.** The follower's rows are the first instance of the
 post-chain rule above: its input is sampled downstream of the followed axes'
-filter chains, so its rows are written on the shaped signal. Every kernel we
+post-processor chains, so its rows are written on the shaped signal. Every kernel we
 have is a **linear operator** on the discretization (a convolution: shaped
 velocity at `t` is a fixed weighted sum of nominal velocities at `t − dᵢ`,
 weights independent of the signal — see `rust/trajectory/src/shaper.rs`). So
@@ -264,10 +263,10 @@ Accepted consequences:
   committed tail of the previous plan enters as constants. Plumbing, not math.
 - Solve cost grows with window width — host compute spent on trajectory
   tightness, per the throughput rule.
-- The filter trait's contract requires exposing your action as a linear
+- The post-processor trait's contract requires exposing your action as a linear
   operator. Every practical shaper and linear PA is one. A hypothetical
-  nonlinear filter supplies its own local linearization or forces an outer
-  loop — that fallback is designed by whoever builds such a filter, not here.
+  nonlinear post-processor supplies its own local linearization or forces an outer
+  loop — that fallback is designed by whoever builds such a post-processor, not here.
 
 Verification: unit tests covering every row family and edge case are the
 backbone. `verify-logic` is dispatched only if plan-writing hits a claim we
@@ -281,11 +280,11 @@ paths, only stages that are configured or skipped:
 
 1. **Input track.** Spatial axis: its planned curve. Follower axis: the
    odometer — integrate the followed axes' realized speed (downstream of
-   their filter chains; quadrature over exact polynomial derivatives, host
+   their post-processor chains; quadrature over exact polynomial derivatives, host
    f64) to get actual distance over time, then
    `track = start + ratio × distance`. Follower-only moves: the track comes
    straight from the plan.
-2. **Filter chain** (optional, any axis): the axis's configured `filters`
+2. **Post-processor chain** (optional, any axis): the axis's configured `post_processors`
    list applied to the track in order — shaper kernels and PA are the same
    stage (§4). Not follower-specific: any axis may declare any chain; the
    architecture does not ask whether it makes sense — that is the user's
@@ -294,12 +293,12 @@ paths, only stages that are configured or skipped:
 3. **Fit to cubic pieces**, ship as an ordinary `PushPieces` lane.
 
 "After shaping," wherever this document says it, means: a follower samples
-the path it follows downstream of that path's own filter chain; the
+the path it follows downstream of that path's own post-processor chain; the
 follower's own chain runs downstream of the sampling, like any axis.
 
-The MCU is untouched: per-axis cubic tapes, no knowledge of followers,
-filters. `docs/kalico-rewrite/mcu-c-rust-boundary.md`
-requires zero edits.
+The MCU is untouched: per-axis cubic tapes, no knowledge of followers or
+post-processors. `docs/kalico-rewrite/mcu-c-rust-boundary.md` requires zero
+edits.
 
 **Two ledgers, by intention** (any follower axis; the extruder is the
 canonical instance):
@@ -323,7 +322,7 @@ match the road.
 
 **Observability.** The planner knows which constraint row binds at every point
 and reports it through the structured log pipeline ("slowed here by
-`[limit extruder]` accel via the PA filter"). The coupling between one axis's
+`[limit extruder]` accel via the PA post-processor"). The coupling between one axis's
 config and the whole machine's speed becomes discoverable at the moment
 someone asks why.
 
@@ -342,8 +341,8 @@ Separately plannable, separately testable, in dependency order:
 3. **Planner extension.** Follower rows, PA rows, snap support,
    shaper-operator folding with cross-segment window plumbing. The deep item;
    depends on 1–2.
-4. **Per-axis emission chain.** Odometer quadrature; filter registry
-   (`[filter]` sections, ordered per-axis chains, runtime-tunable
+4. **Per-axis emission chain.** Odometer quadrature; post-processor registry
+   (`[post_processor]` sections, ordered per-axis chains, runtime-tunable
    parameters) unifying shaper kernels and linear PA as the first two types;
    piece fitting; two-ledger bookkeeping. Depends on 2; testable against 3's
    output offline (klipper-sim).
@@ -359,7 +358,7 @@ Deferred, consciously — door open, nothing built: **windowed post-chain rows
 for spatial axes** (the §4 tightening — spatial rows ship in nominal,
 conservative form first; the upgrade reuses plan 3's cut machinery and only
 speeds prints), motor-space limits (`motors:` key, syntax reserved),
-velocity-dependent caps (torque curves), nonlinear PA (a new filter type),
+velocity-dependent caps (torque curves), nonlinear PA (a new post-processor type),
 mainline-compatible migration shims (`SET_PRESSURE_ADVANCE`, an
 `[input_shaper]` compat flag), automated limit tuning. All additive rows,
 keys, sections, or type implementations; none change the architecture.

--- a/rust/geometry/src/error.rs
+++ b/rust/geometry/src/error.rs
@@ -52,9 +52,6 @@ pub enum Fatal {
         line_no: u32,
         gcode_kind: &'static str,
     },
-    FollowerOnlyMoveUnsupported {
-        line_no: u32,
-    },
 }
 
 #[derive(Debug)]
@@ -79,7 +76,6 @@ pub enum GeometryError {
     UnsupportedGcode { gcode_kind: &'static str },
     NotSinglePieceCubic { reason: &'static str },
     FollowerInvariantViolation { reason: &'static str },
-    FollowerOnlyMoveUnsupported,
     ZeroMotion,
 }
 

--- a/rust/geometry/src/pipeline.rs
+++ b/rust/geometry/src/pipeline.rs
@@ -202,35 +202,39 @@ impl Segments<'_> {
             CurveGeom::Quadratic { cps } => degree_elevate_2_to_3(&nurbs_from_quadratic(cps)),
         };
 
-        match classify_followers(&xyz, follower_deltas) {
-            Ok(followers) => {
-                match CubicSegment::try_new(xyz, followers, feedrate_mm_s, source, None) {
-                    Ok(seg) => {
-                        self.queue.push_back(Item::Segment(Segment::Cubic(seg)));
-                    }
-                    Err(
-                        GeometryError::NotSinglePieceCubic { reason }
-                        | GeometryError::FollowerInvariantViolation { reason },
-                    ) => {
-                        self.queue.push_back(Item::Fatal(Fatal::Internal(Box::new(
-                            InternalDetails {
-                                kind: InternalKind::CubicSegmentInvariantViolation { reason },
-                                context: format!("line_no={line_no}"),
-                                backtrace: std::backtrace::Backtrace::capture(),
-                            },
-                        ))));
-                    }
-                    Err(_) => unreachable!(
-                        "classify_followers would not have returned Ok if try_new could fail this way"
-                    ),
-                }
-            }
-            Err(GeometryError::ZeroMotion) => {}
-            Err(GeometryError::FollowerOnlyMoveUnsupported) => {
-                self.queue
-                    .push_back(Item::Fatal(Fatal::FollowerOnlyMoveUnsupported { line_no }));
-            }
+        let built = match classify_followers(&xyz, follower_deltas) {
+            Ok(Classified::Spatial(followers)) => Some(CubicSegment::try_new(
+                xyz,
+                followers,
+                feedrate_mm_s,
+                source,
+                None,
+            )),
+            Ok(Classified::VirtualPath { length, followers }) => Some(
+                CubicSegment::try_new_virtual(xyz, followers, feedrate_mm_s, source, length),
+            ),
+            Err(GeometryError::ZeroMotion) => None,
             Err(_) => unreachable!("classify_followers return shape is exhaustive"),
+        };
+        match built {
+            None => {}
+            Some(Ok(seg)) => {
+                self.queue.push_back(Item::Segment(Segment::Cubic(seg)));
+            }
+            Some(Err(
+                GeometryError::NotSinglePieceCubic { reason }
+                | GeometryError::FollowerInvariantViolation { reason },
+            )) => {
+                self.queue
+                    .push_back(Item::Fatal(Fatal::Internal(Box::new(InternalDetails {
+                        kind: InternalKind::CubicSegmentInvariantViolation { reason },
+                        context: format!("line_no={line_no}"),
+                        backtrace: std::backtrace::Backtrace::capture(),
+                    }))));
+            }
+            Some(Err(_)) => {
+                unreachable!("CubicSegment constructors only fail with the variants above")
+            }
         }
 
         self.prev_g1_end = None;
@@ -239,28 +243,51 @@ impl Segments<'_> {
     }
 }
 
+enum Classified {
+    Spatial(Vec<FollowerDemand>),
+    VirtualPath {
+        length: f64,
+        followers: Vec<FollowerDemand>,
+    },
+}
+
 fn classify_followers(
     xyz: &nurbs::VectorNurbs<f64, 3>,
     follower_deltas: &[(usize, f64)],
-) -> Result<Vec<FollowerDemand>, GeometryError> {
+) -> Result<Classified, GeometryError> {
     const EPS_PATH: f64 = 1e-6;
     const EPS_FOLLOWER: f64 = 1e-6;
     let path_len = nurbs::arc_length::path_arc_length(xyz);
-    let any_follower_motion = follower_deltas.iter().any(|&(_, d)| d.abs() > EPS_FOLLOWER);
-    if path_len <= EPS_PATH {
-        if any_follower_motion {
-            return Err(GeometryError::FollowerOnlyMoveUnsupported);
-        }
-        return Err(GeometryError::ZeroMotion);
-    }
-    Ok(follower_deltas
+    let moving: Vec<(usize, f64)> = follower_deltas
         .iter()
-        .filter(|&&(_, d)| d.abs() > EPS_FOLLOWER)
-        .map(|&(axis_index, d)| FollowerDemand {
-            axis_index,
-            ratio: d / path_len,
-        })
-        .collect())
+        .copied()
+        .filter(|&(_, d)| d.abs() > EPS_FOLLOWER)
+        .collect();
+    if path_len <= EPS_PATH {
+        if moving.is_empty() {
+            return Err(GeometryError::ZeroMotion);
+        }
+        let length = moving.iter().map(|&(_, d)| d.abs()).fold(0.0, f64::max);
+        return Ok(Classified::VirtualPath {
+            length,
+            followers: moving
+                .into_iter()
+                .map(|(axis_index, d)| FollowerDemand {
+                    axis_index,
+                    ratio: d / length,
+                })
+                .collect(),
+        });
+    }
+    Ok(Classified::Spatial(
+        moving
+            .into_iter()
+            .map(|(axis_index, d)| FollowerDemand {
+                axis_index,
+                ratio: d / path_len,
+            })
+            .collect(),
+    ))
 }
 
 #[must_use]

--- a/rust/geometry/src/pipeline/tests.rs
+++ b/rust/geometry/src/pipeline/tests.rs
@@ -183,14 +183,28 @@ fn z_hop_with_follower_classifies() {
 }
 
 #[test]
-fn follower_only_move_is_fatal() {
+fn follower_only_move_yields_virtual_path() {
     let items =
         collect_with_e_follower("G5 X10 Y0 I3 J0 P-3 Q0 F3000\nG5 X10 Y0 I0 J0 P0 Q0 E5 F3000\n");
+    let cubics: Vec<_> = items
+        .iter()
+        .filter_map(|it| match it {
+            Item::Segment(Segment::Cubic(seg)) => Some(seg),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(cubics.len(), 2, "got {items:#?}");
+    let virt = cubics[1];
+    assert_eq!(virt.virtual_path_mm, Some(5.0));
+    assert_eq!(virt.followers.len(), 1);
+    assert_eq!(virt.followers[0].axis_index, 3);
+    assert!((virt.followers[0].ratio - 1.0).abs() < 1e-12);
+    let cps = virt.xyz.control_points();
+    let first = cps[0];
     assert!(
-        items
-            .iter()
-            .any(|it| matches!(it, Item::Fatal(Fatal::FollowerOnlyMoveUnsupported { .. }))),
-        "expected FollowerOnlyMoveUnsupported, got {items:#?}"
+        cps.iter()
+            .all(|p| p.iter().zip(&first).all(|(a, b)| (a - b).abs() < 1e-9)),
+        "virtual path must have zero spatial displacement"
     );
 }
 

--- a/rust/geometry/src/segment.rs
+++ b/rust/geometry/src/segment.rs
@@ -42,6 +42,9 @@ pub struct CubicSegment {
     pub feedrate_mm_s: f64,
     pub source: SourceRange,
     pub split_info: Option<SplitInfo>,
+    /// `Some(length)` marks a follower-only move planned on a virtual path of
+    /// this arclength; the xyz curve has zero displacement.
+    pub virtual_path_mm: Option<f64>,
 }
 
 impl CubicSegment {
@@ -108,9 +111,42 @@ impl CubicSegment {
             xyz,
             followers,
             feedrate_mm_s,
+            virtual_path_mm: None,
             source,
             split_info,
         })
+    }
+
+    pub fn try_new_virtual(
+        xyz: VectorNurbs<f64, 3>,
+        followers: Vec<FollowerDemand>,
+        feedrate_mm_s: f64,
+        source: SourceRange,
+        virtual_path_mm: f64,
+    ) -> Result<Self, crate::GeometryError> {
+        if !(virtual_path_mm.is_finite() && virtual_path_mm > 0.0) {
+            return Err(crate::GeometryError::FollowerInvariantViolation {
+                reason: "virtual path length must be finite and positive",
+            });
+        }
+        if followers.is_empty() {
+            return Err(crate::GeometryError::FollowerInvariantViolation {
+                reason: "virtual path requires at least one follower",
+            });
+        }
+        let first = xyz.control_points()[0];
+        let displaced = xyz
+            .control_points()
+            .iter()
+            .any(|p| p.iter().zip(&first).any(|(a, b)| (a - b).abs() > 1e-9));
+        if displaced {
+            return Err(crate::GeometryError::FollowerInvariantViolation {
+                reason: "virtual path xyz curve must have zero displacement",
+            });
+        }
+        let mut segment = Self::try_new(xyz, followers, feedrate_mm_s, source, None)?;
+        segment.virtual_path_mm = Some(virtual_path_mm);
+        Ok(segment)
     }
 }
 

--- a/rust/motion-bridge/src/config.rs
+++ b/rust/motion-bridge/src/config.rs
@@ -258,7 +258,7 @@ impl PlannerConfig {
         if self.runtime_caps.velocity.is_some() || self.runtime_caps.accel.is_some() {
             let a = self.runtime_caps.accel.unwrap_or(f64::INFINITY);
             sets.push(temporal::LimitSet {
-                axes: temporal::AxisSet::all(),
+                axes: temporal::AxisSet::spatial(),
                 v_max: self.runtime_caps.velocity.unwrap_or(f64::INFINITY),
                 a_max: a,
                 j_max: if a.is_finite() {
@@ -268,7 +268,7 @@ impl PlannerConfig {
                 },
             });
         }
-        Ok(temporal::Limits::try_new(&sets)?)
+        Ok(temporal::Limits::try_new(&sets, temporal::N_SPATIAL)?)
     }
 }
 

--- a/rust/motion-bridge/src/config.rs
+++ b/rust/motion-bridge/src/config.rs
@@ -221,14 +221,7 @@ impl PlannerConfig {
             if all_spatial {
                 sets.push(section.to_set()?);
             } else if all_follower {
-                if section.max_velocity.is_none()
-                    && section.max_accel.is_none()
-                    && section.max_jerk.is_none()
-                {
-                    return Err(LimitConfigError::EmptySection {
-                        section: section.name.clone(),
-                    });
-                }
+                sets.push(section.to_set()?);
                 for &i in &section.axes {
                     if section.max_velocity.is_some_and(f64::is_finite) {
                         follower_velocity_covered[i] = true;
@@ -268,7 +261,10 @@ impl PlannerConfig {
                 },
             });
         }
-        Ok(temporal::Limits::try_new(&sets, temporal::N_SPATIAL)?)
+        Ok(temporal::Limits::try_new(
+            &sets,
+            n_axes.max(temporal::N_SPATIAL),
+        )?)
     }
 }
 

--- a/rust/motion-bridge/src/config/tests.rs
+++ b/rust/motion-bridge/src/config/tests.rs
@@ -261,3 +261,32 @@ fn follower_axis_without_limit_coverage_is_an_error() {
         LimitConfigError::NoFollowerCoverage { .. }
     ));
 }
+
+#[test]
+fn follower_sections_become_temporal_sets() {
+    let reg = AxisRegistry::try_new(vec![
+        decl("x", &[]),
+        decl("y", &[]),
+        decl("z", &[]),
+        decl("e", &["x", "y", "z"]),
+    ])
+    .unwrap();
+    let mut cfg = PlannerConfig::default();
+    cfg.axis_registry = reg;
+    cfg.limit_sections.push(LimitSection {
+        name: "extruder".into(),
+        axes: vec![3],
+        max_velocity: Some(75.0),
+        max_accel: Some(1500.0),
+        max_jerk: None,
+    });
+    let lims = cfg.to_temporal_limits().unwrap();
+    assert_eq!(lims.n_axes(), 4);
+    let followers: Vec<_> = lims.follower_sets().collect();
+    assert_eq!(followers.len(), 1);
+    let (_, set) = followers[0];
+    assert!(set.axes.contains(3));
+    assert_eq!(set.v_max, 75.0);
+    assert_eq!(set.a_max, 1500.0);
+    assert_eq!(set.j_max, 3000.0);
+}

--- a/rust/motion-bridge/src/config/tests.rs
+++ b/rust/motion-bridge/src/config/tests.rs
@@ -49,7 +49,7 @@ fn runtime_caps_append_an_all_axis_overlay() {
     let overlay = lims.sets().last().unwrap();
     assert_eq!(overlay.v_max, 100.0);
     assert_eq!(overlay.a_max, 1000.0);
-    assert_eq!(overlay.axes, temporal::AxisSet::all());
+    assert_eq!(overlay.axes, temporal::AxisSet::spatial());
 }
 
 #[test]

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -768,6 +768,7 @@ fn run_loop(
 
 fn build_replan_context(config: &PlannerConfig) -> ReplanContext {
     ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits: config
             .to_temporal_limits()
             .expect("limit sections validated in init_planner"),

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -23,6 +23,12 @@ pub struct FollowerDemand {
     pub pa_k: f64,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct FollowerHistory {
+    pub dt: f64,
+    pub axis_velocity: [Vec<f64>; 3],
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct GridConfig {
     pub scheme: GridScheme,

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -42,6 +42,9 @@ pub enum BindingConstraint {
     Velocity { set: usize },
     AccelNorm { set: usize },
     JerkNorm { set: usize },
+    PaVelocity { set: usize },
+    PaAccel { set: usize },
+    PaJerk { set: usize },
     Boundary,
 }
 

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -5,13 +5,23 @@ pub use limits::{
 };
 
 pub mod topp;
-pub use topp::{ScheduleError, ToleranceMode, schedule_segment, schedule_segment_with_tolerance};
+pub use topp::{
+    ScheduleError, ToleranceMode, schedule_segment, schedule_segment_with_followers,
+    schedule_segment_with_tolerance,
+};
 
 pub mod multi;
 pub use multi::{
     BatchError, BatchInput, BatchOutput, GridStrategy, JoiningStatus, JunctionInfo, SegmentInput,
     plan_batch,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FollowerDemand {
+    pub axis: usize,
+    pub ratio: f64,
+    pub pa_k: f64,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct GridConfig {

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod limits;
 pub use limits::{
-    AxisSet, LimitSet, Limits, LimitsError, MAX_AXES, MAX_LIMIT_SETS, kappa_set, restricted_norm,
+    AxisSet, LimitSet, Limits, LimitsError, MAX_AXES, MAX_LIMIT_SETS, N_SPATIAL, kappa_set,
+    restricted_norm,
 };
 
 pub mod topp;

--- a/rust/temporal/src/limits.rs
+++ b/rust/temporal/src/limits.rs
@@ -1,4 +1,5 @@
-pub const MAX_AXES: usize = 3;
+pub const N_SPATIAL: usize = 3;
+pub const MAX_AXES: usize = 8;
 pub const MAX_LIMIT_SETS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16,8 +17,16 @@ impl AxisSet {
         Self(bits)
     }
     #[must_use]
-    pub fn all() -> Self {
-        Self((1 << MAX_AXES) - 1)
+    pub fn spatial() -> Self {
+        Self((1 << N_SPATIAL) - 1)
+    }
+    #[must_use]
+    pub fn is_spatial(self) -> bool {
+        self.0 < (1 << N_SPATIAL)
+    }
+    #[must_use]
+    pub fn is_follower(self) -> bool {
+        self.0 >> N_SPATIAL != 0 && self.0 & ((1 << N_SPATIAL) - 1) == 0
     }
     #[must_use]
     pub fn contains(self, axis: usize) -> bool {
@@ -44,6 +53,7 @@ pub struct LimitSet {
 pub struct Limits {
     sets: [LimitSet; MAX_LIMIT_SETS],
     n_sets: u8,
+    n_axes: u8,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq)]
@@ -60,10 +70,16 @@ pub enum LimitsError {
     NoAccelCoverage { axis: usize },
     #[error("axis {axis}: no limit set declares a finite max_jerk covering it")]
     NoJerkCoverage { axis: usize },
+    #[error("limit set {set}: mixes spatial and follower axes (unsupported)")]
+    MixedSpatialFollower { set: usize },
 }
 
 impl Limits {
-    pub fn try_new(sets: &[LimitSet]) -> Result<Self, LimitsError> {
+    pub fn try_new(sets: &[LimitSet], n_axes: usize) -> Result<Self, LimitsError> {
+        assert!(
+            (N_SPATIAL..=MAX_AXES).contains(&n_axes),
+            "n_axes {n_axes} out of range"
+        );
         if sets.is_empty() {
             return Err(LimitsError::Empty);
         }
@@ -75,8 +91,11 @@ impl Limits {
             if !(ok(s.v_max) && ok(s.a_max) && ok(s.j_max)) {
                 return Err(LimitsError::BadCap { set: idx });
             }
+            if !s.axes.is_spatial() && !s.axes.is_follower() {
+                return Err(LimitsError::MixedSpatialFollower { set: idx });
+            }
         }
-        for axis in 0..MAX_AXES {
+        for axis in 0..n_axes {
             let covered = |f: fn(&LimitSet) -> f64| {
                 sets.iter()
                     .any(|s| s.axes.contains(axis) && f(s).is_finite())
@@ -97,12 +116,32 @@ impl Limits {
         Ok(Self {
             sets: arr,
             n_sets: sets.len() as u8,
+            n_axes: n_axes as u8,
         })
     }
 
     #[must_use]
     pub fn sets(&self) -> &[LimitSet] {
         &self.sets[..self.n_sets as usize]
+    }
+
+    #[must_use]
+    pub fn n_axes(&self) -> usize {
+        self.n_axes as usize
+    }
+
+    pub fn spatial_sets(&self) -> impl Iterator<Item = (usize, &LimitSet)> {
+        self.sets()
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.axes.is_spatial())
+    }
+
+    pub fn follower_sets(&self) -> impl Iterator<Item = (usize, &LimitSet)> {
+        self.sets()
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.axes.is_follower())
     }
 
     #[must_use]
@@ -115,24 +154,27 @@ impl Limits {
                 j_max: j[ax],
             })
             .collect();
-        Self::try_new(&sets).expect("axis_boxes: finite positive caps")
+        Self::try_new(&sets, N_SPATIAL).expect("axis_boxes: finite positive caps")
     }
 
     #[must_use]
     pub fn norm_all(v: f64, a: f64, j: f64) -> Self {
-        Self::try_new(&[LimitSet {
-            axes: AxisSet::all(),
-            v_max: v,
-            a_max: a,
-            j_max: j,
-        }])
+        Self::try_new(
+            &[LimitSet {
+                axes: AxisSet::spatial(),
+                v_max: v,
+                a_max: a,
+                j_max: j,
+            }],
+            N_SPATIAL,
+        )
         .expect("norm_all: finite positive caps")
     }
 
     #[must_use]
     pub fn mvc_b(&self, c_prime: &[f64; 3], floor: f64) -> f64 {
         let mut bound = f64::INFINITY;
-        for s in self.sets() {
+        for (_, s) in self.spatial_sets() {
             if !s.v_max.is_finite() {
                 continue;
             }
@@ -157,7 +199,7 @@ impl Limits {
 
     fn tan_cap(&self, c_prime: &[f64; 3], floor: f64, cap: fn(&LimitSet) -> f64) -> f64 {
         let mut bound = f64::INFINITY;
-        for s in self.sets() {
+        for (_, s) in self.spatial_sets() {
             let c = cap(s);
             if !c.is_finite() {
                 continue;
@@ -172,18 +214,16 @@ impl Limits {
 
     #[must_use]
     pub fn j_path(&self) -> f64 {
-        self.sets()
-            .iter()
-            .map(|s| s.j_max)
+        self.spatial_sets()
+            .map(|(_, s)| s.j_max)
             .filter(|j| j.is_finite())
             .fold(f64::INFINITY, f64::min)
     }
 
     #[must_use]
     pub fn v_ceiling(&self) -> f64 {
-        self.sets()
-            .iter()
-            .map(|s| s.v_max)
+        self.spatial_sets()
+            .map(|(_, s)| s.v_max)
             .filter(|v| v.is_finite())
             .fold(f64::NEG_INFINITY, f64::max)
     }
@@ -214,14 +254,14 @@ impl Limits {
     #[must_use]
     pub fn with_sets_mapped(&self, f: impl Fn(&LimitSet) -> LimitSet) -> Self {
         let sets: Vec<LimitSet> = self.sets().iter().map(f).collect();
-        Self::try_new(&sets).expect("set mapping preserves validity")
+        Self::try_new(&sets, self.n_axes()).expect("set mapping preserves validity")
     }
 
     #[must_use]
     pub fn with_extra_sets(&self, extra: &[LimitSet]) -> Self {
         let mut sets: Vec<LimitSet> = self.sets().to_vec();
         sets.extend_from_slice(extra);
-        Self::try_new(&sets).expect("appending sets preserves validity")
+        Self::try_new(&sets, self.n_axes()).expect("appending sets preserves validity")
     }
 
     #[must_use]
@@ -232,7 +272,7 @@ impl Limits {
         kappa_floor: f64,
     ) -> f64 {
         let mut bound = f64::INFINITY;
-        for s in self.sets() {
+        for (_, s) in self.spatial_sets() {
             if !s.a_max.is_finite() {
                 continue;
             }
@@ -247,11 +287,13 @@ impl Limits {
 
 #[must_use]
 pub fn restricted_norm(v: &[f64; 3], axes: AxisSet) -> f64 {
+    debug_assert!(axes.is_spatial());
     axes.indices().map(|i| v[i] * v[i]).sum::<f64>().sqrt()
 }
 
 #[must_use]
 pub fn kappa_set(c_prime: &[f64; 3], c_double_prime: &[f64; 3], axes: AxisSet, floor: f64) -> f64 {
+    debug_assert!(axes.is_spatial());
     let mut pp = 0.0;
     let mut pq = 0.0;
     let mut qq = 0.0;

--- a/rust/temporal/src/limits/tests.rs
+++ b/rust/temporal/src/limits/tests.rs
@@ -11,33 +11,39 @@ fn set(axes: &[usize], v: f64, a: f64, j: f64) -> LimitSet {
 
 #[test]
 fn coverage_validation_rejects_uncovered_axis() {
-    let err = Limits::try_new(&[set(&[0, 1], 300.0, 3000.0, 6000.0)]).unwrap_err();
+    let err = Limits::try_new(&[set(&[0, 1], 300.0, 3000.0, 6000.0)], 3).unwrap_err();
     assert!(matches!(err, LimitsError::NoVelocityCoverage { axis: 2 }));
 }
 
 #[test]
 fn coverage_is_per_derivative() {
-    let err = Limits::try_new(&[
-        set(&[0, 1, 2], 300.0, f64::INFINITY, f64::INFINITY),
-        set(&[0, 1], f64::INFINITY, 3000.0, 6000.0),
-    ])
+    let err = Limits::try_new(
+        &[
+            set(&[0, 1, 2], 300.0, f64::INFINITY, f64::INFINITY),
+            set(&[0, 1], f64::INFINITY, 3000.0, 6000.0),
+        ],
+        3,
+    )
     .unwrap_err();
     assert!(matches!(err, LimitsError::NoAccelCoverage { axis: 2 }));
 }
 
 #[test]
 fn rejects_nonpositive_caps() {
-    let err = Limits::try_new(&[set(&[0], 0.0, 100.0, 200.0)]).unwrap_err();
+    let err = Limits::try_new(&[set(&[0], 0.0, 100.0, 200.0)], 3).unwrap_err();
     assert!(matches!(err, LimitsError::BadCap { set: 0 }));
 }
 
 #[test]
 fn mvc_b_is_min_over_sets() {
-    let lim = Limits::try_new(&[
-        set(&[0, 1], 60.0, 6000.0, 12000.0),
-        set(&[1], 40.0, f64::INFINITY, f64::INFINITY),
-        set(&[2], 15.0, 100.0, 200.0),
-    ])
+    let lim = Limits::try_new(
+        &[
+            set(&[0, 1], 60.0, 6000.0, 12000.0),
+            set(&[1], 40.0, f64::INFINITY, f64::INFINITY),
+            set(&[2], 15.0, 100.0, 200.0),
+        ],
+        3,
+    )
     .unwrap();
     let pure_y = [0.0, 1.0, 0.0];
     assert!((lim.mvc_b(&pure_y, 1e-9) - 1600.0).abs() < 1e-9);
@@ -88,11 +94,55 @@ fn kappa_set_is_orthogonal_component_of_restricted_second_derivative() {
 }
 
 #[test]
-fn b_cent_cap_uses_per_set_kappa() {
-    let lim = Limits::try_new(&[
-        set(&[0, 1], 300.0, 1000.0, 2000.0),
+fn follower_axis_coverage_is_validated() {
+    let spatial = [
+        set(&[0, 1], 300.0, 3000.0, 6000.0),
         set(&[2], 15.0, 100.0, 200.0),
-    ])
+    ];
+    let err = Limits::try_new(&spatial, 4).unwrap_err();
+    assert!(matches!(err, LimitsError::NoVelocityCoverage { axis: 3 }));
+
+    let mut with_e = spatial.to_vec();
+    with_e.push(set(&[3], 75.0, 1500.0, 3000.0));
+    let lim = Limits::try_new(&with_e, 4).unwrap();
+    assert_eq!(lim.follower_sets().count(), 1);
+    assert_eq!(lim.spatial_sets().count(), 2);
+}
+
+#[test]
+fn mixed_spatial_follower_set_is_rejected() {
+    let sets = [
+        set(&[0, 1, 2], 300.0, 3000.0, 6000.0),
+        set(&[0, 3], 10.0, 100.0, 200.0),
+    ];
+    assert!(matches!(
+        Limits::try_new(&sets, 4).unwrap_err(),
+        LimitsError::MixedSpatialFollower { set: 1 }
+    ));
+}
+
+#[test]
+fn three_axis_construction_is_unchanged() {
+    let lim = Limits::axis_boxes([300.0; 3], [3000.0; 3], [6000.0; 3]);
+    assert_eq!(lim.sets().len(), 3);
+    assert_eq!(lim.follower_sets().count(), 0);
+}
+
+#[test]
+fn spatial_helpers_reject_follower_sets() {
+    let s = set(&[3], 75.0, 1500.0, 3000.0);
+    assert!(!s.axes.is_spatial());
+}
+
+#[test]
+fn b_cent_cap_uses_per_set_kappa() {
+    let lim = Limits::try_new(
+        &[
+            set(&[0, 1], 300.0, 1000.0, 2000.0),
+            set(&[2], 15.0, 100.0, 200.0),
+        ],
+        3,
+    )
     .unwrap();
     let c_prime = [1.0, 0.0, 0.0];
     let c_double_prime = [0.0, 0.5, 0.0];

--- a/rust/temporal/src/multi/joining.rs
+++ b/rust/temporal/src/multi/joining.rs
@@ -69,6 +69,146 @@ pub(crate) fn bidirectional_junction_sweep(
     dirty_count
 }
 
+const TAIL_EXCHANGE_MAX: u32 = 3;
+const TAIL_EXCHANGE_REL_TOL: f64 = 1e-3;
+const TAIL_SAMPLES: usize = 32;
+
+fn profile_time_map(profile: &TopProfile) -> Vec<f64> {
+    let mut t = vec![0.0];
+    for w in profile.samples.windows(2) {
+        let v_sum = (w[0].v + w[1].v).max(1e-12);
+        t.push(t.last().unwrap() + 2.0 * (w[1].s - w[0].s) / v_sum);
+    }
+    t
+}
+
+fn axis_velocity_at(profile: &TopProfile, chain: &ChainGrid, t_map: &[f64], tau: f64) -> [f64; 3] {
+    let n = profile.samples.len();
+    let total = *t_map.last().unwrap();
+    let tau = tau.clamp(0.0, total);
+    let j = t_map.partition_point(|&tj| tj <= tau).clamp(1, n - 1);
+    let frac = (tau - t_map[j - 1]) / (t_map[j] - t_map[j - 1]).max(1e-12);
+    let v = profile.samples[j - 1].v + (profile.samples[j].v - profile.samples[j - 1].v) * frac;
+    let cp = if frac < 0.5 {
+        chain.geom[j - 1].c_prime
+    } else {
+        chain.geom[j].c_prime
+    };
+    [cp[0] * v, cp[1] * v, cp[2] * v]
+}
+
+fn sample_boundary_window(
+    profile: &TopProfile,
+    chain: &ChainGrid,
+    width: f64,
+    from_end: bool,
+) -> crate::FollowerHistory {
+    let t_map = profile_time_map(profile);
+    let total = *t_map.last().unwrap();
+    let dt = width / TAIL_SAMPLES as f64;
+    let mut axis_velocity: [Vec<f64>; 3] = Default::default();
+    for m in 0..TAIL_SAMPLES {
+        let offset = (m as f64 + 0.5) * dt;
+        let tau = if from_end { total - offset } else { offset };
+        let v = axis_velocity_at(profile, chain, &t_map, tau);
+        for alpha in 0..3 {
+            axis_velocity[alpha].push(v[alpha]);
+        }
+    }
+    crate::FollowerHistory { dt, axis_velocity }
+}
+
+fn max_kernel_half_support(chain: &ChainGrid) -> f64 {
+    chain
+        .axis_kernels
+        .iter()
+        .flatten()
+        .map(|k| k.support().1)
+        .fold(0.0, f64::max)
+}
+
+/// The shaper window spans chain junctions (full stops): the neighbor chain's
+/// ramp contributes to shaped speed near the boundary. After joining has
+/// converged, re-solve each windowed chain with its neighbors' boundary-window
+/// velocity samples as constants, iterated until total times settle.
+pub(crate) fn exchange_follower_tails(
+    chain_grids: &mut [ChainGrid],
+    states: &mut [ChainState],
+    n_threads: usize,
+) -> Result<(), BatchError> {
+    let n = chain_grids.len();
+    if n < 2 || !chain_grids.iter().any(ChainGrid::has_active_windows) {
+        return Ok(());
+    }
+    let mut prev_times: Vec<f64> = states
+        .iter()
+        .map(|s| {
+            s.profile
+                .as_ref()
+                .expect("joining solved every chain")
+                .total_time
+        })
+        .collect();
+    for pass in 1..=TAIL_EXCHANGE_MAX {
+        let tails: Vec<Option<(crate::FollowerHistory, crate::FollowerHistory)>> = (0..n)
+            .map(|c| {
+                if !chain_grids[c].has_active_windows() {
+                    return None;
+                }
+                let width = max_kernel_half_support(&chain_grids[c]);
+                let left = (c > 0).then(|| {
+                    sample_boundary_window(
+                        states[c - 1].profile.as_ref().unwrap(),
+                        &chain_grids[c - 1],
+                        width,
+                        true,
+                    )
+                });
+                let right = (c + 1 < n).then(|| {
+                    sample_boundary_window(
+                        states[c + 1].profile.as_ref().unwrap(),
+                        &chain_grids[c + 1],
+                        width,
+                        false,
+                    )
+                });
+                Some((left.unwrap_or_default(), right.unwrap_or_default()))
+            })
+            .collect();
+        for (c, tail) in tails.into_iter().enumerate() {
+            let Some((left, right)) = tail else { continue };
+            if c > 0 {
+                chain_grids[c].follower_history = Some(left);
+            }
+            if c + 1 < n {
+                chain_grids[c].follower_terminal = Some(right);
+            }
+            states[c].dirty = true;
+        }
+        fan_out_solves(chain_grids, states, n_threads)?;
+        let mut worst: (usize, f64) = (0, 0.0);
+        for (c, state) in states.iter().enumerate() {
+            let t = state.profile.as_ref().unwrap().total_time;
+            let rel = (t - prev_times[c]).abs() / prev_times[c].max(1e-9);
+            if rel > worst.1 {
+                worst = (c, rel);
+            }
+            prev_times[c] = t;
+        }
+        if worst.1 <= TAIL_EXCHANGE_REL_TOL {
+            return Ok(());
+        }
+        if pass == TAIL_EXCHANGE_MAX {
+            return Err(BatchError::TailExchangeDiverged {
+                passes: pass,
+                chain: worst.0,
+                rel_change: worst.1,
+            });
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 pub(crate) fn forward_sweep(states: &mut [ChainState], corner_caps: &[f64]) -> usize {
     const EPS_VEL: f64 = 1e-3;

--- a/rust/temporal/src/multi/mod.rs
+++ b/rust/temporal/src/multi/mod.rs
@@ -17,6 +17,7 @@ pub enum GridStrategy {
 pub struct SegmentInput<'a> {
     pub curve: &'a VectorNurbs<f64, 3>,
     pub limits: Limits,
+    pub followers: &'a [crate::FollowerDemand],
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -61,6 +62,8 @@ pub enum BatchError {
     InvalidThreads,
     #[error("segment {0}: {1}")]
     Segment(usize, crate::topp::ScheduleError),
+    #[error("invalid follower demand: {0}")]
+    InvalidFollowerDemand(String),
 }
 
 pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
@@ -124,8 +127,18 @@ pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
                 })
                 .collect();
             let seg_limits: Vec<_> = range.clone().map(|i| input.segments[i].limits).collect();
-            seg_grids.map(|grids| {
-                ChainGrid::from_segment_grids_with_absorbed(grids, seg_limits, &absorbed)
+            let seg_followers: Vec<_> = range
+                .clone()
+                .map(|i| input.segments[i].followers.to_vec())
+                .collect();
+            seg_grids.and_then(|grids| {
+                ChainGrid::try_from_segment_grids_with_followers(
+                    grids,
+                    seg_limits,
+                    seg_followers,
+                    &absorbed,
+                )
+                .map_err(|e| BatchError::InvalidFollowerDemand(e.to_string()))
             })
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/rust/temporal/src/multi/mod.rs
+++ b/rust/temporal/src/multi/mod.rs
@@ -23,6 +23,9 @@ pub struct SegmentInput<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct BatchInput<'a> {
     pub segments: &'a [SegmentInput<'a>],
+    /// Input-shaper kernels + pre-batch follower history; `None` = no shaper
+    /// folding anywhere in the batch.
+    pub shaping: Option<&'a BatchShaping>,
     pub grid_strategy: GridStrategy,
     pub worker_threads: usize,
     pub initial_velocity: f64,
@@ -30,6 +33,12 @@ pub struct BatchInput<'a> {
     /// at a rest start it MUST be 0.0 (asserted) and the rest envelope governs.
     pub initial_accel: f64,
     pub terminal_velocity: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BatchShaping {
+    pub axis_kernels: [Option<nurbs::algebra::PiecewisePolynomialKernel<f64>>; 3],
+    pub follower_history: Option<crate::FollowerHistory>,
 }
 
 #[derive(Debug)]
@@ -64,6 +73,15 @@ pub enum BatchError {
     Segment(usize, crate::topp::ScheduleError),
     #[error("invalid follower demand: {0}")]
     InvalidFollowerDemand(String),
+    #[error(
+        "follower tail exchange did not settle after {passes} passes \
+         (chain {chain} total time still moving {rel_change:.4})"
+    )]
+    TailExchangeDiverged {
+        passes: u32,
+        chain: usize,
+        rel_change: f64,
+    },
 }
 
 pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
@@ -143,6 +161,16 @@ pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    let mut chain_grids = chain_grids;
+    if let Some(shaping) = input.shaping {
+        for (c, cg) in chain_grids.iter_mut().enumerate() {
+            cg.axis_kernels = shaping.axis_kernels.clone();
+            if c == 0 {
+                cg.follower_history = shaping.follower_history.clone();
+            }
+        }
+    }
+
     let mut states: Vec<joining::ChainState> = chain_ranges
         .iter()
         .enumerate()
@@ -178,6 +206,8 @@ pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
         &corner_caps,
         input.worker_threads,
     )?;
+
+    joining::exchange_follower_tails(&mut chain_grids, &mut states, input.worker_threads)?;
 
     // Slice each chain profile into per-segment profiles and flatten.
     let profiles: Vec<TopProfile> = states

--- a/rust/temporal/src/multi/parallel.rs
+++ b/rust/temporal/src/multi/parallel.rs
@@ -355,7 +355,8 @@ fn scale_chain_v_max(chain: &ChainGrid, factor: f64) -> ChainGrid {
                 j_max: s.j_max,
             })
             .collect();
-        *l = crate::Limits::try_new(&sets).expect("velocity rescale preserves validity");
+        *l =
+            crate::Limits::try_new(&sets, l.n_axes()).expect("velocity rescale preserves validity");
     }
     scaled
 }

--- a/rust/temporal/src/multi/tests.rs
+++ b/rust/temporal/src/multi/tests.rs
@@ -25,6 +25,7 @@ fn plan_batch_single_segment_works() {
     };
     let input = BatchInput {
         segments: &[segment],
+        shaping: None,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 10,
             max_n: 200,
@@ -83,6 +84,7 @@ fn smooth_junction_has_no_accel_impulse() {
     ];
     let out = plan_batch(BatchInput {
         segments: &segs,
+        shaping: None,
         grid_strategy: GridStrategy::Fixed(32),
         worker_threads: 1,
         initial_velocity: 0.0,
@@ -138,6 +140,7 @@ fn plan_batch_threads_nonzero_initial_velocity() {
     };
     let input = BatchInput {
         segments: &[segment],
+        shaping: None,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,
             max_n: 200,

--- a/rust/temporal/src/multi/tests.rs
+++ b/rust/temporal/src/multi/tests.rs
@@ -21,6 +21,7 @@ fn plan_batch_single_segment_works() {
     let segment = SegmentInput {
         curve: &curve,
         limits: textbook_limits(),
+        followers: &[],
     };
     let input = BatchInput {
         segments: &[segment],
@@ -72,10 +73,12 @@ fn smooth_junction_has_no_accel_impulse() {
         SegmentInput {
             curve: &left,
             limits,
+            followers: &[],
         },
         SegmentInput {
             curve: &right,
             limits,
+            followers: &[],
         },
     ];
     let out = plan_batch(BatchInput {
@@ -131,6 +134,7 @@ fn plan_batch_threads_nonzero_initial_velocity() {
     let segment = SegmentInput {
         curve: &curve,
         limits: textbook_limits(),
+        followers: &[],
     };
     let input = BatchInput {
         segments: &[segment],

--- a/rust/temporal/src/topp/chain.rs
+++ b/rust/temporal/src/topp/chain.rs
@@ -1,5 +1,30 @@
-use crate::Limits;
 use crate::topp::path::{ArclengthGrid, InterSample};
+use crate::{FollowerDemand, Limits, N_SPATIAL};
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum ChainError {
+    #[error(
+        "segment {segment}: follower demand axis {axis} out of range \
+         [{N_SPATIAL}, {n_axes})"
+    )]
+    FollowerAxisOutOfRange {
+        segment: usize,
+        axis: usize,
+        n_axes: usize,
+    },
+    #[error("segment {segment}: follower demand axis {axis} has invalid ratio {ratio}")]
+    InvalidFollowerRatio {
+        segment: usize,
+        axis: usize,
+        ratio: f64,
+    },
+    #[error("segment {segment}: follower demand axis {axis} has invalid pa_k {pa_k}")]
+    InvalidFollowerPaGain {
+        segment: usize,
+        axis: usize,
+        pa_k: f64,
+    },
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PointGeom {
@@ -35,6 +60,8 @@ pub struct ChainGrid {
     /// Interior geometry samples for each chain interval `[i, i+1]`, len M−1.
     /// Each sample's θ ∈ (0,1).
     pub inter_geom: Vec<Vec<InterSample>>,
+    /// Follower demands per segment, indexed like `limits`.
+    pub followers: Vec<Vec<FollowerDemand>>,
 }
 
 pub(crate) const MAX_JUNCTION_SPACING_RATIO: f64 = 16.0;
@@ -43,6 +70,43 @@ impl ChainGrid {
     pub fn from_segment_grids(grids: Vec<ArclengthGrid>, limits: Vec<Limits>) -> Self {
         let n = grids.len();
         Self::from_segment_grids_with_absorbed(grids, limits, &vec![false; n])
+    }
+
+    pub fn try_from_segment_grids_with_followers(
+        grids: Vec<ArclengthGrid>,
+        limits: Vec<Limits>,
+        followers: Vec<Vec<FollowerDemand>>,
+        absorbed: &[bool],
+    ) -> Result<Self, ChainError> {
+        assert_eq!(followers.len(), limits.len());
+        for (segment, (segment_followers, lim)) in followers.iter().zip(&limits).enumerate() {
+            for f in segment_followers {
+                if f.axis < N_SPATIAL || f.axis >= lim.n_axes() {
+                    return Err(ChainError::FollowerAxisOutOfRange {
+                        segment,
+                        axis: f.axis,
+                        n_axes: lim.n_axes(),
+                    });
+                }
+                if !f.ratio.is_finite() || f.ratio == 0.0 {
+                    return Err(ChainError::InvalidFollowerRatio {
+                        segment,
+                        axis: f.axis,
+                        ratio: f.ratio,
+                    });
+                }
+                if !f.pa_k.is_finite() || f.pa_k < 0.0 {
+                    return Err(ChainError::InvalidFollowerPaGain {
+                        segment,
+                        axis: f.axis,
+                        pa_k: f.pa_k,
+                    });
+                }
+            }
+        }
+        let mut chain = Self::from_segment_grids_with_absorbed(grids, limits, absorbed);
+        chain.followers = followers;
+        Ok(chain)
     }
 
     /// Concatenate per-segment grids into one chain. Adjacent grids must be
@@ -123,6 +187,7 @@ impl ChainGrid {
             s_offset += g.total_length;
         }
 
+        let followers = vec![Vec::new(); limits.len()];
         Self {
             s,
             geom,
@@ -132,6 +197,7 @@ impl ChainGrid {
             junctions,
             segment_ranges,
             inter_geom,
+            followers,
         }
     }
 
@@ -141,6 +207,10 @@ impl ChainGrid {
 
     pub fn limits_at(&self, i: usize) -> &Limits {
         &self.limits[self.limits_idx[i]]
+    }
+
+    pub fn followers_at(&self, i: usize) -> &[FollowerDemand] {
+        &self.followers[self.limits_idx[i]]
     }
 }
 

--- a/rust/temporal/src/topp/chain.rs
+++ b/rust/temporal/src/topp/chain.rs
@@ -1,5 +1,6 @@
 use crate::topp::path::{ArclengthGrid, InterSample};
-use crate::{FollowerDemand, Limits, N_SPATIAL};
+use crate::{FollowerDemand, FollowerHistory, Limits, N_SPATIAL};
+use nurbs::algebra::PiecewisePolynomialKernel;
 
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum ChainError {
@@ -62,6 +63,14 @@ pub struct ChainGrid {
     pub inter_geom: Vec<Vec<InterSample>>,
     /// Follower demands per segment, indexed like `limits`.
     pub followers: Vec<Vec<FollowerDemand>>,
+    /// Input-shaper kernels per spatial axis; `None` = passthrough.
+    pub axis_kernels: [Option<PiecewisePolynomialKernel<f64>>; 3],
+    /// Realized per-axis velocity immediately before this chain, for the
+    /// shaper window's left edge.
+    pub follower_history: Option<FollowerHistory>,
+    /// Per-axis velocity immediately after this chain (the right neighbor's
+    /// ramp), for the shaper window's right edge.
+    pub follower_terminal: Option<FollowerHistory>,
 }
 
 pub(crate) const MAX_JUNCTION_SPACING_RATIO: f64 = 16.0;
@@ -198,7 +207,15 @@ impl ChainGrid {
             segment_ranges,
             inter_geom,
             followers,
+            axis_kernels: [None, None, None],
+            follower_history: None,
+            follower_terminal: None,
         }
+    }
+
+    pub fn has_active_windows(&self) -> bool {
+        self.axis_kernels.iter().any(Option::is_some)
+            && self.followers.iter().any(|f| !f.is_empty())
     }
 
     pub fn n_points(&self) -> usize {

--- a/rust/temporal/src/topp/chain.rs
+++ b/rust/temporal/src/topp/chain.rs
@@ -88,7 +88,17 @@ impl ChainGrid {
         absorbed: &[bool],
     ) -> Result<Self, ChainError> {
         assert_eq!(followers.len(), limits.len());
-        for (segment, (segment_followers, lim)) in followers.iter().zip(&limits).enumerate() {
+        Self::validate_followers(&followers, &limits)?;
+        let mut chain = Self::from_segment_grids_with_absorbed(grids, limits, absorbed);
+        chain.followers = followers;
+        Ok(chain)
+    }
+
+    fn validate_followers(
+        followers: &[Vec<FollowerDemand>],
+        limits: &[Limits],
+    ) -> Result<(), ChainError> {
+        for (segment, (segment_followers, lim)) in followers.iter().zip(limits).enumerate() {
             for f in segment_followers {
                 if f.axis < N_SPATIAL || f.axis >= lim.n_axes() {
                     return Err(ChainError::FollowerAxisOutOfRange {
@@ -113,9 +123,7 @@ impl ChainGrid {
                 }
             }
         }
-        let mut chain = Self::from_segment_grids_with_absorbed(grids, limits, absorbed);
-        chain.followers = followers;
-        Ok(chain)
+        Ok(())
     }
 
     /// Concatenate per-segment grids into one chain. Adjacent grids must be
@@ -211,6 +219,60 @@ impl ChainGrid {
             follower_history: None,
             follower_terminal: None,
         }
+    }
+
+    /// Chain for a follower-only move: zero spatial geometry, arclength =
+    /// the largest follower displacement, follower rows + feedrate cap do
+    /// all the limiting (spec §2's fallback line).
+    pub fn virtual_path(
+        length: f64,
+        n: usize,
+        limits: Limits,
+        followers: Vec<FollowerDemand>,
+        feedrate_mm_s: f64,
+    ) -> Result<Self, ChainError> {
+        assert!(length > 0.0 && length.is_finite(), "virtual path length");
+        assert!(n >= 2, "virtual path needs at least 2 grid points");
+        assert!(
+            !followers.is_empty(),
+            "virtual path without followers is a zero move"
+        );
+        let limits = if feedrate_mm_s.is_finite() && feedrate_mm_s > 0.0 {
+            let axes: Vec<usize> = followers.iter().map(|f| f.axis).collect();
+            limits.with_extra_sets(&[crate::LimitSet {
+                axes: crate::AxisSet::from_indices(&axes),
+                v_max: feedrate_mm_s,
+                a_max: f64::INFINITY,
+                j_max: f64::INFINITY,
+            }])
+        } else {
+            limits
+        };
+        let h = length / (n - 1) as f64;
+        let zero_geom = PointGeom {
+            c_prime: [0.0; 3],
+            c_double_prime: [0.0; 3],
+            c_triple_prime: [0.0; 3],
+        };
+        let mut chain = Self {
+            s: (0..n).map(|i| i as f64 * h).collect(),
+            geom: vec![zero_geom; n],
+            h_intervals: vec![h; n - 1],
+            limits_idx: vec![0; n],
+            limits: vec![limits],
+            junctions: Vec::new(),
+            segment_ranges: vec![(0, n - 1)],
+            inter_geom: vec![Vec::new(); n - 1],
+            followers: vec![Vec::new()],
+            axis_kernels: [None, None, None],
+            follower_history: None,
+            follower_terminal: None,
+        };
+        let grids: Vec<ArclengthGrid> = Vec::new();
+        let _ = grids;
+        Self::validate_followers(&[followers.clone()], &chain.limits)?;
+        chain.followers = vec![followers];
+        Ok(chain)
     }
 
     pub fn has_active_windows(&self) -> bool {

--- a/rust/temporal/src/topp/chain/tests.rs
+++ b/rust/temporal/src/topp/chain/tests.rs
@@ -49,3 +49,72 @@ fn extreme_spacing_ratio_panics() {
 fn lim(v: f64) -> Limits {
     Limits::axis_boxes([v; 3], [5_000.0; 3], [100_000.0; 3])
 }
+
+#[test]
+fn chain_carries_per_segment_follower_demands() {
+    let a = tests_support::line([0.0; 3], [40.0, 0.0, 0.0]);
+    let b = tests_support::line([40.0, 0.0, 0.0], [80.0, 0.0, 0.0]);
+    let ga = sample_arclength_grid(&a, 11).unwrap();
+    let gb = sample_arclength_grid(&b, 11).unwrap();
+    let demand = crate::FollowerDemand {
+        axis: 3,
+        ratio: 0.05,
+        pa_k: 0.0,
+    };
+    let chain = ChainGrid::try_from_segment_grids_with_followers(
+        vec![ga, gb],
+        vec![lim_e(300.0), lim_e(300.0)],
+        vec![vec![demand], vec![]],
+        &[false, false],
+    )
+    .unwrap();
+    let (s0, e0) = chain.segment_ranges[0];
+    let (s1, e1) = chain.segment_ranges[1];
+    for i in s0..e0 {
+        assert_eq!(chain.followers_at(i), &[demand]);
+    }
+    for i in (e0.max(s1) + 1)..=e1 {
+        assert!(chain.followers_at(i).is_empty());
+    }
+}
+
+#[test]
+fn follower_demand_validation_fails_loudly() {
+    let a = tests_support::line([0.0; 3], [40.0, 0.0, 0.0]);
+    let ga = sample_arclength_grid(&a, 11).unwrap();
+    let bad = |d: crate::FollowerDemand| {
+        ChainGrid::try_from_segment_grids_with_followers(
+            vec![ga.clone()],
+            vec![lim_e(300.0)],
+            vec![vec![d]],
+            &[false],
+        )
+        .unwrap_err()
+    };
+    let base = crate::FollowerDemand {
+        axis: 3,
+        ratio: 0.05,
+        pa_k: 0.0,
+    };
+    bad(crate::FollowerDemand { axis: 1, ..base });
+    bad(crate::FollowerDemand { axis: 4, ..base });
+    bad(crate::FollowerDemand {
+        ratio: f64::NAN,
+        ..base
+    });
+    bad(crate::FollowerDemand { ratio: 0.0, ..base });
+    bad(crate::FollowerDemand { pa_k: -1.0, ..base });
+}
+
+fn lim_e(v: f64) -> Limits {
+    let mut sets: Vec<crate::LimitSet> = Limits::axis_boxes([v; 3], [5_000.0; 3], [100_000.0; 3])
+        .sets()
+        .to_vec();
+    sets.push(crate::LimitSet {
+        axes: crate::AxisSet::from_indices(&[3]),
+        v_max: 75.0,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    Limits::try_new(&sets, 4).unwrap()
+}

--- a/rust/temporal/src/topp/constraints.rs
+++ b/rust/temporal/src/topp/constraints.rs
@@ -22,7 +22,7 @@ pub struct ConstraintBundle {
     pub b_max_cent: Vec<f64>,
 
     pub h_intervals: Vec<f64>,
-    pub j_path: f64,
+    pub j_path_at: Vec<f64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -293,12 +293,26 @@ pub fn build_chain(
 
     let n_vars = off_x2 + n_interior;
 
-    let j_path = chain
-        .limits
-        .iter()
-        .map(Limits::j_path)
-        .fold(f64::INFINITY, f64::min);
-    debug_assert!(j_path > 0.0, "jerk limit must be positive");
+    let j_path_at: Vec<f64> = (0..n)
+        .map(|i| {
+            let mut cap = chain.limits_at(i).j_path();
+            for f in chain.followers_at(i) {
+                if f.pa_k != 0.0 {
+                    continue;
+                }
+                for (_, set) in chain.limits_at(i).follower_sets() {
+                    if set.axes.contains(f.axis) && set.j_max.is_finite() {
+                        cap = cap.min(set.j_max / f.ratio.abs());
+                    }
+                }
+            }
+            cap
+        })
+        .collect();
+    debug_assert!(
+        j_path_at.iter().all(|&j| j > 0.0),
+        "jerk limit must be positive"
+    );
 
     let mut cones: Vec<(Cone, usize)> = Vec::new();
     let mut a_rows: Vec<Vec<f64>> = Vec::new();
@@ -625,7 +639,7 @@ pub fn build_chain(
             let i = k + 1;
             let t_idx = off_t + k;
             let w = crate::topp::stencil::b_dd_weights(h[i - 1], h[i]);
-            let c = h_bar(i) / (2.0 * j_path);
+            let c = h_bar(i) / (2.0 * j_path_at[k + 1]);
             for sign in [1.0_f64, -1.0] {
                 push_row(
                     &mut a_rows,
@@ -726,7 +740,7 @@ pub fn build_chain(
         objective,
         b_max_cent,
         h_intervals: chain.h_intervals.clone(),
-        j_path,
+        j_path_at,
     })
 }
 

--- a/rust/temporal/src/topp/constraints.rs
+++ b/rust/temporal/src/topp/constraints.rs
@@ -379,7 +379,7 @@ pub fn build_chain(
                              a_rows: &mut Vec<Vec<f64>>,
                              b_rhs: &mut Vec<f64>,
                              count: &mut usize| {
-            for set in lim.sets() {
+            for (_, set) in lim.spatial_sets() {
                 if !set.v_max.is_finite() {
                     continue;
                 }
@@ -421,6 +421,16 @@ pub fn build_chain(
     }
 
     {
+        let count =
+            crate::topp::follower::emit_base_follower_rows(chain, off_b, off_a, |entries, rhs| {
+                push_row(&mut a_rows, &mut b_rhs, entries, rhs)
+            });
+        if count > 0 {
+            cones.push((Cone::Nonneg, count));
+        }
+    }
+
+    {
         const BLOCK_D_SAFETY: f64 = 0.1;
         let mut nonneg_run = 0_usize;
         let emit_accel = |i: usize,
@@ -432,7 +442,7 @@ pub fn build_chain(
                           nonneg_run: &mut usize| {
             let b_cap_i = b_max_cent[i].min(b_cap);
             let a_cap_i = b_cap_i / (2.0 * h_bar(i));
-            for set in lim.sets() {
+            for (_, set) in lim.spatial_sets() {
                 if !set.a_max.is_finite() {
                     continue;
                 }

--- a/rust/temporal/src/topp/constraints.rs
+++ b/rust/temporal/src/topp/constraints.rs
@@ -237,6 +237,27 @@ pub fn build_chain(
                 j_env = j_env.max(j_tan_i);
             }
         }
+        if !(a_env.is_finite() && j_env.is_finite()) {
+            for i in 0..n {
+                let lim = chain.limits_at(i);
+                for f in chain.followers_at(i) {
+                    let r = f.ratio.abs();
+                    let mut a_cap = f64::INFINITY;
+                    let mut j_cap = f64::INFINITY;
+                    for (_, set) in lim.follower_sets() {
+                        if !set.axes.contains(f.axis) {
+                            continue;
+                        }
+                        a_cap = a_cap.min(set.a_max / r);
+                        j_cap = j_cap.min(set.j_max / r);
+                    }
+                    if a_cap.is_finite() && j_cap.is_finite() {
+                        a_env = a_env.max(a_cap);
+                        j_env = j_env.max(j_cap);
+                    }
+                }
+            }
+        }
         debug_assert!(
             a_env > 0.0 && j_env > 0.0,
             "A_env/J_env must be positive — corrupt grid tangents"

--- a/rust/temporal/src/topp/follower.rs
+++ b/rust/temporal/src/topp/follower.rs
@@ -34,5 +34,270 @@ pub(crate) fn emit_base_follower_rows(
     count
 }
 
+pub(crate) const PA_CUT_MAX_ENTRIES: usize = 10;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FollowerCut {
+    pub entries: [(usize, f64); PA_CUT_MAX_ENTRIES],
+    pub n_entries: usize,
+    pub rhs_pos: f64,
+    pub rhs_neg: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PaFamily {
+    Velocity,
+    Accel,
+    Jerk,
+}
+
+struct LinearizedDemand {
+    value: f64,
+    entries: Vec<(usize, f64)>,
+}
+
+fn accumulate(entries: &mut Vec<(usize, f64)>, col: usize, coeff: f64) {
+    if coeff == 0.0 {
+        return;
+    }
+    for e in entries.iter_mut() {
+        if e.0 == col {
+            e.1 += coeff;
+            return;
+        }
+    }
+    entries.push((col, coeff));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pa_demand_linearized(
+    family: PaFamily,
+    r: f64,
+    k: f64,
+    b: &[f64],
+    a: &[f64],
+    i: usize,
+    s: &[f64],
+    h_intervals: &[f64],
+    off_b: usize,
+    off_a: usize,
+    b_floor: f64,
+) -> LinearizedDemand {
+    let n = b.len();
+    let (idx2, hl, hr) = crate::topp::stencil::stencil_at(i, n, h_intervals);
+    let w2 = crate::topp::stencil::b_dd_weights(hl, hr);
+    let b_dd = w2[0] * b[idx2[0]] + w2[1] * b[idx2[1]] + w2[2] * b[idx2[2]];
+    let sqrt_b = b[i].max(b_floor).max(f64::MIN_POSITIVE).sqrt();
+    let s_dddot = sqrt_b * b_dd / 2.0;
+
+    let mut entries = Vec::new();
+    let value;
+    match family {
+        PaFamily::Velocity => {
+            value = r * (sqrt_b + k * a[i]);
+            accumulate(&mut entries, off_b + i, r / (2.0 * sqrt_b));
+            accumulate(&mut entries, off_a + i, r * k);
+        }
+        PaFamily::Accel => {
+            value = r * (a[i] + k * s_dddot);
+            accumulate(&mut entries, off_a + i, r);
+            add_s_dddot_gradient(&mut entries, r * k, &idx2, &w2, sqrt_b, b_dd, i, off_b);
+        }
+        PaFamily::Jerk => {
+            let (idx3, w3) = crate::topp::stencil::b_ddd_weights_at(i, s);
+            let b_ddd: f64 = (0..4).map(|m| w3[m] * b[idx3[m]]).sum();
+            let s_ddddot = a[i] * b_dd / 2.0 + b[i].max(0.0) * b_ddd / 2.0;
+            value = r * (s_dddot + k * s_ddddot);
+            add_s_dddot_gradient(&mut entries, r, &idx2, &w2, sqrt_b, b_dd, i, off_b);
+            accumulate(&mut entries, off_a + i, r * k * b_dd / 2.0);
+            for m in 0..3 {
+                accumulate(&mut entries, off_b + idx2[m], r * k * a[i] * w2[m] / 2.0);
+            }
+            for m in 0..4 {
+                accumulate(
+                    &mut entries,
+                    off_b + idx3[m],
+                    r * k * b[i].max(0.0) * w3[m] / 2.0,
+                );
+            }
+            accumulate(&mut entries, off_b + i, r * k * b_ddd / 2.0);
+        }
+    }
+    LinearizedDemand { value, entries }
+}
+
+fn add_s_dddot_gradient(
+    entries: &mut Vec<(usize, f64)>,
+    scale: f64,
+    idx2: &[usize; 3],
+    w2: &[f64; 3],
+    sqrt_b: f64,
+    b_dd: f64,
+    i: usize,
+    off_b: usize,
+) {
+    for m in 0..3 {
+        accumulate(entries, off_b + idx2[m], scale * sqrt_b * w2[m] / 2.0);
+    }
+    accumulate(entries, off_b + i, scale * b_dd / (4.0 * sqrt_b));
+}
+
+fn pa_families_for(set: &crate::LimitSet) -> [(PaFamily, f64); 3] {
+    [
+        (PaFamily::Velocity, set.v_max),
+        (PaFamily::Accel, set.a_max),
+        (PaFamily::Jerk, set.j_max),
+    ]
+}
+
+pub(crate) fn max_pa_ratio(b: &[f64], a: &[f64], chain: &ChainGrid) -> f64 {
+    let b_floor = 0.0;
+    let mut worst: f64 = 0.0;
+    for i in 0..b.len() {
+        let lim = chain.limits_at(i);
+        for f in chain.followers_at(i) {
+            if f.pa_k == 0.0 {
+                continue;
+            }
+            let r = f.ratio.abs();
+            for (_, set) in lim.follower_sets() {
+                if !set.axes.contains(f.axis) {
+                    continue;
+                }
+                for (family, cap) in pa_families_for(set) {
+                    if !cap.is_finite() {
+                        continue;
+                    }
+                    let d = pa_demand_linearized(
+                        family,
+                        r,
+                        f.pa_k,
+                        b,
+                        a,
+                        i,
+                        &chain.s,
+                        &chain.h_intervals,
+                        0,
+                        b.len(),
+                        b_floor,
+                    );
+                    worst = worst.max(d.value.abs() / cap);
+                }
+            }
+        }
+    }
+    worst
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_follower_pa_cuts(
+    b: &[f64],
+    a: &[f64],
+    chain: &ChainGrid,
+    target_ratio: f64,
+    eps_feas: f64,
+    placement_fraction: f64,
+    target_decay: f64,
+    b_floor: f64,
+) -> Vec<FollowerCut> {
+    let n = b.len();
+    let off_b = 0;
+    let off_a = n;
+    let mut cuts = Vec::new();
+    for i in 0..n {
+        let lim = chain.limits_at(i);
+        for f in chain.followers_at(i) {
+            if f.pa_k == 0.0 {
+                continue;
+            }
+            let r = f.ratio.abs();
+            for (_, set) in lim.follower_sets() {
+                if !set.axes.contains(f.axis) {
+                    continue;
+                }
+                for (family, cap) in pa_families_for(set) {
+                    if !cap.is_finite() {
+                        continue;
+                    }
+                    let d = pa_demand_linearized(
+                        family,
+                        r,
+                        f.pa_k,
+                        b,
+                        a,
+                        i,
+                        &chain.s,
+                        &chain.h_intervals,
+                        off_b,
+                        off_a,
+                        b_floor,
+                    );
+                    let ratio = d.value.abs() / cap;
+                    let cap_inflated = if target_ratio <= 1.0 + eps_feas {
+                        if ratio <= eps_feas {
+                            continue;
+                        }
+                        cap
+                    } else if ratio > placement_fraction * target_ratio {
+                        cap * target_ratio
+                    } else if ratio > 1.0 + eps_feas {
+                        cap * (ratio * target_decay).max(1.0)
+                    } else if ratio > eps_feas {
+                        cap
+                    } else {
+                        continue;
+                    };
+                    if let Some(cut) = finish_cut(&d, b, a, cap_inflated, off_b, off_a) {
+                        cuts.push(cut);
+                    }
+                }
+            }
+        }
+    }
+    cuts
+}
+
+fn finish_cut(
+    d: &LinearizedDemand,
+    b: &[f64],
+    a: &[f64],
+    cap: f64,
+    off_b: usize,
+    off_a: usize,
+) -> Option<FollowerCut> {
+    assert!(
+        d.entries.len() <= PA_CUT_MAX_ENTRIES,
+        "PA cut entry overflow"
+    );
+    let n = b.len();
+    let grad_dot_xbar: f64 = d
+        .entries
+        .iter()
+        .map(|&(col, g)| {
+            if col < off_a {
+                g * b[col - off_b]
+            } else {
+                g * a[col - off_a]
+            }
+        })
+        .sum();
+    let _ = n;
+    let k_const = d.value - grad_dot_xbar;
+    let row_scale = d.entries.iter().map(|&(_, g)| g.abs()).fold(0.0, f64::max);
+    if row_scale == 0.0 {
+        return None;
+    }
+    let mut entries = [(0usize, 0.0f64); PA_CUT_MAX_ENTRIES];
+    for (slot, &(col, g)) in d.entries.iter().enumerate() {
+        entries[slot] = (col, g / row_scale);
+    }
+    Some(FollowerCut {
+        entries,
+        n_entries: d.entries.len(),
+        rhs_pos: (cap - k_const) / row_scale,
+        rhs_neg: (cap + k_const) / row_scale,
+    })
+}
+
 #[cfg(test)]
 mod tests;

--- a/rust/temporal/src/topp/follower.rs
+++ b/rust/temporal/src/topp/follower.rs
@@ -1,0 +1,38 @@
+use crate::topp::chain::ChainGrid;
+
+pub(crate) fn emit_base_follower_rows(
+    chain: &ChainGrid,
+    off_b: usize,
+    off_a: usize,
+    mut push_row: impl FnMut(&[(usize, f64)], f64),
+) -> usize {
+    let mut count = 0;
+    for i in 0..chain.s.len() {
+        let lim = chain.limits_at(i);
+        for f in chain.followers_at(i) {
+            if f.pa_k != 0.0 {
+                continue;
+            }
+            let r = f.ratio.abs();
+            for (_, set) in lim.follower_sets() {
+                if !set.axes.contains(f.axis) {
+                    continue;
+                }
+                if set.v_max.is_finite() {
+                    let cap = (set.v_max / r).powi(2);
+                    push_row(&[(off_b + i, -1.0)], cap);
+                    count += 1;
+                }
+                if set.a_max.is_finite() {
+                    push_row(&[(off_a + i, -r)], set.a_max);
+                    push_row(&[(off_a + i, r)], set.a_max);
+                    count += 2;
+                }
+            }
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/temporal/src/topp/follower.rs
+++ b/rust/temporal/src/topp/follower.rs
@@ -6,6 +6,9 @@ pub(crate) fn emit_base_follower_rows(
     off_a: usize,
     mut push_row: impl FnMut(&[(usize, f64)], f64),
 ) -> usize {
+    if chain.has_active_windows() {
+        return 0;
+    }
     let mut count = 0;
     for i in 0..chain.s.len() {
         let lim = chain.limits_at(i);
@@ -297,6 +300,464 @@ fn finish_cut(
         rhs_pos: (cap - k_const) / row_scale,
         rhs_neg: (cap + k_const) / row_scale,
     })
+}
+
+use crate::topp::window::{WindowHistory, WindowOperator, frozen_time_map};
+
+pub(crate) const FOLLOWER_REFREEZE_MAX: u32 = 8;
+pub(crate) const REFREEZE_DRIFT_TOL: f64 = 1e-2;
+
+pub(crate) struct AxisWindows {
+    pub v: WindowOperator,
+    pub a: WindowOperator,
+    pub j: WindowOperator,
+}
+
+pub(crate) struct FollowerWindows {
+    pub t_map: Vec<f64>,
+    pub axes: [AxisWindows; 3],
+    pub max_half_support: f64,
+}
+
+fn history_accel_from_velocity(v: &[f64], dt: f64) -> Vec<f64> {
+    let n = v.len();
+    (0..n)
+        .map(|m| {
+            if n < 2 {
+                0.0
+            } else if m == 0 {
+                (v[0] - v[1]) / dt
+            } else if m == n - 1 {
+                (v[n - 2] - v[n - 1]) / dt
+            } else {
+                (v[m - 1] - v[m + 1]) / (2.0 * dt)
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn build_follower_windows(chain: &ChainGrid, b_bar: &[f64]) -> FollowerWindows {
+    let t_map = frozen_time_map(b_bar, &chain.h_intervals);
+    let n = t_map.len();
+    let mut max_half_support = 0.0_f64;
+    let axes = std::array::from_fn(|alpha| {
+        let Some(kernel) = &chain.axis_kernels[alpha] else {
+            return AxisWindows {
+                v: WindowOperator::identity(n),
+                a: WindowOperator::identity(n),
+                j: WindowOperator::identity(n),
+            };
+        };
+        max_half_support = max_half_support.max(kernel.support().1);
+        let signal_histories = |h: &Option<crate::FollowerHistory>| match h {
+            Some(h) if !h.axis_velocity[alpha].is_empty() => {
+                let v = &h.axis_velocity[alpha];
+                let a = history_accel_from_velocity(v, h.dt);
+                let j = history_accel_from_velocity(&a, h.dt);
+                [
+                    WindowHistory {
+                        dt: h.dt,
+                        samples: v.clone(),
+                    },
+                    WindowHistory {
+                        dt: h.dt,
+                        samples: a,
+                    },
+                    WindowHistory {
+                        dt: h.dt,
+                        samples: j,
+                    },
+                ]
+            }
+            _ => [
+                WindowHistory::empty(),
+                WindowHistory::empty(),
+                WindowHistory::empty(),
+            ],
+        };
+        let [hist_v, hist_a, hist_j] = signal_histories(&chain.follower_history);
+        let [term_v, term_a, term_j] = signal_histories(&chain.follower_terminal);
+        AxisWindows {
+            v: WindowOperator::from_kernel_with_terminal(kernel, &t_map, &hist_v, &term_v),
+            a: WindowOperator::from_kernel_with_terminal(kernel, &t_map, &hist_a, &term_a),
+            j: WindowOperator::from_kernel_with_terminal(kernel, &t_map, &hist_j, &term_j),
+        }
+    });
+    FollowerWindows {
+        t_map,
+        axes,
+        max_half_support: max_half_support.max(f64::MIN_POSITIVE),
+    }
+}
+
+/// Window weights depend only on pairwise time differences within one kernel
+/// support, so drift is measured on those differences, not on accumulated
+/// absolute time.
+pub(crate) fn refreeze_drift(windows: &FollowerWindows, b_new: &[f64], chain: &ChainGrid) -> f64 {
+    let t_new = frozen_time_map(b_new, &chain.h_intervals);
+    let t_old = &windows.t_map;
+    let h = windows.max_half_support;
+    let d: Vec<f64> = t_new.iter().zip(t_old).map(|(n, o)| n - o).collect();
+    let mut worst: f64 = 0.0;
+    for i in 0..t_old.len() {
+        let mut j = i;
+        while j > 0 && t_old[i] - t_old[j - 1] <= h {
+            j -= 1;
+        }
+        for dj in &d[j..=i] {
+            worst = worst.max((d[i] - dj).abs());
+        }
+    }
+    worst / h
+}
+
+struct WindowedSignals {
+    v: [f64; 3],
+    a: [f64; 3],
+    j: [f64; 3],
+}
+
+fn windowed_signals_at(
+    windows: &FollowerWindows,
+    chain: &ChainGrid,
+    b: &[f64],
+    a: &[f64],
+    i: usize,
+) -> WindowedSignals {
+    let mut out = WindowedSignals {
+        v: [0.0; 3],
+        a: [0.0; 3],
+        j: [0.0; 3],
+    };
+    for alpha in 0..3 {
+        let aw = &windows.axes[alpha];
+        let mut v_acc = aw.v.row(i).history;
+        for &(jj, w) in &aw.v.row(i).weights {
+            v_acc += w * chain.geom[jj].c_prime[alpha] * b[jj].max(0.0).sqrt();
+        }
+        let mut a_acc = aw.a.row(i).history;
+        for &(jj, w) in &aw.a.row(i).weights {
+            let g = &chain.geom[jj];
+            a_acc += w * (g.c_double_prime[alpha] * b[jj] + g.c_prime[alpha] * a[jj]);
+        }
+        let mut j_acc = aw.j.row(i).history;
+        for &(jj, w) in &aw.j.row(i).weights {
+            let g = &chain.geom[jj];
+            let sqrt_b = b[jj].max(0.0).sqrt();
+            let s_dddot = crate::topp::stencil::s_dddot_at_weights(b, jj, &chain.h_intervals);
+            j_acc += w
+                * (g.c_triple_prime[alpha] * b[jj].max(0.0) * sqrt_b
+                    + 3.0 * g.c_double_prime[alpha] * sqrt_b * a[jj]
+                    + g.c_prime[alpha] * s_dddot);
+        }
+        out.v[alpha] = v_acc;
+        out.a[alpha] = a_acc;
+        out.j[alpha] = j_acc;
+    }
+    out
+}
+
+fn norm3(v: &[f64; 3]) -> f64 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
+pub(crate) struct WindowedDemand {
+    pub family: PaFamily,
+    pub set: usize,
+    pub value: f64,
+    pub cap: f64,
+    pub pa: bool,
+}
+
+pub(crate) fn windowed_demands_at(
+    windows: &FollowerWindows,
+    chain: &ChainGrid,
+    b: &[f64],
+    a: &[f64],
+    i: usize,
+) -> Vec<WindowedDemand> {
+    let followers = chain.followers_at(i);
+    if followers.is_empty() {
+        return Vec::new();
+    }
+    let sig = windowed_signals_at(windows, chain, b, a, i);
+    let (nv, na, nj) = (norm3(&sig.v), norm3(&sig.a), norm3(&sig.j));
+    let s_ddddot = if followers.iter().any(|f| f.pa_k != 0.0) && b.len() >= 4 {
+        crate::topp::stencil::s_ddddot_at_weights(b, a[i], i, &chain.s, &chain.h_intervals)
+    } else {
+        0.0
+    };
+    let lim = chain.limits_at(i);
+    let mut out = Vec::new();
+    for f in followers {
+        let r = f.ratio.abs();
+        let k = f.pa_k;
+        for (set_idx, set) in lim.follower_sets() {
+            if !set.axes.contains(f.axis) {
+                continue;
+            }
+            if set.v_max.is_finite() {
+                out.push(WindowedDemand {
+                    family: PaFamily::Velocity,
+                    set: set_idx,
+                    value: r * (nv + k * na),
+                    cap: set.v_max,
+                    pa: k != 0.0,
+                });
+            }
+            if set.a_max.is_finite() {
+                out.push(WindowedDemand {
+                    family: PaFamily::Accel,
+                    set: set_idx,
+                    value: r * (na + k * nj),
+                    cap: set.a_max,
+                    pa: k != 0.0,
+                });
+            }
+            if set.j_max.is_finite() {
+                out.push(WindowedDemand {
+                    family: PaFamily::Jerk,
+                    set: set_idx,
+                    value: r * (nj + k * s_ddddot.abs()),
+                    cap: set.j_max,
+                    pa: k != 0.0,
+                });
+            }
+        }
+    }
+    out
+}
+
+pub(crate) fn max_windowed_ratio(
+    windows: &FollowerWindows,
+    chain: &ChainGrid,
+    b: &[f64],
+    a: &[f64],
+) -> f64 {
+    let mut worst: f64 = 0.0;
+    for i in 0..b.len() {
+        for d in windowed_demands_at(windows, chain, b, a, i) {
+            worst = worst.max(d.value / d.cap);
+        }
+    }
+    worst
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WindowedCut {
+    pub entries: Vec<(usize, f64)>,
+    pub rhs: f64,
+}
+
+const HYPERPLANE_NORM_FLOOR: f64 = 1e-9;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_windowed_follower_cuts(
+    b: &[f64],
+    a: &[f64],
+    chain: &ChainGrid,
+    windows: &FollowerWindows,
+    target_ratio: f64,
+    eps_feas: f64,
+    placement_fraction: f64,
+    target_decay: f64,
+    b_floor: f64,
+) -> Vec<WindowedCut> {
+    let n = b.len();
+    let off_b = 0;
+    let off_a = n;
+    let mut cuts = Vec::new();
+    for i in 0..n {
+        let followers = chain.followers_at(i);
+        if followers.is_empty() {
+            continue;
+        }
+        let sig = windowed_signals_at(windows, chain, b, a, i);
+        let (nv, na, nj) = (norm3(&sig.v), norm3(&sig.a), norm3(&sig.j));
+        let u_v = sig.v.map(|x| x / nv.max(HYPERPLANE_NORM_FLOOR));
+        let u_a = sig.a.map(|x| x / na.max(HYPERPLANE_NORM_FLOOR));
+        let u_j = sig.j.map(|x| x / nj.max(HYPERPLANE_NORM_FLOOR));
+
+        let grad_v = |scale: f64, entries: &mut Vec<(usize, f64)>| {
+            for alpha in 0..3 {
+                let aw = &windows.axes[alpha];
+                for &(jj, w) in &aw.v.row(i).weights {
+                    let sqrt_b = b[jj].max(b_floor).max(f64::MIN_POSITIVE).sqrt();
+                    accumulate(
+                        entries,
+                        off_b + jj,
+                        scale * u_v[alpha] * w * chain.geom[jj].c_prime[alpha] / (2.0 * sqrt_b),
+                    );
+                }
+            }
+        };
+        let grad_a = |scale: f64, entries: &mut Vec<(usize, f64)>| {
+            for alpha in 0..3 {
+                let aw = &windows.axes[alpha];
+                for &(jj, w) in &aw.a.row(i).weights {
+                    let g = &chain.geom[jj];
+                    accumulate(
+                        entries,
+                        off_b + jj,
+                        scale * u_a[alpha] * w * g.c_double_prime[alpha],
+                    );
+                    accumulate(
+                        entries,
+                        off_a + jj,
+                        scale * u_a[alpha] * w * g.c_prime[alpha],
+                    );
+                }
+            }
+        };
+        let grad_j = |scale: f64, entries: &mut Vec<(usize, f64)>| {
+            for alpha in 0..3 {
+                let aw = &windows.axes[alpha];
+                for &(jj, w) in &aw.j.row(i).weights {
+                    let g = &chain.geom[jj];
+                    let sqrt_b = b[jj].max(b_floor).max(f64::MIN_POSITIVE).sqrt();
+                    let (idx2, hl, hr) =
+                        crate::topp::stencil::stencil_at(jj, n, &chain.h_intervals);
+                    let w2 = crate::topp::stencil::b_dd_weights(hl, hr);
+                    let b_dd = w2[0] * b[idx2[0]] + w2[1] * b[idx2[1]] + w2[2] * b[idx2[2]];
+                    let c = scale * u_j[alpha] * w;
+                    accumulate(
+                        entries,
+                        off_b + jj,
+                        c * (1.5 * g.c_triple_prime[alpha] * sqrt_b
+                            + 3.0 * g.c_double_prime[alpha] * a[jj] / (2.0 * sqrt_b)
+                            + g.c_prime[alpha] * b_dd / (4.0 * sqrt_b)),
+                    );
+                    for m in 0..3 {
+                        accumulate(
+                            entries,
+                            off_b + idx2[m],
+                            c * g.c_prime[alpha] * sqrt_b * w2[m] / 2.0,
+                        );
+                    }
+                    accumulate(
+                        entries,
+                        off_a + jj,
+                        c * 3.0 * g.c_double_prime[alpha] * sqrt_b,
+                    );
+                }
+            }
+        };
+
+        for d in windowed_demands_at(windows, chain, b, a, i) {
+            let ratio = d.value / d.cap;
+            let cap_inflated = if target_ratio <= 1.0 + eps_feas {
+                if ratio <= eps_feas {
+                    continue;
+                }
+                d.cap
+            } else if ratio > placement_fraction * target_ratio {
+                d.cap * target_ratio
+            } else if ratio > 1.0 + eps_feas {
+                d.cap * (ratio * target_decay).max(1.0)
+            } else if ratio > eps_feas {
+                d.cap
+            } else {
+                continue;
+            };
+            let follower = chain
+                .followers_at(i)
+                .iter()
+                .find(|f| {
+                    chain
+                        .limits_at(i)
+                        .sets()
+                        .get(d.set)
+                        .is_some_and(|set| set.axes.contains(f.axis))
+                })
+                .expect("demand came from a covering follower");
+            let r = follower.ratio.abs();
+            let k = follower.pa_k;
+            let mut entries = Vec::new();
+            match d.family {
+                PaFamily::Velocity => {
+                    grad_v(r, &mut entries);
+                    if k != 0.0 {
+                        grad_a(r * k, &mut entries);
+                    }
+                }
+                PaFamily::Accel => {
+                    grad_a(r, &mut entries);
+                    if k != 0.0 {
+                        grad_j(r * k, &mut entries);
+                    }
+                }
+                PaFamily::Jerk => {
+                    grad_j(r, &mut entries);
+                    if k != 0.0 {
+                        let snap_dem = pa_demand_linearized(
+                            PaFamily::Jerk,
+                            1.0,
+                            0.0,
+                            b,
+                            a,
+                            i,
+                            &chain.s,
+                            &chain.h_intervals,
+                            off_b,
+                            off_a,
+                            b_floor,
+                        );
+                        let _ = snap_dem;
+                        let s_ddddot = crate::topp::stencil::s_ddddot_at_weights(
+                            b,
+                            a[i],
+                            i,
+                            &chain.s,
+                            &chain.h_intervals,
+                        );
+                        let sigma = if s_ddddot >= 0.0 { 1.0 } else { -1.0 };
+                        let (idx2, hl, hr) =
+                            crate::topp::stencil::stencil_at(i, n, &chain.h_intervals);
+                        let w2 = crate::topp::stencil::b_dd_weights(hl, hr);
+                        let b_dd = w2[0] * b[idx2[0]] + w2[1] * b[idx2[1]] + w2[2] * b[idx2[2]];
+                        let (idx3, w3) = crate::topp::stencil::b_ddd_weights_at(i, &chain.s);
+                        let b_ddd: f64 = (0..4).map(|m| w3[m] * b[idx3[m]]).sum();
+                        let c = r * k * sigma;
+                        accumulate(&mut entries, off_a + i, c * b_dd / 2.0);
+                        for m in 0..3 {
+                            accumulate(&mut entries, off_b + idx2[m], c * a[i] * w2[m] / 2.0);
+                        }
+                        for m in 0..4 {
+                            accumulate(
+                                &mut entries,
+                                off_b + idx3[m],
+                                c * b[i].max(0.0) * w3[m] / 2.0,
+                            );
+                        }
+                        accumulate(&mut entries, off_b + i, c * b_ddd / 2.0);
+                    }
+                }
+            }
+            let grad_dot_xbar: f64 = entries
+                .iter()
+                .map(|&(col, g)| {
+                    if col < off_a {
+                        g * b[col - off_b]
+                    } else {
+                        g * a[col - off_a]
+                    }
+                })
+                .sum();
+            let k_const = d.value - grad_dot_xbar;
+            let row_scale = entries.iter().map(|&(_, g)| g.abs()).fold(0.0, f64::max);
+            if row_scale == 0.0 {
+                continue;
+            }
+            for e in &mut entries {
+                e.1 /= row_scale;
+            }
+            cuts.push(WindowedCut {
+                entries,
+                rhs: (cap_inflated - k_const) / row_scale,
+            });
+        }
+    }
+    cuts
 }
 
 #[cfg(test)]

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -162,3 +162,112 @@ fn follower_jerk_cap_binds_through_the_slp() {
         "path jerk {max_jerk} exceeds effective cap 2000"
     );
 }
+
+fn finite_diff_derivatives(profile: &crate::TopProfile) -> Vec<(f64, f64, f64, f64)> {
+    let n = profile.samples.len();
+    let mut t = vec![0.0];
+    for w in profile.samples.windows(2) {
+        let v_avg = (w[0].v + w[1].v).max(1e-9);
+        t.push(t.last().unwrap() + 2.0 * (w[1].s - w[0].s) / v_avg);
+    }
+    let v: Vec<f64> = profile.samples.iter().map(|s| s.v).collect();
+    let deriv = |f: &[f64]| -> Vec<f64> {
+        (0..n)
+            .map(|i| {
+                if i == 0 || i == n - 1 {
+                    0.0
+                } else {
+                    (f[i + 1] - f[i - 1]) / (t[i + 1] - t[i - 1]).max(1e-12)
+                }
+            })
+            .collect()
+    };
+    let a = deriv(&v);
+    let j = deriv(&a);
+    let s4 = deriv(&j);
+    (0..n).map(|i| (v[i], a[i], j[i], s4[i])).collect()
+}
+
+#[test]
+fn pa_velocity_row_slows_the_accel_phase() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.05,
+        }],
+    );
+    let d = finite_diff_derivatives(&profile);
+    for (i, &(v, a, _, _)) in d.iter().enumerate() {
+        let demand = 0.5 * (v + 0.05 * a);
+        assert!(
+            demand <= 50.0 * (1.0 + 5e-2),
+            "sample {i}: PA velocity demand {demand} > 50"
+        );
+    }
+}
+
+#[test]
+fn pa_accel_row_holds_pointwise() {
+    let limits = limits_with_follower(1.0e6, 500.0, 1.0e12);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.05,
+        }],
+    );
+    let d = finite_diff_derivatives(&profile);
+    for (i, &(_, a, j, _)) in d.iter().enumerate().skip(2).take(d.len() - 4) {
+        let demand = 0.5 * (a + 0.05 * j).abs();
+        assert!(
+            demand <= 500.0 * 1.10,
+            "sample {i}: PA accel demand {demand} > 500"
+        );
+    }
+}
+
+#[test]
+fn pa_jerk_row_holds_pointwise() {
+    let limits = limits_with_follower(1.0e6, 1.0e9, 5000.0);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.05,
+        }],
+    );
+    let d = finite_diff_derivatives(&profile);
+    for (i, &(_, _, j, s4)) in d.iter().enumerate().skip(3).take(d.len() - 6) {
+        let demand = 0.5 * (j + 0.05 * s4).abs();
+        assert!(
+            demand <= 5000.0 * 1.20,
+            "sample {i}: PA jerk demand {demand} > 5000"
+        );
+    }
+}
+
+#[test]
+fn verify_tags_pa_rows() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let follower_set_idx = limits.follower_sets().next().map(|(idx, _)| idx).unwrap();
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.05,
+        }],
+    );
+    let tagged = profile.samples.iter().any(|s| {
+        s.binding
+            == BindingConstraint::PaVelocity {
+                set: follower_set_idx,
+            }
+    });
+    assert!(tagged, "no sample tagged PaVelocity");
+}

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -271,3 +271,261 @@ fn verify_tags_pa_rows() {
     });
     assert!(tagged, "no sample tagged PaVelocity");
 }
+
+use crate::topp::window::eval_kernel;
+use nurbs::algebra::PiecewisePolynomialKernel;
+
+fn bell_kernel(frequency_hz: f64) -> PiecewisePolynomialKernel<f64> {
+    let t_sm = 0.8025 / frequency_hz;
+    let h = t_sm / 2.0;
+    let c = 15.0 / (16.0 * h.powi(5));
+    PiecewisePolynomialKernel::single_poly_from_absolute(
+        vec![c * h.powi(4), 0.0, -2.0 * c * h * h, 0.0, c],
+        (-h, h),
+    )
+}
+
+fn solve_folded(
+    limits: &Limits,
+    followers: &[FollowerDemand],
+    kernels: [Option<PiecewisePolynomialKernel<f64>>; 3],
+    history: Option<crate::FollowerHistory>,
+) -> crate::TopProfile {
+    let curve = line([0.0; 3], [100.0, 0.0, 0.0]);
+    let arc = crate::topp::path::sample_arclength_grid(&curve, 401).unwrap();
+    let mut chain = crate::topp::chain::ChainGrid::try_from_segment_grids_with_followers(
+        vec![arc],
+        vec![*limits],
+        vec![followers.to_vec()],
+        &[false],
+    )
+    .unwrap();
+    chain.axis_kernels = kernels;
+    chain.follower_history = history;
+    crate::topp::schedule_chain_with_tolerance(
+        &chain,
+        crate::topp::EndpointConditions {
+            v_start: 0.0,
+            v_end: 0.0,
+            a_start: None,
+        },
+        ToleranceMode::Tight,
+    )
+    .unwrap()
+}
+
+fn solve_identity_dense(limits: &Limits, followers: &[FollowerDemand]) -> crate::TopProfile {
+    let curve = line([0.0; 3], [100.0, 0.0, 0.0]);
+    schedule_segment_with_followers(
+        &curve,
+        limits,
+        &GridConfig {
+            scheme: GridScheme::UniformArclength,
+            n: 401,
+        },
+        0.0,
+        0.0,
+        ToleranceMode::Tight,
+        followers,
+    )
+    .unwrap()
+}
+
+#[test]
+fn passthrough_kernels_reproduce_identity_rows() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let demand = [FollowerDemand {
+        axis: 3,
+        ratio: 0.5,
+        pa_k: 0.0,
+    }];
+    let folded = solve_folded(&limits, &demand, [None, None, None], None);
+    let identity = solve_identity_dense(&limits, &demand);
+    assert!((folded.total_time - identity.total_time).abs() < 1e-9);
+}
+
+#[test]
+fn folded_rows_recover_speed_at_a_smoothed_start() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let demand = [FollowerDemand {
+        axis: 3,
+        ratio: 0.5,
+        pa_k: 0.0,
+    }];
+    let folded = solve_folded(
+        &limits,
+        &demand,
+        [Some(bell_kernel(40.0)), None, None],
+        None,
+    );
+    let identity = solve_identity_dense(&limits, &demand);
+    assert!(
+        folded.total_time < identity.total_time - 1e-4,
+        "folded {} should beat identity {} (shaped speed lags during ramp)",
+        folded.total_time,
+        identity.total_time
+    );
+}
+
+fn brute_force_shaped_demand_check(
+    profile: &crate::TopProfile,
+    kernel: &PiecewisePolynomialKernel<f64>,
+    ratio: f64,
+    v_max: f64,
+    history_v: f64,
+) {
+    let n = profile.samples.len();
+    let mut t = vec![0.0];
+    for w in profile.samples.windows(2) {
+        let v_avg = (w[0].v + w[1].v).max(1e-9);
+        t.push(t.last().unwrap() + 2.0 * (w[1].s - w[0].s) / v_avg);
+    }
+    let total = *t.last().unwrap();
+    let v_at = |tau: f64| -> f64 {
+        if tau < 0.0 {
+            return history_v;
+        }
+        if tau >= total {
+            return profile.samples[n - 1].v;
+        }
+        let j = t.partition_point(|&tj| tj <= tau).min(n - 1);
+        let (t0, t1) = (t[j - 1], t[j]);
+        let (v0, v1) = (profile.samples[j - 1].v, profile.samples[j].v);
+        v0 + (v1 - v0) * (tau - t0) / (t1 - t0).max(1e-12)
+    };
+    let (k_lo, k_hi) = kernel.support();
+    let dt = 1e-3;
+    let mut tau = 0.0;
+    while tau <= total {
+        let mut shaped = 0.0;
+        let mut z = k_lo;
+        while z <= k_hi {
+            shaped += eval_kernel(kernel, z) * v_at(tau - z) * dt;
+            z += dt;
+        }
+        let demand = ratio * shaped.abs();
+        assert!(
+            demand <= v_max * (1.0 + 5e-2),
+            "t={tau:.4}: shaped demand {demand} > {v_max}"
+        );
+        tau += 5e-3;
+    }
+}
+
+#[test]
+fn folded_demand_holds_against_brute_force_convolution() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let kernel = bell_kernel(40.0);
+    let folded = solve_folded(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+        [Some(kernel.clone()), None, None],
+        None,
+    );
+    brute_force_shaped_demand_check(&folded, &kernel, 0.5, 50.0, 0.0);
+}
+
+#[test]
+fn nonzero_history_constrains_the_chain_start() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let kernel = bell_kernel(40.0);
+    let half = kernel.support().1;
+    let history = crate::FollowerHistory {
+        dt: half / 32.0,
+        axis_velocity: [vec![100.0; 32], Vec::new(), Vec::new()],
+    };
+    let folded = solve_folded(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+        [Some(kernel.clone()), None, None],
+        Some(history),
+    );
+    brute_force_shaped_demand_check(&folded, &kernel, 0.5, 50.0, 100.0);
+}
+
+#[test]
+fn refreeze_divergence_fails_loudly() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let curve = line([0.0; 3], [100.0, 0.0, 0.0]);
+    let arc = crate::topp::path::sample_arclength_grid(&curve, 401).unwrap();
+    let mut chain = crate::topp::chain::ChainGrid::try_from_segment_grids_with_followers(
+        vec![arc],
+        vec![limits],
+        vec![vec![FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }]],
+        &[false],
+    )
+    .unwrap();
+    chain.axis_kernels = [Some(bell_kernel(40.0)), None, None];
+    let err = crate::topp::schedule_chain_with_refreeze_cap(
+        &chain,
+        crate::topp::EndpointConditions {
+            v_start: 0.0,
+            v_end: 0.0,
+            a_start: None,
+        },
+        ToleranceMode::Tight,
+        1,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::topp::ScheduleError::FollowerSlpDiverged { refreezes: 1, .. }
+    ));
+}
+
+#[test]
+fn batch_tail_exchange_holds_shaped_demand_across_a_stop() {
+    use crate::multi::{BatchInput, BatchShaping, GridStrategy, SegmentInput, plan_batch};
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let demand = [FollowerDemand {
+        axis: 3,
+        ratio: 0.5,
+        pa_k: 0.0,
+    }];
+    let a = line([0.0; 3], [50.0, 0.0, 0.0]);
+    let b = line([50.0, 0.0, 0.0], [50.0, 50.0, 0.0]);
+    let segments = [
+        SegmentInput {
+            curve: &a,
+            limits,
+            followers: &demand,
+        },
+        SegmentInput {
+            curve: &b,
+            limits,
+            followers: &demand,
+        },
+    ];
+    let shaping = BatchShaping {
+        axis_kernels: [Some(bell_kernel(40.0)), Some(bell_kernel(40.0)), None],
+        follower_history: None,
+    };
+    let out = plan_batch(BatchInput {
+        segments: &segments,
+        shaping: Some(&shaping),
+        grid_strategy: GridStrategy::Fixed(201),
+        worker_threads: 1,
+        initial_velocity: 0.0,
+        initial_accel: 0.0,
+        terminal_velocity: 0.0,
+    })
+    .unwrap();
+    assert_eq!(out.profiles.len(), 2);
+    for profile in &out.profiles {
+        let peak = profile.samples.iter().map(|s| s.v).fold(0.0, f64::max);
+        assert!(peak > 50.0, "chains should still move briskly, got {peak}");
+    }
+    brute_force_shaped_demand_check(&out.profiles[0], &bell_kernel(40.0), 0.5, 50.0, 0.0);
+}

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -125,3 +125,40 @@ fn binding_tag_names_the_follower_set() {
         "cruise sample should bind on the follower velocity row"
     );
 }
+
+#[test]
+fn follower_jerk_cap_binds_through_the_slp() {
+    let limits = limits_with_follower(1.0e6, 1.0e9, 1000.0);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+    );
+    let n = profile.samples.len();
+    let t: Vec<f64> = {
+        let mut acc = vec![0.0];
+        for w in profile.samples.windows(2) {
+            let v_avg = (w[0].v + w[1].v).max(1e-9);
+            acc.push(acc.last().unwrap() + 2.0 * (w[1].s - w[0].s) / v_avg);
+        }
+        acc
+    };
+    let mut max_jerk: f64 = 0.0;
+    for i in 1..n - 1 {
+        let dt_l = t[i] - t[i - 1];
+        let dt_r = t[i + 1] - t[i];
+        if dt_l < 1e-9 || dt_r < 1e-9 {
+            continue;
+        }
+        let a_l = (profile.samples[i].v - profile.samples[i - 1].v) / dt_l;
+        let a_r = (profile.samples[i + 1].v - profile.samples[i].v) / dt_r;
+        max_jerk = max_jerk.max(((a_r - a_l) / (0.5 * (dt_l + dt_r))).abs());
+    }
+    assert!(
+        max_jerk <= 2000.0 * 1.10,
+        "path jerk {max_jerk} exceeds effective cap 2000"
+    );
+}

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -1,0 +1,127 @@
+use crate::topp::chain::tests_support::line;
+use crate::topp::{
+    ToleranceMode, schedule_segment_with_followers, schedule_segment_with_tolerance,
+};
+use crate::{AxisSet, BindingConstraint, FollowerDemand, GridConfig, GridScheme, LimitSet, Limits};
+
+fn limits_with_follower(v_e: f64, a_e: f64, j_e: f64) -> Limits {
+    let mut sets: Vec<LimitSet> = Limits::axis_boxes([500.0; 3], [20_000.0; 3], [400_000.0; 3])
+        .sets()
+        .to_vec();
+    sets.push(LimitSet {
+        axes: AxisSet::from_indices(&[3]),
+        v_max: v_e,
+        a_max: a_e,
+        j_max: j_e,
+    });
+    Limits::try_new(&sets, 4).unwrap()
+}
+
+fn grid() -> GridConfig {
+    GridConfig {
+        scheme: GridScheme::UniformArclength,
+        n: 101,
+    }
+}
+
+fn solve_with_followers(limits: &Limits, followers: &[FollowerDemand]) -> crate::TopProfile {
+    let curve = line([0.0; 3], [100.0, 0.0, 0.0]);
+    schedule_segment_with_followers(
+        &curve,
+        limits,
+        &grid(),
+        0.0,
+        0.0,
+        ToleranceMode::Tight,
+        followers,
+    )
+    .unwrap()
+}
+
+#[test]
+fn follower_velocity_caps_cruise_speed() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+    );
+    let peak = profile.samples.iter().map(|s| s.v).fold(0.0, f64::max);
+    assert!(
+        (peak - 100.0).abs() < 1.0,
+        "expected cruise cap 100 mm/s, got {peak}"
+    );
+}
+
+#[test]
+fn follower_accel_caps_path_accel() {
+    let limits = limits_with_follower(1.0e6, 500.0, 1.0e12);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+    );
+    let mut t = 0.0;
+    let mut max_dvdt: f64 = 0.0;
+    for w in profile.samples.windows(2) {
+        let v_avg = (w[0].v + w[1].v).max(1e-9);
+        let dt = 2.0 * (w[1].s - w[0].s) / v_avg;
+        if dt > 1e-12 {
+            max_dvdt = max_dvdt.max(((w[1].v - w[0].v) / dt).abs());
+        }
+        t += dt;
+    }
+    let _ = t;
+    assert!(
+        max_dvdt <= 1000.0 * 1.01,
+        "path accel {max_dvdt} exceeds 1000"
+    );
+}
+
+#[test]
+fn zero_follower_slice_matches_plain_solve() {
+    let limits = limits_with_follower(1.0e6, 1.0e9, 1.0e12);
+    let curve = line([0.0; 3], [100.0, 0.0, 0.0]);
+    let with_empty = schedule_segment_with_followers(
+        &curve,
+        &limits,
+        &grid(),
+        0.0,
+        0.0,
+        ToleranceMode::Tight,
+        &[],
+    )
+    .unwrap();
+    let plain =
+        schedule_segment_with_tolerance(&curve, &limits, &grid(), 0.0, 0.0, ToleranceMode::Tight)
+            .unwrap();
+    assert!((with_empty.total_time - plain.total_time).abs() < 1e-12);
+}
+
+#[test]
+fn binding_tag_names_the_follower_set() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let follower_set_idx = limits.follower_sets().next().map(|(idx, _)| idx).unwrap();
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+    );
+    let mid = &profile.samples[profile.samples.len() / 2];
+    assert_eq!(
+        mid.binding,
+        BindingConstraint::Velocity {
+            set: follower_set_idx
+        },
+        "cruise sample should bind on the follower velocity row"
+    );
+}

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -529,3 +529,54 @@ fn batch_tail_exchange_holds_shaped_demand_across_a_stop() {
     }
     brute_force_shaped_demand_check(&out.profiles[0], &bell_kernel(40.0), 0.5, 50.0, 0.0);
 }
+
+#[test]
+fn virtual_path_plans_under_follower_limits_and_feedrate() {
+    let limits = limits_with_follower(75.0, 1500.0, 1.0e9);
+    let followers = vec![FollowerDemand {
+        axis: 3,
+        ratio: 1.0,
+        pa_k: 0.0,
+    }];
+    let solve = |feedrate: f64| {
+        let chain = crate::topp::chain::ChainGrid::virtual_path(
+            10.0,
+            51,
+            limits,
+            followers.clone(),
+            feedrate,
+        )
+        .unwrap();
+        crate::topp::schedule_chain_with_tolerance(
+            &chain,
+            crate::topp::EndpointConditions {
+                v_start: 0.0,
+                v_end: 0.0,
+                a_start: None,
+            },
+            ToleranceMode::Tight,
+        )
+        .unwrap()
+    };
+    let slow = solve(40.0);
+    let peak_slow = slow.samples.iter().map(|s| s.v).fold(0.0, f64::max);
+    assert!(
+        (peak_slow - 40.0).abs() < 1.0,
+        "feedrate 40 should cap cruise, got {peak_slow}"
+    );
+    let fast = solve(200.0);
+    let peak_fast = fast.samples.iter().map(|s| s.v).fold(0.0, f64::max);
+    assert!(
+        (peak_fast - 75.0).abs() < 1.5,
+        "follower v_max 75 should cap cruise, got {peak_fast}"
+    );
+    let mut max_dvdt: f64 = 0.0;
+    for w in fast.samples.windows(2) {
+        let v_avg = (w[0].v + w[1].v).max(1e-9);
+        let dt = 2.0 * (w[1].s - w[0].s) / v_avg;
+        if dt > 1e-12 {
+            max_dvdt = max_dvdt.max(((w[1].v - w[0].v) / dt).abs());
+        }
+    }
+    assert!(max_dvdt <= 1500.0 * 1.02, "accel {max_dvdt} > 1500");
+}

--- a/rust/temporal/src/topp/mod.rs
+++ b/rust/temporal/src/topp/mod.rs
@@ -5,6 +5,7 @@ use scaling::SolverScale;
 
 pub mod chain;
 pub mod constraints;
+pub(crate) mod follower;
 pub(crate) mod output;
 pub mod path;
 pub mod scaling;

--- a/rust/temporal/src/topp/mod.rs
+++ b/rust/temporal/src/topp/mod.rs
@@ -36,12 +36,26 @@ pub enum ScheduleError {
     PathParam(String),
     #[error("solver setup failed: {0}")]
     SolverSetup(String),
+    #[error(
+        "follower shaper-folding SLP diverged after {refreezes} refreezes \
+         (worst ratio {worst_ratio:.4})"
+    )]
+    FollowerSlpDiverged { refreezes: u32, worst_ratio: f64 },
 }
 
 pub fn schedule_chain_with_tolerance(
     chain: &chain::ChainGrid,
     endpoints: EndpointConditions,
     tolerance: ToleranceMode,
+) -> Result<TopProfile, ScheduleError> {
+    schedule_chain_with_refreeze_cap(chain, endpoints, tolerance, follower::FOLLOWER_REFREEZE_MAX)
+}
+
+pub(crate) fn schedule_chain_with_refreeze_cap(
+    chain: &chain::ChainGrid,
+    endpoints: EndpointConditions,
+    tolerance: ToleranceMode,
+    refreeze_max: u32,
 ) -> Result<TopProfile, ScheduleError> {
     let v_start = endpoints.v_start;
     let v_end = endpoints.v_end;
@@ -117,8 +131,12 @@ pub fn schedule_chain_with_tolerance(
     };
 
     let call_slp = |tol| {
-        solver::slp_solve_with_axis_jerk_chain(&bundle, &scaled, tol, &scale)
-            .map_err(|e| ScheduleError::SolverSetup(format!("{e}")))
+        if scaled.has_active_windows() {
+            solve_with_refreeze(&bundle, &scaled, tol, &scale, refreeze_max)
+        } else {
+            solver::slp_solve_with_axis_jerk_chain(&bundle, &scaled, None, tol, &scale)
+                .map_err(|e| ScheduleError::SolverSetup(format!("{e}")))
+        }
     };
 
     let (mut solver_result, slp_outcome) = match tolerance {
@@ -147,6 +165,40 @@ pub fn schedule_chain_with_tolerance(
         },
         slp_outcome,
     ))
+}
+
+const FOLLOWER_REFREEZE_KM_ALPHA: f64 = 0.7;
+
+fn solve_with_refreeze(
+    bundle: &constraints::ConstraintBundle,
+    scaled: &chain::ChainGrid,
+    tol: f64,
+    scale: &SolverScale,
+    refreeze_max: u32,
+) -> Result<(solver::SolverResult, solver::SlpOutcome), ScheduleError> {
+    let (result, _outcome) =
+        solver::slp_solve_with_axis_jerk_chain(bundle, scaled, None, tol, scale)
+            .map_err(|e| ScheduleError::SolverSetup(format!("{e}")))?;
+    let mut b_freeze = result.b.clone();
+    let mut last_worst = f64::INFINITY;
+    for _refreeze in 0..refreeze_max {
+        let windows = follower::build_follower_windows(scaled, &b_freeze);
+        let (r2, o2) =
+            solver::slp_solve_with_axis_jerk_chain(bundle, scaled, Some(&windows), tol, scale)
+                .map_err(|e| ScheduleError::SolverSetup(format!("{e}")))?;
+        let drift = follower::refreeze_drift(&windows, &r2.b, scaled);
+        last_worst = follower::max_windowed_ratio(&windows, scaled, &r2.b, &r2.a);
+        if drift < follower::REFREEZE_DRIFT_TOL && last_worst <= 1.0 + solver::SLP9_EPS_FEAS {
+            return Ok((r2, o2));
+        }
+        for (f, n) in b_freeze.iter_mut().zip(&r2.b) {
+            *f = (1.0 - FOLLOWER_REFREEZE_KM_ALPHA) * *f + FOLLOWER_REFREEZE_KM_ALPHA * n;
+        }
+    }
+    Err(ScheduleError::FollowerSlpDiverged {
+        refreezes: refreeze_max,
+        worst_ratio: last_worst,
+    })
 }
 
 pub fn schedule_segment(

--- a/rust/temporal/src/topp/mod.rs
+++ b/rust/temporal/src/topp/mod.rs
@@ -11,6 +11,7 @@ pub mod scaling;
 pub(crate) mod solver;
 pub mod stencil;
 pub(crate) mod verify;
+pub mod window;
 
 pub use constraints::EndpointConditions;
 pub use solver::{AxisJerkGradient, axis_jerk_gradient_for_test};

--- a/rust/temporal/src/topp/mod.rs
+++ b/rust/temporal/src/topp/mod.rs
@@ -165,6 +165,18 @@ pub fn schedule_segment_with_tolerance(
     v_end: f64,
     tolerance: ToleranceMode,
 ) -> Result<TopProfile, ScheduleError> {
+    schedule_segment_with_followers(curve, limits, grid, v_start, v_end, tolerance, &[])
+}
+
+pub fn schedule_segment_with_followers(
+    curve: &VectorNurbs<f64, 3>,
+    limits: &Limits,
+    grid: &GridConfig,
+    v_start: f64,
+    v_end: f64,
+    tolerance: ToleranceMode,
+    followers: &[crate::FollowerDemand],
+) -> Result<TopProfile, ScheduleError> {
     if !v_start.is_finite() || v_start < 0.0 {
         return Err(ScheduleError::InvalidEndpointVelocity(
             "v_start must be finite, ≥ 0",
@@ -184,7 +196,13 @@ pub fn schedule_segment_with_tolerance(
     let arc_grid = path::sample_arclength_grid(curve, grid.n)
         .map_err(|e| ScheduleError::PathParam(format!("{e}")))?;
 
-    let chain = chain::ChainGrid::from_segment_grids(vec![arc_grid], vec![*limits]);
+    let chain = chain::ChainGrid::try_from_segment_grids_with_followers(
+        vec![arc_grid],
+        vec![*limits],
+        vec![followers.to_vec()],
+        &[false],
+    )
+    .map_err(|e| ScheduleError::SolverSetup(e.to_string()))?;
     schedule_chain_with_tolerance(
         &chain,
         EndpointConditions {

--- a/rust/temporal/src/topp/scaling.rs
+++ b/rust/temporal/src/topp/scaling.rs
@@ -144,6 +144,7 @@ impl SolverScale {
                 })
                 .collect(),
             segment_ranges: chain.segment_ranges.clone(),
+            followers: chain.followers.clone(),
             inter_geom: chain
                 .inter_geom
                 .iter()

--- a/rust/temporal/src/topp/scaling.rs
+++ b/rust/temporal/src/topp/scaling.rs
@@ -145,6 +145,25 @@ impl SolverScale {
                 .collect(),
             segment_ranges: chain.segment_ranges.clone(),
             followers: chain.followers.clone(),
+            axis_kernels: chain.axis_kernels.clone(),
+            follower_history: chain.follower_history.as_ref().map(|h| {
+                let mut scaled = h.clone();
+                for axis in &mut scaled.axis_velocity {
+                    for v in axis.iter_mut() {
+                        *v = self.scale_velocity(*v);
+                    }
+                }
+                scaled
+            }),
+            follower_terminal: chain.follower_terminal.as_ref().map(|h| {
+                let mut scaled = h.clone();
+                for axis in &mut scaled.axis_velocity {
+                    for v in axis.iter_mut() {
+                        *v = self.scale_velocity(*v);
+                    }
+                }
+                scaled
+            }),
             inter_geom: chain
                 .inter_geom
                 .iter()

--- a/rust/temporal/src/topp/scaling.rs
+++ b/rust/temporal/src/topp/scaling.rs
@@ -43,7 +43,7 @@ impl SolverScale {
                 j_max: l.j_max / s,
             })
             .collect();
-        Limits::try_new(&sets).expect("scaling preserves validity")
+        Limits::try_new(&sets, limits.n_axes()).expect("scaling preserves validity")
     }
 
     pub(crate) fn scale_grid(&self, grid: &ArclengthGrid) -> ArclengthGrid {

--- a/rust/temporal/src/topp/solver.rs
+++ b/rust/temporal/src/topp/solver.rs
@@ -402,8 +402,10 @@ fn solve_with_cuts_and_trust_region(
     }
 
     let mut b_rhs: Vec<f64> = bundle.b_rhs.clone();
-    let j_path = bundle.j_path;
-    debug_assert!(j_path > 0.0, "bundle must carry positive j_path");
+    debug_assert!(
+        bundle.j_path_at.iter().all(|&j| j > 0.0),
+        "bundle must carry positive j_path_at"
+    );
     let b_floor = scale.to_scaled_b(SLP_B_FLOOR);
     for cut in cuts {
         match cut {
@@ -676,7 +678,7 @@ fn append_path_jerk_cut_weights(
 pub(crate) fn find_jerk_violators_chain(
     b: &[f64],
     h_intervals: &[f64],
-    j_path: f64,
+    j_path_at: &[f64],
 ) -> Vec<JerkViolator> {
     let n = b.len();
     if n < 3 {
@@ -691,7 +693,7 @@ pub(crate) fn find_jerk_violators_chain(
         let (idx, hl, hr) = crate::topp::stencil::stencil_at(i, n, h_intervals);
         let w = crate::topp::stencil::b_dd_weights(hl, hr);
         let b_dd = w[0] * b[idx[0]] + w[1] * b[idx[1]] + w[2] * b[idx[2]];
-        let ratio = b_dd.abs() * bi.sqrt() / (2.0 * j_path);
+        let ratio = b_dd.abs() * bi.sqrt() / (2.0 * j_path_at[i]);
         if ratio > 1.0 + SLP_EPS_FEAS {
             out.push(JerkViolator { i, ratio });
         }
@@ -904,8 +906,7 @@ pub(crate) fn slp_solve_chain(
     tol: f64,
     scale: &SolverScale,
 ) -> Result<(SolverResult, SlpOutcome), SolverSetupError> {
-    let j_path = bundle.j_path;
-    debug_assert!(j_path > 0.0);
+    debug_assert!(bundle.j_path_at.iter().all(|&j| j > 0.0));
     let n = bundle.n_grid;
 
     let mut cuts: Vec<SlpCut> = Vec::new();
@@ -918,7 +919,8 @@ pub(crate) fn slp_solve_chain(
         return Ok((last_result, SlpOutcome::InnerSolverFailure));
     }
 
-    let violators = find_jerk_violators_chain(&last_result.b, &bundle.h_intervals, j_path);
+    let violators =
+        find_jerk_violators_chain(&last_result.b, &bundle.h_intervals, &bundle.j_path_at);
     if violators.is_empty() {
         return Ok((last_result, SlpOutcome::Converged { outer_iters: 0 }));
     }
@@ -945,7 +947,7 @@ pub(crate) fn slp_solve_chain(
             cuts.push(SlpCut::PathJerkWeights {
                 i,
                 b_bar,
-                j_path,
+                j_path: bundle.j_path_at[i],
                 idx,
                 w,
                 h_bar,
@@ -970,7 +972,8 @@ pub(crate) fn slp_solve_chain(
         }
         last_result = new_result;
 
-        let new_violators = find_jerk_violators_chain(&last_result.b, &bundle.h_intervals, j_path);
+        let new_violators =
+            find_jerk_violators_chain(&last_result.b, &bundle.h_intervals, &bundle.j_path_at);
         if new_violators.is_empty() {
             return Ok((last_result, SlpOutcome::Converged { outer_iters: outer }));
         }

--- a/rust/temporal/src/topp/solver.rs
+++ b/rust/temporal/src/topp/solver.rs
@@ -52,7 +52,7 @@ use clarabel::solver::{
 use crate::topp::constraints::{Cone, ConstraintBundle};
 use crate::topp::scaling::SolverScale;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) enum SlpCut {
     /// Weight-based path-jerk cut. Rows scaled by `h̄²` to stay O(1).
     PathJerkWeights {
@@ -65,6 +65,7 @@ pub(crate) enum SlpCut {
     },
     AxisJerk(AxisJerkCut),
     Follower(crate::topp::follower::FollowerCut),
+    FollowerWindowed(crate::topp::follower::WindowedCut),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -369,7 +370,13 @@ fn solve_with_cuts_and_trust_region(
     let n_grid = bundle.n_grid;
 
     let mut cones_clarabel = map_clarabel_cones(bundle)?;
-    let cut_rows = 2 * cuts.len();
+    let cut_rows: usize = cuts
+        .iter()
+        .map(|c| match c {
+            SlpCut::FollowerWindowed(_) => 1,
+            _ => 2,
+        })
+        .sum();
     if cut_rows > 0 {
         cones_clarabel.push(NonnegativeConeT(cut_rows));
     }
@@ -453,6 +460,14 @@ fn solve_with_cuts_and_trust_region(
                     b_rhs.push(if sign > 0.0 { fc.rhs_pos } else { fc.rhs_neg });
                     n_rows += 1;
                 }
+            }
+            SlpCut::FollowerWindowed(wc) => {
+                let row = n_rows;
+                for &(col, g) in &wc.entries {
+                    push_nz(&mut rowval_per_col, &mut nzval_per_col, col, row, g);
+                }
+                b_rhs.push(wc.rhs);
+                n_rows += 1;
             }
         }
     }
@@ -717,6 +732,7 @@ pub(crate) fn find_jerk_violators_chain(
 pub(crate) fn max_axis_ratio_chain(
     result: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
+    windows: Option<&crate::topp::follower::FollowerWindows>,
 ) -> f64 {
     let n = result.b.len();
     debug_assert_eq!(chain.s.len(), n);
@@ -758,9 +774,14 @@ pub(crate) fn max_axis_ratio_chain(
             }
         }
     }
-    worst.max(crate::topp::follower::max_pa_ratio(
-        &result.b, &result.a, chain,
-    ))
+    match windows {
+        Some(w) => worst.max(crate::topp::follower::max_windowed_ratio(
+            w, chain, &result.b, &result.a,
+        )),
+        None => worst.max(crate::topp::follower::max_pa_ratio(
+            &result.b, &result.a, chain,
+        )),
+    }
 }
 
 fn jerk_vector(
@@ -802,7 +823,7 @@ fn set_jerk_projection(
 
 const SLP9_MAX_OUTER_ITERS: u32 = 30;
 const SLP9_WARN_AT_ITER: u32 = 15;
-const SLP9_EPS_FEAS: f64 = 5e-2;
+pub(crate) const SLP9_EPS_FEAS: f64 = 5e-2;
 const SLP9_RHO_B_INIT: f64 = 0.10;
 const SLP9_RHO_A_INIT: f64 = 0.25;
 const SLP9_RHO_B_MIN: f64 = 0.005;
@@ -1038,9 +1059,11 @@ enum Slp9LoopOutcome {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn run_slp9_loop(
     bundle: &ConstraintBundle,
     chain: &crate::topp::chain::ChainGrid,
+    windows: Option<&crate::topp::follower::FollowerWindows>,
     start: SolverResult,
     tol: f64,
     scale: &SolverScale,
@@ -1053,7 +1076,7 @@ fn run_slp9_loop(
 ) -> Result<Slp9LoopOutcome, SolverSetupError> {
     let mut last_result = start.clone();
     let mut best_result = start;
-    let mut best_ratio = max_axis_ratio_chain(&last_result, chain);
+    let mut best_ratio = max_axis_ratio_chain(&last_result, chain, windows);
     let mut rho_b = rho_b_init;
     let mut rho_a = rho_a_init;
     let mut accepted_total: u32 = 0;
@@ -1070,20 +1093,37 @@ fn run_slp9_loop(
         let target_floor = (1.0 + SLP9_EPS_FEAS) * (1.0 - SLP9_TARGET_MARGIN);
         let target_ratio = (best_ratio * SLP9_TARGET_DECAY).max(target_floor);
         let mut cuts = build_axis_jerk_cuts_chain(&last_result, chain, target_ratio);
-        cuts.extend(
-            crate::topp::follower::build_follower_pa_cuts(
-                &last_result.b,
-                &last_result.a,
-                chain,
-                target_ratio,
-                SLP9_EPS_FEAS,
-                SLP9_CUT_PLACEMENT_FRACTION,
-                SLP9_TARGET_DECAY,
-                scale.to_scaled_b(SLP_B_FLOOR),
-            )
-            .into_iter()
-            .map(SlpCut::Follower),
-        );
+        match windows {
+            Some(w) => cuts.extend(
+                crate::topp::follower::build_windowed_follower_cuts(
+                    &last_result.b,
+                    &last_result.a,
+                    chain,
+                    w,
+                    target_ratio,
+                    SLP9_EPS_FEAS,
+                    SLP9_CUT_PLACEMENT_FRACTION,
+                    SLP9_TARGET_DECAY,
+                    scale.to_scaled_b(SLP_B_FLOOR),
+                )
+                .into_iter()
+                .map(SlpCut::FollowerWindowed),
+            ),
+            None => cuts.extend(
+                crate::topp::follower::build_follower_pa_cuts(
+                    &last_result.b,
+                    &last_result.a,
+                    chain,
+                    target_ratio,
+                    SLP9_EPS_FEAS,
+                    SLP9_CUT_PLACEMENT_FRACTION,
+                    SLP9_TARGET_DECAY,
+                    scale.to_scaled_b(SLP_B_FLOOR),
+                )
+                .into_iter()
+                .map(SlpCut::Follower),
+            ),
+        }
         if cuts.is_empty() {
             return Ok(Slp9LoopOutcome::Done(
                 last_result,
@@ -1115,7 +1155,7 @@ fn run_slp9_loop(
             ) {
                 continue;
             }
-            let cand_ratio = max_axis_ratio_chain(&candidate, chain);
+            let cand_ratio = max_axis_ratio_chain(&candidate, chain, windows);
             if cand_ratio < best_ratio {
                 accepted = Some(candidate);
                 best_ratio = cand_ratio;
@@ -1128,7 +1168,7 @@ fn run_slp9_loop(
                 candidate.status,
                 SolverStatus::Infeasible | SolverStatus::MaxIter { .. }
             ) {
-                let cand_ratio = max_axis_ratio_chain(&candidate, chain);
+                let cand_ratio = max_axis_ratio_chain(&candidate, chain, windows);
                 if cand_ratio < best_ratio {
                     accepted = Some(candidate);
                     best_ratio = cand_ratio;
@@ -1189,19 +1229,20 @@ fn damp_profile_uniform(result: &SolverResult, lambda: f64) -> SolverResult {
 fn uniform_damp_for_feasibility(
     result: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
+    windows: Option<&crate::topp::follower::FollowerWindows>,
     current_ratio: f64,
 ) -> (SolverResult, f64) {
     let mut lambda = (SLP9_DAMP_TARGET_RATIO / current_ratio).cbrt().min(1.0);
     for _ in 0..32 {
         let damped = damp_profile_uniform(result, lambda);
-        let ratio = max_axis_ratio_chain(&damped, chain);
+        let ratio = max_axis_ratio_chain(&damped, chain, windows);
         if ratio <= SLP9_DAMP_TARGET_RATIO {
             return (damped, ratio);
         }
         lambda *= 0.75;
     }
     let damped = damp_profile_uniform(result, lambda);
-    let ratio = max_axis_ratio_chain(&damped, chain);
+    let ratio = max_axis_ratio_chain(&damped, chain, windows);
     (damped, ratio)
 }
 
@@ -1229,6 +1270,7 @@ fn damp_interior_a(result: &SolverResult, scale_factor: f64) -> SolverResult {
 fn damp_scale_for_axis_feasibility(
     result: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
+    windows: Option<&crate::topp::follower::FollowerWindows>,
     current_ratio: f64,
 ) -> f64 {
     let target_ratio = SLP9_DAMP_TARGET_RATIO;
@@ -1237,7 +1279,7 @@ fn damp_scale_for_axis_feasibility(
     let mut s = s_analytical.min(1.0);
     for _ in 0..24 {
         let damped = damp_interior_a(result, s);
-        let ratio = max_axis_ratio_chain(&damped, chain);
+        let ratio = max_axis_ratio_chain(&damped, chain, windows);
         if ratio <= target_ratio {
             return s;
         }
@@ -1246,10 +1288,99 @@ fn damp_scale_for_axis_feasibility(
     s
 }
 
+const SLP9_POLISH_MAX_ITERS: u32 = 5;
+const SLP9_POLISH_MIN_GAIN: f64 = 1e-6;
+
+fn profile_time(result: &SolverResult, h_intervals: &[f64]) -> f64 {
+    h_intervals
+        .iter()
+        .enumerate()
+        .map(|(i, h)| {
+            let v_sum = result.b[i].max(0.0).sqrt() + result.b[i + 1].max(0.0).sqrt();
+            if v_sum > 0.0 {
+                2.0 * h / v_sum
+            } else {
+                f64::INFINITY
+            }
+        })
+        .sum()
+}
+
+/// The SLP9 loop only ever reduces constraint violation; descending from the
+/// follower-free iterate it stops at first feasibility, which can sit a few
+/// percent below the local optimum. Re-maximize speed under full-cap cuts
+/// rebuilt at each accepted iterate while staying feasible.
+fn polish_windowed(
+    bundle: &ConstraintBundle,
+    chain: &crate::topp::chain::ChainGrid,
+    windows: &crate::topp::follower::FollowerWindows,
+    start: SolverResult,
+    tol: f64,
+    scale: &SolverScale,
+) -> Result<SolverResult, SolverSetupError> {
+    let mut current = start;
+    let mut current_time = profile_time(&current, &bundle.h_intervals);
+    for _ in 0..SLP9_POLISH_MAX_ITERS {
+        let mut cuts = build_axis_jerk_cuts_chain(&current, chain, 1.0);
+        cuts.extend(
+            crate::topp::follower::build_windowed_follower_cuts(
+                &current.b,
+                &current.a,
+                chain,
+                windows,
+                1.0,
+                SLP9_EPS_FEAS,
+                SLP9_CUT_PLACEMENT_FRACTION,
+                SLP9_TARGET_DECAY,
+                scale.to_scaled_b(SLP_B_FLOOR),
+            )
+            .into_iter()
+            .map(SlpCut::FollowerWindowed),
+        );
+        let candidate = solve_with_cuts(bundle, &cuts, tol, scale)?;
+        if matches!(
+            candidate.status,
+            SolverStatus::Infeasible | SolverStatus::MaxIter { .. }
+        ) {
+            break;
+        }
+        let ratio = max_axis_ratio_chain(&candidate, chain, Some(windows));
+        if ratio > 1.0 + SLP9_EPS_FEAS {
+            break;
+        }
+        let t = profile_time(&candidate, &bundle.h_intervals);
+        if t < current_time * (1.0 - SLP9_POLISH_MIN_GAIN) {
+            current = candidate;
+            current_time = t;
+        } else {
+            break;
+        }
+    }
+    Ok(current)
+}
+
 #[allow(clippy::too_many_lines)]
 pub(crate) fn slp_solve_with_axis_jerk_chain(
     bundle: &ConstraintBundle,
     chain: &crate::topp::chain::ChainGrid,
+    windows: Option<&crate::topp::follower::FollowerWindows>,
+    tol: f64,
+    scale: &SolverScale,
+) -> Result<(SolverResult, SlpOutcome), SolverSetupError> {
+    let (result, outcome) =
+        slp_solve_with_axis_jerk_chain_inner(bundle, chain, windows, tol, scale)?;
+    if let (Some(w), SlpOutcome::Converged { .. }) = (windows, &outcome) {
+        let polished = polish_windowed(bundle, chain, w, result, tol, scale)?;
+        return Ok((polished, outcome));
+    }
+    Ok((result, outcome))
+}
+
+#[allow(clippy::too_many_lines)]
+fn slp_solve_with_axis_jerk_chain_inner(
+    bundle: &ConstraintBundle,
+    chain: &crate::topp::chain::ChainGrid,
+    windows: Option<&crate::topp::follower::FollowerWindows>,
     tol: f64,
     scale: &SolverScale,
 ) -> Result<(SolverResult, SlpOutcome), SolverSetupError> {
@@ -1269,7 +1400,7 @@ pub(crate) fn slp_solve_with_axis_jerk_chain(
         _ => 0,
     };
 
-    let initial_max = max_axis_ratio_chain(&path_result, chain);
+    let initial_max = max_axis_ratio_chain(&path_result, chain, windows);
     if initial_max <= 1.0 + SLP9_EPS_FEAS {
         return Ok((
             path_result,
@@ -1302,6 +1433,7 @@ pub(crate) fn slp_solve_with_axis_jerk_chain(
         let loop_outcome = run_slp9_loop(
             bundle,
             chain,
+            windows,
             current_start.clone(),
             tol,
             scale,
@@ -1332,14 +1464,15 @@ pub(crate) fn slp_solve_with_axis_jerk_chain(
                         },
                     ));
                 }
-                let damp_s = damp_scale_for_axis_feasibility(&best_result, chain, best_ratio);
+                let damp_s =
+                    damp_scale_for_axis_feasibility(&best_result, chain, windows, best_ratio);
                 let damped = damp_interior_a(&best_result, damp_s);
-                let ratio_after_damp = max_axis_ratio_chain(&damped, chain);
+                let ratio_after_damp = max_axis_ratio_chain(&damped, chain, windows);
                 let restored = if ratio_after_damp <= 1.0 {
                     damped
                 } else {
                     let (uniform, uniform_ratio) =
-                        uniform_damp_for_feasibility(&best_result, chain, best_ratio);
+                        uniform_damp_for_feasibility(&best_result, chain, windows, best_ratio);
                     if uniform_ratio > 1.0 {
                         return Ok((
                             best_result,

--- a/rust/temporal/src/topp/solver.rs
+++ b/rust/temporal/src/topp/solver.rs
@@ -716,7 +716,7 @@ pub(crate) fn max_axis_ratio_chain(
         let geom = &chain.geom[i];
         let lim = chain.limits_at(i);
         let jerk = jerk_vector(geom, s_dot3, s_dot, s_ddot, s_dddot);
-        for set in lim.sets() {
+        for (_, set) in lim.spatial_sets() {
             if !set.j_max.is_finite() {
                 continue;
             }
@@ -735,7 +735,7 @@ pub(crate) fn max_axis_ratio_chain(
         let geom = &jct.geom;
         let lim = &chain.limits[jct.limits_idx];
         let jerk = jerk_vector(geom, s_dot3, s_dot, s_ddot, s_dddot);
-        for set in lim.sets() {
+        for (_, set) in lim.spatial_sets() {
             if !set.j_max.is_finite() {
                 continue;
             }
@@ -828,7 +828,7 @@ pub(crate) fn build_axis_jerk_cuts_chain(
         let geom = &chain.geom[i];
         let lim = chain.limits_at(i);
         let jerk = jerk_vector(geom, s_dot3, s_dot, s_ddot, s_dddot);
-        for (set_idx, set) in lim.sets().iter().enumerate() {
+        for (set_idx, set) in lim.spatial_sets() {
             if !set.j_max.is_finite() {
                 continue;
             }
@@ -861,7 +861,7 @@ pub(crate) fn build_axis_jerk_cuts_chain(
             let jlim = &chain.limits[jct.limits_idx];
             let jgeom = &jct.geom;
             let jjerk = jerk_vector(jgeom, s_dot3, s_dot, s_ddot, s_dddot);
-            for (set_idx, set) in jlim.sets().iter().enumerate() {
+            for (set_idx, set) in jlim.spatial_sets() {
                 if !set.j_max.is_finite() {
                     continue;
                 }

--- a/rust/temporal/src/topp/solver.rs
+++ b/rust/temporal/src/topp/solver.rs
@@ -64,6 +64,7 @@ pub(crate) enum SlpCut {
         h_bar: f64,
     },
     AxisJerk(AxisJerkCut),
+    Follower(crate::topp::follower::FollowerCut),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -443,6 +444,16 @@ fn solve_with_cuts_and_trust_region(
                     n_grid,
                 );
             }
+            SlpCut::Follower(fc) => {
+                for sign in [1.0_f64, -1.0] {
+                    let row = n_rows;
+                    for &(col, g) in &fc.entries[..fc.n_entries] {
+                        push_nz(&mut rowval_per_col, &mut nzval_per_col, col, row, sign * g);
+                    }
+                    b_rhs.push(if sign > 0.0 { fc.rhs_pos } else { fc.rhs_neg });
+                    n_rows += 1;
+                }
+            }
         }
     }
 
@@ -747,7 +758,9 @@ pub(crate) fn max_axis_ratio_chain(
             }
         }
     }
-    worst
+    worst.max(crate::topp::follower::max_pa_ratio(
+        &result.b, &result.a, chain,
+    ))
 }
 
 fn jerk_vector(
@@ -1056,7 +1069,21 @@ fn run_slp9_loop(
 
         let target_floor = (1.0 + SLP9_EPS_FEAS) * (1.0 - SLP9_TARGET_MARGIN);
         let target_ratio = (best_ratio * SLP9_TARGET_DECAY).max(target_floor);
-        let cuts = build_axis_jerk_cuts_chain(&last_result, chain, target_ratio);
+        let mut cuts = build_axis_jerk_cuts_chain(&last_result, chain, target_ratio);
+        cuts.extend(
+            crate::topp::follower::build_follower_pa_cuts(
+                &last_result.b,
+                &last_result.a,
+                chain,
+                target_ratio,
+                SLP9_EPS_FEAS,
+                SLP9_CUT_PLACEMENT_FRACTION,
+                SLP9_TARGET_DECAY,
+                scale.to_scaled_b(SLP_B_FLOOR),
+            )
+            .into_iter()
+            .map(SlpCut::Follower),
+        );
         if cuts.is_empty() {
             return Ok(Slp9LoopOutcome::Done(
                 last_result,
@@ -1144,6 +1171,38 @@ fn run_slp9_loop(
             last_max_ratio: best_ratio,
         },
     ))
+}
+
+/// Uniform time dilation of the iterate: `b ← λ²·b`, `a ← λ²·a`. Every
+/// constraint-family ratio decreases monotonically as λ → 0, so this can
+/// always restore a feasible linearization point (unlike `damp_interior_a`,
+/// which leaves `b`-driven families untouched).
+fn damp_profile_uniform(result: &SolverResult, lambda: f64) -> SolverResult {
+    let l2 = lambda * lambda;
+    SolverResult {
+        b: result.b.iter().map(|&b| b * l2).collect(),
+        a: result.a.iter().map(|&a| a * l2).collect(),
+        status: result.status,
+    }
+}
+
+fn uniform_damp_for_feasibility(
+    result: &SolverResult,
+    chain: &crate::topp::chain::ChainGrid,
+    current_ratio: f64,
+) -> (SolverResult, f64) {
+    let mut lambda = (SLP9_DAMP_TARGET_RATIO / current_ratio).cbrt().min(1.0);
+    for _ in 0..32 {
+        let damped = damp_profile_uniform(result, lambda);
+        let ratio = max_axis_ratio_chain(&damped, chain);
+        if ratio <= SLP9_DAMP_TARGET_RATIO {
+            return (damped, ratio);
+        }
+        lambda *= 0.75;
+    }
+    let damped = damp_profile_uniform(result, lambda);
+    let ratio = max_axis_ratio_chain(&damped, chain);
+    (damped, ratio)
 }
 
 /// Scales all interior `a` values by `scale_factor`, leaving `b` and endpoint
@@ -1261,6 +1320,9 @@ pub(crate) fn slp_solve_with_axis_jerk_chain(
                 outer_iters,
                 accepted_total: _,
             } => {
+                if best_ratio <= 1.0 + SLP9_EPS_FEAS {
+                    return Ok((best_result, SlpOutcome::Converged { outer_iters }));
+                }
                 if restorations_used >= SLP9_MAX_RESTORATIONS {
                     return Ok((
                         best_result,
@@ -1273,16 +1335,23 @@ pub(crate) fn slp_solve_with_axis_jerk_chain(
                 let damp_s = damp_scale_for_axis_feasibility(&best_result, chain, best_ratio);
                 let damped = damp_interior_a(&best_result, damp_s);
                 let ratio_after_damp = max_axis_ratio_chain(&damped, chain);
-                if ratio_after_damp > 1.0 {
-                    return Ok((
-                        best_result,
-                        SlpOutcome::Diverged {
-                            last_max_ratio: best_ratio,
-                            outer_iters,
-                        },
-                    ));
-                }
-                current_start = damped;
+                let restored = if ratio_after_damp <= 1.0 {
+                    damped
+                } else {
+                    let (uniform, uniform_ratio) =
+                        uniform_damp_for_feasibility(&best_result, chain, best_ratio);
+                    if uniform_ratio > 1.0 {
+                        return Ok((
+                            best_result,
+                            SlpOutcome::Diverged {
+                                last_max_ratio: best_ratio,
+                                outer_iters,
+                            },
+                        ));
+                    }
+                    uniform
+                };
+                current_start = restored;
                 outer_iters_consumed = outer_iters - path_outer_iters;
                 restorations_used += 1;
             }

--- a/rust/temporal/src/topp/solver/tests.rs
+++ b/rust/temporal/src/topp/solver/tests.rs
@@ -368,15 +368,15 @@ fn damp_scale_for_axis_feasibility_achieves_target() {
         status: SolverStatus::Solved,
     };
 
-    let initial_ratio = max_axis_ratio_chain(&result, &chain);
+    let initial_ratio = max_axis_ratio_chain(&result, &chain, None);
     assert!(
         initial_ratio > SLP9_DAMP_TARGET_RATIO,
         "test requires initial_ratio > {SLP9_DAMP_TARGET_RATIO}, got {initial_ratio}",
     );
 
-    let s = damp_scale_for_axis_feasibility(&result, &chain, initial_ratio);
+    let s = damp_scale_for_axis_feasibility(&result, &chain, None, initial_ratio);
     let damped = damp_interior_a(&result, s);
-    let final_ratio = max_axis_ratio_chain(&damped, &chain);
+    let final_ratio = max_axis_ratio_chain(&damped, &chain, None);
 
     assert!(
         final_ratio <= SLP9_DAMP_TARGET_RATIO,

--- a/rust/temporal/src/topp/solver/tests.rs
+++ b/rust/temporal/src/topp/solver/tests.rs
@@ -155,7 +155,7 @@ fn find_jerk_violators_chain_ratio_has_no_spurious_h_factor() {
     let j_path = 100.0_f64;
     let b = vec![401.375_f64, 400.0, 401.375];
     let h_intervals = vec![h, h];
-    let violators = find_jerk_violators_chain(&b, &h_intervals, j_path);
+    let violators = find_jerk_violators_chain(&b, &h_intervals, &[j_path; 3]);
     assert_eq!(
         violators.len(),
         1,

--- a/rust/temporal/src/topp/stencil.rs
+++ b/rust/temporal/src/topp/stencil.rs
@@ -33,5 +33,56 @@ pub fn s_dddot_at_weights(b: &[f64], i: usize, h_intervals: &[f64]) -> f64 {
     b[i].max(0.0).sqrt() * b_dd / 2.0
 }
 
+pub fn fornberg_weights(x0: f64, xs: &[f64], order: usize) -> Vec<Vec<f64>> {
+    let n = xs.len();
+    assert!(n > order, "need more nodes than derivative order");
+    let mut w = vec![vec![0.0; n]; order + 1];
+    let mut c1 = 1.0;
+    let mut c4 = xs[0] - x0;
+    w[0][0] = 1.0;
+    for i in 1..n {
+        let mn = i.min(order);
+        let mut c2 = 1.0;
+        let c5 = c4;
+        c4 = xs[i] - x0;
+        for j in 0..i {
+            let c3 = xs[i] - xs[j];
+            c2 *= c3;
+            if j == i - 1 {
+                for k in (1..=mn).rev() {
+                    w[k][i] = c1 * (k as f64 * w[k - 1][i - 1] - c5 * w[k][i - 1]) / c2;
+                }
+                w[0][i] = -c1 * c5 * w[0][i - 1] / c2;
+            }
+            for k in (1..=mn).rev() {
+                w[k][j] = (c4 * w[k][j] - k as f64 * w[k - 1][j]) / c3;
+            }
+            w[0][j] = c4 * w[0][j] / c3;
+        }
+        c1 = c2;
+    }
+    w
+}
+
+pub fn b_ddd_weights_at(i: usize, s: &[f64]) -> ([usize; 4], [f64; 4]) {
+    let n = s.len();
+    assert!(n >= 4, "third difference needs at least 4 points");
+    let start = i.saturating_sub(1).min(n - 4);
+    let idx = [start, start + 1, start + 2, start + 3];
+    let xs = [s[idx[0]], s[idx[1]], s[idx[2]], s[idx[3]]];
+    let w = fornberg_weights(s[i], &xs, 3);
+    (idx, [w[3][0], w[3][1], w[3][2], w[3][3]])
+}
+
+pub fn s_ddddot_at_weights(b: &[f64], a_i: f64, i: usize, s: &[f64], h_intervals: &[f64]) -> f64 {
+    let n = b.len();
+    let (idx2, hl, hr) = stencil_at(i, n, h_intervals);
+    let w2 = b_dd_weights(hl, hr);
+    let b_dd = w2[0] * b[idx2[0]] + w2[1] * b[idx2[1]] + w2[2] * b[idx2[2]];
+    let (idx3, w3) = b_ddd_weights_at(i, s);
+    let b_ddd: f64 = (0..4).map(|k| w3[k] * b[idx3[k]]).sum();
+    a_i * b_dd / 2.0 + b[i].max(0.0) * b_ddd / 2.0
+}
+
 #[cfg(test)]
 mod tests;

--- a/rust/temporal/src/topp/stencil/tests.rs
+++ b/rust/temporal/src/topp/stencil/tests.rs
@@ -32,3 +32,48 @@ fn weights_reduce_to_uniform() {
     assert!((wdd[1] - (-2.0 / (h * h))).abs() < 1e-12);
     assert!((wdd[2] - 1.0 / (h * h)).abs() < 1e-12);
 }
+
+#[test]
+fn fornberg_matches_b_dd_weights() {
+    let (hl, hr) = (0.7, 1.3);
+    let xs = [-hl, 0.0, hr];
+    let w = fornberg_weights(0.0, &xs, 2);
+    let closed = b_dd_weights(hl, hr);
+    for k in 0..3 {
+        assert!((w[2][k] - closed[k]).abs() < 1e-12, "k={k}");
+    }
+    let closed_d = b_d_weights(hl, hr);
+    for k in 0..3 {
+        assert!((w[1][k] - closed_d[k]).abs() < 1e-12, "k={k}");
+    }
+}
+
+#[test]
+fn b_ddd_weights_exact_on_cubics() {
+    let s = [0.0, 0.7, 1.5, 2.6];
+    let b: Vec<f64> = s.iter().map(|&x: &f64| x.powi(3)).collect();
+    for i in 0..4 {
+        let (idx, w) = b_ddd_weights_at(i, &s);
+        let ddd: f64 = (0..4).map(|k| w[k] * b[idx[k]]).sum();
+        assert!((ddd - 6.0).abs() < 1e-9, "i={i} got {ddd}");
+    }
+}
+
+#[test]
+fn s_snap_on_quartic_b_profile() {
+    // b(s) = (1+s)^4 ⇒ ṡ = (1+s)², s̈ = 2(1+s)³, s⃛ = 6(1+s)⁴, s⁗ = 24(1+s)⁵
+    let n = 401;
+    let h = 0.5 / (n - 1) as f64;
+    let s: Vec<f64> = (0..n).map(|i| i as f64 * h).collect();
+    let b: Vec<f64> = s.iter().map(|&x| (1.0 + x).powi(4)).collect();
+    let h_intervals = vec![h; n - 1];
+    let i = n / 2;
+    let x = s[i];
+    let a_i = 2.0 * (1.0 + x).powi(3);
+    let snap = s_ddddot_at_weights(&b, a_i, i, &s, &h_intervals);
+    let analytic = 24.0 * (1.0 + x).powi(5);
+    assert!(
+        (snap - analytic).abs() / analytic < 1e-2,
+        "got {snap}, want {analytic}"
+    );
+}

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -197,6 +197,14 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         };
     }
 
+    let windows = if chain.has_active_windows() {
+        Some(crate::topp::follower::build_follower_windows(
+            chain, &result.b,
+        ))
+    } else {
+        None
+    };
+
     let mut binding_per_grid: Vec<BindingConstraint> = Vec::with_capacity(n);
     let mut point_worst_ratio: Vec<f64> = Vec::with_capacity(n);
     let mut global_worst_ratio: f64 = f64::NEG_INFINITY;
@@ -233,9 +241,27 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             s_dddot,
             s_ddddot,
             limits: chain.limits_at(i),
-            followers: chain.followers_at(i),
+            followers: if windows.is_some() {
+                &[]
+            } else {
+                chain.followers_at(i)
+            },
         });
 
+        let mut pr = pr;
+        if let Some(w) = &windows {
+            for d in crate::topp::follower::windowed_demands_at(w, chain, &result.b, &result.a, i) {
+                let ratio = d.value / d.cap;
+                if ratio > pr.max_jerk {
+                    pr.max_jerk = ratio;
+                }
+                if ratio > pr.worst_ratio {
+                    pr.worst_ratio = ratio;
+                    pr.worst_tag = windowed_tag(&d);
+                }
+            }
+        }
+        let pr = pr;
         let final_tag = if (i == 0 || i == n - 1) && b_i.abs() < BOUNDARY_B_TOL {
             BindingConstraint::Boundary
         } else {
@@ -314,6 +340,18 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         feasible,
         worst_jerk_ratio,
         worst_non_jerk_ratio,
+    }
+}
+
+fn windowed_tag(d: &crate::topp::follower::WindowedDemand) -> BindingConstraint {
+    use crate::topp::follower::PaFamily;
+    match (d.family, d.pa) {
+        (PaFamily::Velocity, false) => BindingConstraint::Velocity { set: d.set },
+        (PaFamily::Accel, false) => BindingConstraint::AccelNorm { set: d.set },
+        (PaFamily::Jerk, false) => BindingConstraint::JerkNorm { set: d.set },
+        (PaFamily::Velocity, true) => BindingConstraint::PaVelocity { set: d.set },
+        (PaFamily::Accel, true) => BindingConstraint::PaAccel { set: d.set },
+        (PaFamily::Jerk, true) => BindingConstraint::PaJerk { set: d.set },
     }
 }
 

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -32,6 +32,7 @@ struct PointInputs<'a> {
     s_dot: f64,
     s_ddot: f64,
     s_dddot: f64,
+    s_ddddot: f64,
     limits: &'a Limits,
     followers: &'a [FollowerDemand],
 }
@@ -91,27 +92,49 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
     }
     for f in p.followers {
         let r = f.ratio.abs();
+        let k = f.pa_k;
         for (set_idx, set) in lim.follower_sets() {
             if !set.axes.contains(f.axis) {
                 continue;
             }
-            if set.v_max.is_finite() {
-                entries.push((
-                    r * p.s_dot / set.v_max,
-                    BindingConstraint::Velocity { set: set_idx },
-                ));
-            }
-            if set.a_max.is_finite() {
-                entries.push((
-                    r * p.s_ddot.abs() / set.a_max,
-                    BindingConstraint::AccelNorm { set: set_idx },
-                ));
-            }
-            if set.j_max.is_finite() {
-                entries.push((
-                    r * p.s_dddot.abs() / set.j_max,
-                    BindingConstraint::JerkNorm { set: set_idx },
-                ));
+            if k == 0.0 {
+                if set.v_max.is_finite() {
+                    entries.push((
+                        r * p.s_dot / set.v_max,
+                        BindingConstraint::Velocity { set: set_idx },
+                    ));
+                }
+                if set.a_max.is_finite() {
+                    entries.push((
+                        r * p.s_ddot.abs() / set.a_max,
+                        BindingConstraint::AccelNorm { set: set_idx },
+                    ));
+                }
+                if set.j_max.is_finite() {
+                    entries.push((
+                        r * p.s_dddot.abs() / set.j_max,
+                        BindingConstraint::JerkNorm { set: set_idx },
+                    ));
+                }
+            } else {
+                if set.v_max.is_finite() {
+                    entries.push((
+                        r * (p.s_dot + k * p.s_ddot).abs() / set.v_max,
+                        BindingConstraint::PaVelocity { set: set_idx },
+                    ));
+                }
+                if set.a_max.is_finite() {
+                    entries.push((
+                        r * (p.s_ddot + k * p.s_dddot).abs() / set.a_max,
+                        BindingConstraint::PaAccel { set: set_idx },
+                    ));
+                }
+                if set.j_max.is_finite() {
+                    entries.push((
+                        r * (p.s_dddot + k * p.s_ddddot).abs() / set.j_max,
+                        BindingConstraint::PaJerk { set: set_idx },
+                    ));
+                }
             }
         }
     }
@@ -126,7 +149,13 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
             worst_ratio = ratio;
             worst_tag = tag;
         }
-        if matches!(tag, BindingConstraint::JerkNorm { .. }) {
+        if matches!(
+            tag,
+            BindingConstraint::JerkNorm { .. }
+                | BindingConstraint::PaJerk { .. }
+                | BindingConstraint::PaVelocity { .. }
+                | BindingConstraint::PaAccel { .. }
+        ) {
             if ratio > max_jerk {
                 max_jerk = ratio;
             }
@@ -153,6 +182,7 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
 /// primary arrays; the dual pass is what enforces the right side.
 pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyReport {
     let n = chain.n_points();
+    let has_pa = chain.followers.iter().flatten().any(|f| f.pa_k != 0.0);
     debug_assert_eq!(result.b.len(), n);
     debug_assert_eq!(result.a.len(), n);
 
@@ -181,6 +211,17 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         let s_dot = b_i.max(0.0).sqrt();
         let s_ddot = a_i;
         let s_dddot = crate::topp::stencil::s_dddot_at_weights(&result.b, i, &chain.h_intervals);
+        let s_ddddot = if has_pa {
+            crate::topp::stencil::s_ddddot_at_weights(
+                &result.b,
+                a_i,
+                i,
+                &chain.s,
+                &chain.h_intervals,
+            )
+        } else {
+            0.0
+        };
 
         let g = &chain.geom[i];
         let pr = ratios_at(&PointInputs {
@@ -190,6 +231,7 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             s_dot,
             s_ddot,
             s_dddot,
+            s_ddddot,
             limits: chain.limits_at(i),
             followers: chain.followers_at(i),
         });
@@ -222,6 +264,17 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         let s_dot = b_i.max(0.0).sqrt();
         let s_ddot = result.a[i];
         let s_dddot = crate::topp::stencil::s_dddot_at_weights(&result.b, i, &chain.h_intervals);
+        let s_ddddot = if has_pa {
+            crate::topp::stencil::s_ddddot_at_weights(
+                &result.b,
+                s_ddot,
+                i,
+                &chain.s,
+                &chain.h_intervals,
+            )
+        } else {
+            0.0
+        };
 
         let pr = ratios_at(&PointInputs {
             cp: jd.geom.c_prime,
@@ -230,6 +283,7 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             s_dot,
             s_ddot,
             s_dddot,
+            s_ddddot,
             limits: &chain.limits[jd.limits_idx],
             followers: &chain.followers[jd.limits_idx],
         });

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -1,6 +1,6 @@
 use crate::topp::chain::ChainGrid;
 use crate::topp::solver::SolverResult;
-use crate::{BindingConstraint, Limits, restricted_norm};
+use crate::{BindingConstraint, FollowerDemand, Limits, restricted_norm};
 
 /// 0.2% feasibility margin for velocity / accel / centripetal.
 pub(crate) const EPS_FEAS: f64 = 2e-3;
@@ -33,6 +33,7 @@ struct PointInputs<'a> {
     s_ddot: f64,
     s_dddot: f64,
     limits: &'a Limits,
+    followers: &'a [FollowerDemand],
 }
 
 struct PointRatios {
@@ -64,7 +65,7 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
 
     let lim = p.limits;
     let mut entries: Vec<(f64, BindingConstraint)> = Vec::with_capacity(3 * lim.sets().len());
-    for (set_idx, set) in lim.sets().iter().enumerate() {
+    for (set_idx, set) in lim.spatial_sets() {
         if set.v_max.is_finite() {
             entries.push((
                 restricted_norm(&vel, set.axes) / set.v_max,
@@ -72,7 +73,7 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
             ));
         }
     }
-    for (set_idx, set) in lim.sets().iter().enumerate() {
+    for (set_idx, set) in lim.spatial_sets() {
         if set.a_max.is_finite() {
             entries.push((
                 restricted_norm(&accel, set.axes) / set.a_max,
@@ -80,12 +81,38 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
             ));
         }
     }
-    for (set_idx, set) in lim.sets().iter().enumerate() {
+    for (set_idx, set) in lim.spatial_sets() {
         if set.j_max.is_finite() {
             entries.push((
                 restricted_norm(&jerk, set.axes) / set.j_max,
                 BindingConstraint::JerkNorm { set: set_idx },
             ));
+        }
+    }
+    for f in p.followers {
+        let r = f.ratio.abs();
+        for (set_idx, set) in lim.follower_sets() {
+            if !set.axes.contains(f.axis) {
+                continue;
+            }
+            if set.v_max.is_finite() {
+                entries.push((
+                    r * p.s_dot / set.v_max,
+                    BindingConstraint::Velocity { set: set_idx },
+                ));
+            }
+            if set.a_max.is_finite() {
+                entries.push((
+                    r * p.s_ddot.abs() / set.a_max,
+                    BindingConstraint::AccelNorm { set: set_idx },
+                ));
+            }
+            if set.j_max.is_finite() {
+                entries.push((
+                    r * p.s_dddot.abs() / set.j_max,
+                    BindingConstraint::JerkNorm { set: set_idx },
+                ));
+            }
         }
     }
 
@@ -164,6 +191,7 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             s_ddot,
             s_dddot,
             limits: chain.limits_at(i),
+            followers: chain.followers_at(i),
         });
 
         let final_tag = if (i == 0 || i == n - 1) && b_i.abs() < BOUNDARY_B_TOL {
@@ -203,6 +231,7 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             s_ddot,
             s_dddot,
             limits: &chain.limits[jd.limits_idx],
+            followers: &chain.followers[jd.limits_idx],
         });
 
         if pr.worst_ratio > global_worst_ratio {

--- a/rust/temporal/src/topp/window.rs
+++ b/rust/temporal/src/topp/window.rs
@@ -83,6 +83,18 @@ impl WindowOperator {
         t_map: &[f64],
         history: &WindowHistory,
     ) -> Self {
+        Self::from_kernel_with_terminal(kernel, t_map, history, &WindowHistory::empty())
+    }
+
+    /// `terminal` holds post-chain signal samples; sample `m` sits at
+    /// `t_end + (m + 0.5) * dt`. Kernel mass beyond the supplied samples
+    /// falls back to holding the final chain sample.
+    pub fn from_kernel_with_terminal(
+        kernel: &PiecewisePolynomialKernel<f64>,
+        t_map: &[f64],
+        history: &WindowHistory,
+        terminal: &WindowHistory,
+    ) -> Self {
         let n = t_map.len();
         assert!(n >= 2, "window operator needs at least two samples");
         let (k_lo, k_hi) = kernel.support();
@@ -114,6 +126,17 @@ impl WindowOperator {
                         }
                     }
                 }
+                if terminal.dt > 0.0 {
+                    let t_end = t_map[n - 1];
+                    for (m, &sample) in terminal.samples.iter().enumerate() {
+                        let tau = t_end + (m as f64 + 0.5) * terminal.dt;
+                        let k = eval_kernel(kernel, ti - tau);
+                        if k != 0.0 {
+                            history_value += k * terminal.dt * sample;
+                            mass += k * terminal.dt;
+                        }
+                    }
+                }
                 let leftover = 1.0 - mass;
                 if leftover > 0.0 && ti + k_hi > t_map[n - 1] {
                     let last = weights
@@ -125,10 +148,15 @@ impl WindowOperator {
                         Some(w) => *w += leftover,
                         None => weights.push((n - 1, leftover)),
                     }
+                    mass = 1.0;
+                }
+                assert!(mass > 0.0, "window row {i}: zero kernel mass");
+                for (_, w) in &mut weights {
+                    *w /= mass;
                 }
                 WindowRow {
                     weights,
-                    history: history_value,
+                    history: history_value / mass,
                 }
             })
             .collect();

--- a/rust/temporal/src/topp/window.rs
+++ b/rust/temporal/src/topp/window.rs
@@ -1,0 +1,161 @@
+use nurbs::algebra::PiecewisePolynomialKernel;
+
+pub fn frozen_time_map(b: &[f64], h_intervals: &[f64]) -> Vec<f64> {
+    assert_eq!(b.len(), h_intervals.len() + 1);
+    let mut t = Vec::with_capacity(b.len());
+    let mut acc = 0.0;
+    t.push(0.0);
+    for (i, h) in h_intervals.iter().enumerate() {
+        let v_sum = b[i].max(0.0).sqrt() + b[i + 1].max(0.0).sqrt();
+        assert!(
+            v_sum > 0.0,
+            "frozen time map: zero speed across interval {i}"
+        );
+        acc += 2.0 * h / v_sum;
+        t.push(acc);
+    }
+    t
+}
+
+pub fn eval_kernel(kernel: &PiecewisePolynomialKernel<f64>, z: f64) -> f64 {
+    let (k_lo, k_hi) = kernel.support();
+    if z < k_lo || z > k_hi {
+        return 0.0;
+    }
+    for p in &kernel.pieces {
+        if z >= p.u_start - 1e-15 && z <= p.u_end + 1e-15 {
+            return p.evaluate(z);
+        }
+    }
+    0.0
+}
+
+#[derive(Debug, Clone)]
+pub struct WindowRow {
+    pub weights: Vec<(usize, f64)>,
+    pub history: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct WindowOperator {
+    rows: Vec<WindowRow>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WindowHistory {
+    pub dt: f64,
+    /// Pre-chain signal values; sample `m` sits at `t = -(m + 0.5) * dt`.
+    pub samples: Vec<f64>,
+}
+
+impl WindowHistory {
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn constant_signal(value: f64, duration: f64, n: usize) -> Self {
+        assert!(n > 0 && duration > 0.0);
+        Self {
+            dt: duration / n as f64,
+            samples: vec![value; n],
+        }
+    }
+}
+
+impl WindowOperator {
+    #[must_use]
+    pub fn identity(n: usize) -> Self {
+        Self {
+            rows: (0..n)
+                .map(|i| WindowRow {
+                    weights: vec![(i, 1.0)],
+                    history: 0.0,
+                })
+                .collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn from_kernel(
+        kernel: &PiecewisePolynomialKernel<f64>,
+        t_map: &[f64],
+        history: &WindowHistory,
+    ) -> Self {
+        let n = t_map.len();
+        assert!(n >= 2, "window operator needs at least two samples");
+        let (k_lo, k_hi) = kernel.support();
+        let rows = (0..n)
+            .map(|i| {
+                let ti = t_map[i];
+                let mut weights = Vec::new();
+                let mut mass = 0.0;
+                for (j, &tj) in t_map.iter().enumerate() {
+                    let z = ti - tj;
+                    if z < k_lo || z > k_hi {
+                        continue;
+                    }
+                    let q = trapezoid_weight(t_map, j);
+                    let w = eval_kernel(kernel, z) * q;
+                    if w != 0.0 {
+                        weights.push((j, w));
+                        mass += w;
+                    }
+                }
+                let mut history_value = 0.0;
+                if history.dt > 0.0 {
+                    for (m, &sample) in history.samples.iter().enumerate() {
+                        let tau = -(m as f64 + 0.5) * history.dt;
+                        let k = eval_kernel(kernel, ti - tau);
+                        if k != 0.0 {
+                            history_value += k * history.dt * sample;
+                            mass += k * history.dt;
+                        }
+                    }
+                }
+                let leftover = 1.0 - mass;
+                if leftover > 0.0 && ti + k_hi > t_map[n - 1] {
+                    let last = weights
+                        .iter_mut()
+                        .rev()
+                        .find(|(j, _)| *j == n - 1)
+                        .map(|(_, w)| w);
+                    match last {
+                        Some(w) => *w += leftover,
+                        None => weights.push((n - 1, leftover)),
+                    }
+                }
+                WindowRow {
+                    weights,
+                    history: history_value,
+                }
+            })
+            .collect();
+        Self { rows }
+    }
+
+    #[must_use]
+    pub fn row(&self, i: usize) -> &WindowRow {
+        &self.rows[i]
+    }
+
+    #[must_use]
+    pub fn n_rows(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+fn trapezoid_weight(t: &[f64], j: usize) -> f64 {
+    let n = t.len();
+    if j == 0 {
+        (t[1] - t[0]) / 2.0
+    } else if j == n - 1 {
+        (t[n - 1] - t[n - 2]) / 2.0
+    } else {
+        (t[j + 1] - t[j - 1]) / 2.0
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/temporal/src/topp/window/tests.rs
+++ b/rust/temporal/src/topp/window/tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+use nurbs::algebra::PiecewisePolynomialKernel;
+
+fn test_bell_kernel(frequency_hz: f64) -> PiecewisePolynomialKernel<f64> {
+    let t_sm = 0.8025 / frequency_hz;
+    let h = t_sm / 2.0;
+    let c = 15.0 / (16.0 * h.powi(5));
+    let coeffs = vec![c * h.powi(4), 0.0, -2.0 * c * h * h, 0.0, c];
+    PiecewisePolynomialKernel::single_poly_from_absolute(coeffs, (-h, h))
+}
+
+fn kernel_half_support(kernel: &PiecewisePolynomialKernel<f64>) -> f64 {
+    kernel.support().1
+}
+
+#[test]
+fn time_map_of_constant_speed_is_uniform() {
+    let b = vec![4.0; 5];
+    let h = vec![1.0; 4];
+    let t = frozen_time_map(&b, &h);
+    for (i, ti) in t.iter().enumerate() {
+        assert!((ti - 0.5 * i as f64).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn identity_window_is_identity() {
+    let w = WindowOperator::identity(5);
+    let signal = [1.0, 2.0, 3.0, 4.0, 5.0];
+    for i in 0..5 {
+        let row = w.row(i);
+        let applied: f64 = row.weights.iter().map(|&(j, wj)| wj * signal[j]).sum();
+        assert!((applied + row.history - signal[i]).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn kernel_window_weights_sum_to_one_in_the_interior() {
+    let kernel = test_bell_kernel(40.0);
+    let b = vec![100.0_f64.powi(2); 200];
+    let h = vec![0.1; 199];
+    let t = frozen_time_map(&b, &h);
+    let w = WindowOperator::from_kernel(&kernel, &t, &WindowHistory::empty());
+    let mid = w.row(100);
+    let total: f64 = mid.weights.iter().map(|&(_, wj)| wj).sum();
+    assert!((total - 1.0).abs() < 2e-3, "got {total}");
+}
+
+#[test]
+fn history_supplies_the_left_edge() {
+    let kernel = test_bell_kernel(40.0);
+    let b = vec![100.0_f64.powi(2); 200];
+    let h = vec![0.1; 199];
+    let t = frozen_time_map(&b, &h);
+    let hist = WindowHistory::constant_signal(100.0, kernel_half_support(&kernel), 64);
+    let w = WindowOperator::from_kernel(&kernel, &t, &hist);
+    let row0 = w.row(0);
+    let interior: f64 = row0.weights.iter().map(|&(_, wj)| wj).sum::<f64>() * 100.0;
+    assert!((interior + row0.history - 100.0).abs() < 1.0);
+}
+
+#[test]
+fn right_edge_extends_with_terminal_hold() {
+    let kernel = test_bell_kernel(40.0);
+    let b = vec![100.0_f64.powi(2); 200];
+    let h = vec![0.1; 199];
+    let t = frozen_time_map(&b, &h);
+    let hist = WindowHistory::constant_signal(100.0, kernel_half_support(&kernel), 64);
+    let w = WindowOperator::from_kernel(&kernel, &t, &hist);
+    let signal = vec![100.0; 200];
+    let last = w.row(199);
+    let applied: f64 = last.weights.iter().map(|&(j, wj)| wj * signal[j]).sum();
+    assert!(
+        (applied + last.history - 100.0).abs() < 1.0,
+        "got {applied}"
+    );
+}
+
+#[test]
+#[should_panic(expected = "zero speed")]
+fn zero_speed_interval_panics() {
+    let b = vec![0.0, 0.0];
+    let h = vec![1.0];
+    let _ = frozen_time_map(&b, &h);
+}

--- a/rust/temporal/tests/gantry_norm_isotropy.rs
+++ b/rust/temporal/tests/gantry_norm_isotropy.rs
@@ -2,20 +2,23 @@ use nurbs::VectorNurbs;
 use temporal::{AxisSet, GridConfig, GridScheme, LimitSet, Limits, SolveStatus, schedule_segment};
 
 fn gantry_limits() -> Limits {
-    Limits::try_new(&[
-        LimitSet {
-            axes: AxisSet::from_indices(&[0, 1]),
-            v_max: 300.0,
-            a_max: 3000.0,
-            j_max: 6000.0,
-        },
-        LimitSet {
-            axes: AxisSet::from_indices(&[2]),
-            v_max: 15.0,
-            a_max: 100.0,
-            j_max: 200.0,
-        },
-    ])
+    Limits::try_new(
+        &[
+            LimitSet {
+                axes: AxisSet::from_indices(&[0, 1]),
+                v_max: 300.0,
+                a_max: 3000.0,
+                j_max: 6000.0,
+            },
+            LimitSet {
+                axes: AxisSet::from_indices(&[2]),
+                v_max: 15.0,
+                a_max: 100.0,
+                j_max: 200.0,
+            },
+        ],
+        temporal::N_SPATIAL,
+    )
     .unwrap()
 }
 

--- a/rust/temporal/tests/micro_segment_rest_to_rest.rs
+++ b/rust/temporal/tests/micro_segment_rest_to_rest.rs
@@ -90,6 +90,7 @@ fn rung3_micro_arc_0_01mm_via_adaptive_batch() {
     let segments = [SegmentInput {
         curve: &curve,
         limits,
+        followers: &[],
     }];
     let output = plan_batch(BatchInput {
         segments: &segments,

--- a/rust/temporal/tests/micro_segment_rest_to_rest.rs
+++ b/rust/temporal/tests/micro_segment_rest_to_rest.rs
@@ -94,6 +94,7 @@ fn rung3_micro_arc_0_01mm_via_adaptive_batch() {
     }];
     let output = plan_batch(BatchInput {
         segments: &segments,
+        shaping: None,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,
             max_n: 200,

--- a/rust/temporal/tests/multi_segment.rs
+++ b/rust/temporal/tests/multi_segment.rs
@@ -51,10 +51,12 @@ mod fixture_1_two_g1_sharp_corner {
             SegmentInput {
                 curve: &left,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &right,
                 limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {
@@ -108,10 +110,12 @@ mod fixture_2_g1_to_g5_smooth {
             SegmentInput {
                 curve: &left,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &right,
                 limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {
@@ -160,10 +164,12 @@ mod fixture_3_long_straight_then_corner {
             SegmentInput {
                 curve: &straight,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &corner_right,
                 limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {
@@ -239,14 +245,17 @@ mod fixture_4_per_segment_limits_change {
             SegmentInput {
                 curve: &segments_curves[0],
                 limits: normal_limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &segments_curves[1],
                 limits: reduced_limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &segments_curves[2],
                 limits: normal_limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {
@@ -319,7 +328,11 @@ mod fixture_5_star_pattern {
         let limits = textbook_limits();
         let segments: Vec<_> = curves
             .iter()
-            .map(|c| SegmentInput { curve: c, limits })
+            .map(|c| SegmentInput {
+                curve: c,
+                limits,
+                followers: &[],
+            })
             .collect();
         let input = BatchInput {
             segments: &segments,
@@ -410,7 +423,11 @@ mod fixture_6_long_realistic_chain {
         let limits = realistic_machine_limits();
         let segments: Vec<_> = curves
             .iter()
-            .map(|c| SegmentInput { curve: c, limits })
+            .map(|c| SegmentInput {
+                curve: c,
+                limits,
+                followers: &[],
+            })
             .collect();
         let input = BatchInput {
             segments: &segments,
@@ -734,14 +751,17 @@ mod fixture_10_near_zero_length_middle_segment_smooth_chain {
             SegmentInput {
                 curve: &seg0,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &seg1,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &seg2,
                 limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {
@@ -798,7 +818,11 @@ mod fixture_10_near_zero_length_middle_segment_smooth_chain {
         let limits = textbook_limits();
         let segments: Vec<_> = curves
             .iter()
-            .map(|c| SegmentInput { curve: c, limits })
+            .map(|c| SegmentInput {
+                curve: c,
+                limits,
+                followers: &[],
+            })
             .collect();
         let baseline = BatchInput {
             segments: &segments,
@@ -851,14 +875,17 @@ mod fixture_11_nanometer_dust_segment_smooth_chain {
             SegmentInput {
                 curve: &seg0,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &dust,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &seg2,
                 limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {
@@ -923,10 +950,12 @@ mod fixture_9_kinematic_boundary_end_no_oscillation {
             SegmentInput {
                 curve: &seg0,
                 limits,
+                followers: &[],
             },
             SegmentInput {
                 curve: &seg1,
                 limits,
+                followers: &[],
             },
         ];
         let input = BatchInput {

--- a/rust/temporal/tests/multi_segment.rs
+++ b/rust/temporal/tests/multi_segment.rs
@@ -61,6 +61,7 @@ mod fixture_1_two_g1_sharp_corner {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 3,
             initial_velocity: 0.0,
@@ -120,6 +121,7 @@ mod fixture_2_g1_to_g5_smooth {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 3,
             initial_velocity: 0.0,
@@ -174,6 +176,7 @@ mod fixture_3_long_straight_then_corner {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 3,
             initial_velocity: 0.0,
@@ -260,6 +263,7 @@ mod fixture_4_per_segment_limits_change {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 3,
             initial_velocity: 0.0,
@@ -336,6 +340,7 @@ mod fixture_5_star_pattern {
             .collect();
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 3,
             initial_velocity: 0.0,
@@ -431,6 +436,7 @@ mod fixture_6_long_realistic_chain {
             .collect();
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 3,
             initial_velocity: 0.0,
@@ -766,6 +772,7 @@ mod fixture_10_near_zero_length_middle_segment_smooth_chain {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: GridStrategy::Adaptive {
                 min_n: 20,
                 max_n: 200,
@@ -826,6 +833,7 @@ mod fixture_10_near_zero_length_middle_segment_smooth_chain {
             .collect();
         let baseline = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: GridStrategy::Adaptive {
                 min_n: 20,
                 max_n: 200,
@@ -890,6 +898,7 @@ mod fixture_11_nanometer_dust_segment_smooth_chain {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: GridStrategy::Adaptive {
                 min_n: 20,
                 max_n: 200,
@@ -960,6 +969,7 @@ mod fixture_9_kinematic_boundary_end_no_oscillation {
         ];
         let input = BatchInput {
             segments: &segments,
+            shaping: None,
             grid_strategy: adaptive(),
             worker_threads: 1,
             initial_velocity: 400.0,

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -315,6 +315,27 @@ fn run_one_iteration(
     planning_a_max: &[[f64; 3]],
     kernels: &AxisKernels,
 ) -> Result<BetaIterResult, ShapeError> {
+    let follower_storage: Vec<Vec<temporal::FollowerDemand>> = input
+        .segments
+        .iter()
+        .map(|seg| {
+            seg.followers
+                .iter()
+                .map(|f| temporal::FollowerDemand {
+                    axis: f.axis_index,
+                    ratio: f.ratio,
+                    pa_k: input.follower_pa[f.axis_index],
+                })
+                .collect()
+        })
+        .collect();
+    let any_followers = follower_storage.iter().any(|f| !f.is_empty());
+    let shaping = temporal::multi::BatchShaping {
+        axis_kernels: [kernels.x.clone(), kernels.y.clone(), kernels.z.clone()],
+        follower_history: input.follower_history.cloned(),
+    };
+    let shaping_active = any_followers
+        && (shaping.axis_kernels.iter().any(Option::is_some) || shaping.follower_history.is_some());
     let run_segments: Vec<temporal::multi::SegmentInput<'_>> = input
         .segments
         .iter()
@@ -329,6 +350,9 @@ fn run_one_iteration(
                 }
             }
             let derated_limits = orig.limits.with_sets_mapped(|set| {
+                if set.axes.is_follower() {
+                    return *set;
+                }
                 let scale = set
                     .axes
                     .indices()
@@ -344,14 +368,14 @@ fn run_one_iteration(
             temporal::multi::SegmentInput {
                 curve: orig.curve,
                 limits: derated_limits,
-                followers: &[],
+                followers: &follower_storage[flat_idx],
             }
         })
         .collect();
 
     let batch_input = temporal::multi::BatchInput {
         segments: &run_segments,
-        shaping: None,
+        shaping: shaping_active.then_some(&shaping),
         grid_strategy: input.grid_strategy,
         worker_threads: input.worker_threads,
         initial_velocity: input.initial_v,

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -344,6 +344,7 @@ fn run_one_iteration(
             temporal::multi::SegmentInput {
                 curve: orig.curve,
                 limits: derated_limits,
+                followers: &[],
             }
         })
         .collect();

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -351,6 +351,7 @@ fn run_one_iteration(
 
     let batch_input = temporal::multi::BatchInput {
         segments: &run_segments,
+        shaping: None,
         grid_strategy: input.grid_strategy,
         worker_threads: input.worker_threads,
         initial_velocity: input.initial_v,

--- a/rust/trajectory/src/beta/tests.rs
+++ b/rust/trajectory/src/beta/tests.rs
@@ -9,11 +9,20 @@ const E_FOLLOWER_04: &[FollowerDemand] = &[FollowerDemand {
 use nurbs::VectorNurbs;
 
 fn default_limits() -> temporal::Limits {
-    temporal::Limits::axis_boxes(
+    let mut sets: Vec<temporal::LimitSet> = temporal::Limits::axis_boxes(
         [500.0, 500.0, 500.0],
         [5_000.0, 5_000.0, 5_000.0],
         [100_000.0, 100_000.0, 100_000.0],
     )
+    .sets()
+    .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: 75.0,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    temporal::Limits::try_new(&sets, 4).unwrap()
 }
 
 fn default_shaper_config() -> ShaperConfig {
@@ -35,11 +44,7 @@ fn straight_linear(start: [f64; 3], end: [f64; 3]) -> VectorNurbs<f64, 3> {
 #[test]
 fn single_straight_line_converges() {
     let curve = straight_linear([0.0, 0.0, 0.0], [50.0, 0.0, 0.0]);
-    let generous_limits = temporal::Limits::axis_boxes(
-        [500.0, 500.0, 500.0],
-        [5_000.0, 5_000.0, 5_000.0],
-        [100_000.0, 100_000.0, 100_000.0],
-    );
+    let generous_limits = default_limits();
     let segments = [ShapeSegmentInput {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
@@ -51,6 +56,8 @@ fn single_straight_line_converges() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: temporal::multi::GridStrategy::Fixed(10),
         worker_threads: 1,

--- a/rust/trajectory/src/beta/tests.rs
+++ b/rust/trajectory/src/beta/tests.rs
@@ -44,6 +44,7 @@ fn single_straight_line_converges() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: generous_limits,
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,

--- a/rust/trajectory/src/emit_shaped/tests.rs
+++ b/rust/trajectory/src/emit_shaped/tests.rs
@@ -91,6 +91,7 @@ fn empty_history_matches_shape_batch_byte_identical() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,

--- a/rust/trajectory/src/emit_shaped/tests.rs
+++ b/rust/trajectory/src/emit_shaped/tests.rs
@@ -18,11 +18,20 @@ fn straight_linear(start: [f64; 3], end: [f64; 3]) -> VectorNurbs<f64, 3> {
 }
 
 fn default_limits() -> temporal::Limits {
-    temporal::Limits::axis_boxes(
+    let mut sets: Vec<temporal::LimitSet> = temporal::Limits::axis_boxes(
         [500.0, 500.0, 500.0],
         [5_000.0, 5_000.0, 5_000.0],
         [100_000.0, 100_000.0, 100_000.0],
     )
+    .sets()
+    .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: 75.0,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    temporal::Limits::try_new(&sets, 4).unwrap()
 }
 
 fn default_shaper_config() -> ShaperConfig {
@@ -98,6 +107,8 @@ fn empty_history_matches_shape_batch_byte_identical() {
     }];
 
     let plan_input = PlanInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &plan_segs,
         grid_strategy: temporal::multi::GridStrategy::Fixed(10),
         worker_threads: 1,
@@ -151,6 +162,8 @@ fn empty_history_matches_shape_batch_byte_identical() {
         feedrate_mm_s: plan_segs[0].feedrate_mm_s,
     }];
     let shape_input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segs,
         grid_strategy: temporal::multi::GridStrategy::Fixed(10),
         worker_threads: 1,

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -84,6 +84,11 @@ pub struct ShapedSegment {
 pub enum ShapeError {
     #[error("temporal batch error: {0}")]
     TemporalBatch(#[from] temporal::multi::BatchError),
+    #[error(
+        "virtual-path (follower-only) segment reached the live streaming \
+         planner; routing lands with follower emission (plan 4)"
+    )]
+    VirtualPathUnrouted,
     #[error("temporal joining: {0:?}{1}")]
     TemporalJoining(temporal::multi::JoiningStatus, String),
     #[error("segment {index} unsolvable: {status:?}")]

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -20,6 +20,10 @@ pub use streaming::ReplanReport;
 #[derive(Debug)]
 pub struct ShapeBatchInput<'a> {
     pub segments: &'a [ShapeSegmentInput<'a>],
+    /// Pressure-advance gain per axis index; zero = no PA.
+    pub follower_pa: [f64; temporal::MAX_AXES],
+    /// Realized pre-batch per-axis velocity for the shaper window's left edge.
+    pub follower_history: Option<&'a temporal::FollowerHistory>,
     pub grid_strategy: temporal::multi::GridStrategy,
     pub worker_threads: usize,
     pub shaper: ShaperConfig,

--- a/rust/trajectory/src/plan_velocity.rs
+++ b/rust/trajectory/src/plan_velocity.rs
@@ -53,6 +53,8 @@ pub struct PlanInput<'a> {
     pub initial_a: f64,
     pub terminal_v: f64,
     pub safety_mode: SafetyMode,
+    pub follower_pa: [f64; temporal::MAX_AXES],
+    pub follower_history: Option<&'a temporal::FollowerHistory>,
     /// Axis-wise second derivatives to pin at the first sample of the first fitted
     /// segment. Forwarded verbatim to [`ShapeBatchInput::start_d2_override`].
     pub start_d2_override: Option<[f64; 3]>,
@@ -93,6 +95,8 @@ pub fn plan_velocity(input: &PlanInput<'_>) -> Result<PlanOutput, ShapeError> {
 
     let shape_input = ShapeBatchInput {
         segments: &segments,
+        follower_pa: input.follower_pa,
+        follower_history: input.follower_history,
         grid_strategy: input.grid_strategy,
         worker_threads: input.worker_threads,
         shaper,

--- a/rust/trajectory/src/plan_velocity/tests.rs
+++ b/rust/trajectory/src/plan_velocity/tests.rs
@@ -12,11 +12,20 @@ fn straight_linear(start: [f64; 3], end: [f64; 3]) -> VectorNurbs<f64, 3> {
 }
 
 fn default_limits() -> temporal::Limits {
-    temporal::Limits::axis_boxes(
+    let mut sets: Vec<temporal::LimitSet> = temporal::Limits::axis_boxes(
         [500.0, 500.0, 500.0],
         [5_000.0, 5_000.0, 5_000.0],
         [100_000.0, 100_000.0, 100_000.0],
     )
+    .sets()
+    .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: 75.0,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    temporal::Limits::try_new(&sets, 4).unwrap()
 }
 
 fn default_kernels() -> [Option<PlanShaper>; 4] {
@@ -34,6 +43,8 @@ fn default_kernels() -> [Option<PlanShaper>; 4] {
 
 fn default_input<'a>(segments: &'a [PlanSegment<'a>], safety: SafetyMode) -> PlanInput<'a> {
     PlanInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments,
         grid_strategy: temporal::multi::GridStrategy::Fixed(10),
         worker_threads: 1,

--- a/rust/trajectory/src/plan_velocity/tests.rs
+++ b/rust/trajectory/src/plan_velocity/tests.rs
@@ -63,6 +63,7 @@ fn rejects_negative_initial_v() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -83,6 +84,7 @@ fn rejects_nan_terminal_v() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -103,6 +105,7 @@ fn nonzero_initial_v_produces_chained_profile() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -136,6 +139,7 @@ fn passthrough_on_x_is_valid() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -156,6 +160,7 @@ fn passthrough_on_y_is_valid() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -176,6 +181,7 @@ fn none_on_x_treated_as_passthrough() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -196,6 +202,7 @@ fn all_passthrough_produces_fitted_output() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -214,6 +221,7 @@ fn returns_one_fitted_per_xy_segment() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -233,6 +241,7 @@ fn worst_case_future_segment_durations_monotone() {
             temporal: temporal::multi::SegmentInput {
                 curve: &curve0,
                 limits: default_limits(),
+                followers: &[],
             },
             followers: E_FOLLOWER_04,
             feedrate_mm_s: 100.0,
@@ -241,6 +250,7 @@ fn worst_case_future_segment_durations_monotone() {
             temporal: temporal::multi::SegmentInput {
                 curve: &curve1,
                 limits: default_limits(),
+                followers: &[],
             },
             followers: E_FOLLOWER_04,
             feedrate_mm_s: 100.0,
@@ -279,6 +289,7 @@ fn worst_case_future_is_no_faster_than_terminal_known() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -307,6 +318,7 @@ fn plan_velocity_rejects_accel_at_rest_start() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -325,6 +337,7 @@ fn plan_velocity_rejects_nonfinite_accel() {
         temporal: temporal::multi::SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,

--- a/rust/trajectory/src/streaming/mod.rs
+++ b/rust/trajectory/src/streaming/mod.rs
@@ -22,7 +22,7 @@ pub struct ReplanReport {
 
 mod decel_finder;
 mod emit;
-mod state;
+pub(crate) mod state;
 
 #[cfg(test)]
 mod tests;

--- a/rust/trajectory/src/streaming/mod.rs
+++ b/rust/trajectory/src/streaming/mod.rs
@@ -61,6 +61,8 @@ pub struct ReplanContext {
     /// Fallback path speed at `t_dispatched` when the cursor is outside the `pieces` domain.
     pub fallback_initial_v: f64,
     pub safety_mode: SafetyMode,
+    /// Pressure-advance gain per axis index; zero = no PA.
+    pub follower_pa: [f64; temporal::MAX_AXES],
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -864,7 +864,7 @@ fn boundary_path_speed_cap(seg: &PlanSegment<'_>) -> f64 {
     seg.temporal.limits.mvc_b(&unit_tan, 1e-12).sqrt()
 }
 
-fn per_segment_limits(
+pub(crate) fn per_segment_limits(
     curve: &nurbs::VectorNurbs<f64, 3>,
     base: &temporal::Limits,
     feedrate_mm_s: f64,
@@ -891,14 +891,15 @@ fn per_segment_limits(
     let chord_len = (span[0] * span[0] + span[1] * span[1] + span[2] * span[2]).sqrt();
 
     let set_is_inactive = |axes: temporal::AxisSet| {
-        axes.indices()
-            .all(|ax| span[ax] <= AXIS_INACTIVE_SPAN_EPS_MM)
+        axes.is_spatial()
+            && axes
+                .indices()
+                .all(|ax| span[ax] <= AXIS_INACTIVE_SPAN_EPS_MM)
     };
     let max_active_j = base
-        .sets()
-        .iter()
-        .filter(|s| !set_is_inactive(s.axes) && s.j_max.is_finite())
-        .map(|s| s.j_max)
+        .spatial_sets()
+        .filter(|(_, s)| !set_is_inactive(s.axes) && s.j_max.is_finite())
+        .map(|(_, s)| s.j_max)
         .fold(0.0_f64, f64::max);
 
     let mut limits = *base;

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -142,6 +142,7 @@ impl ShaperState {
                         &ctx.limits,
                         m.segment.feedrate_mm_s,
                     ),
+                    followers: &[],
                 },
                 followers: &m.segment.followers,
                 feedrate_mm_s: m.segment.feedrate_mm_s,
@@ -549,6 +550,7 @@ fn try_rung2(
             temporal: temporal::multi::SegmentInput {
                 curve: &m.segment.xyz,
                 limits: per_segment_limits(&m.segment.xyz, &ctx.limits, m.segment.feedrate_mm_s),
+                followers: &[],
             },
             followers: &m.segment.followers,
             feedrate_mm_s: m.segment.feedrate_mm_s,
@@ -623,6 +625,7 @@ fn try_rung3(
         temporal: temporal::multi::SegmentInput {
             curve: &seg.segment.xyz,
             limits: per_segment_limits(&seg.segment.xyz, &ctx.limits, seg.segment.feedrate_mm_s),
+            followers: &[],
         },
         followers: &seg.segment.followers,
         feedrate_mm_s: seg.segment.feedrate_mm_s,

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -872,7 +872,7 @@ fn per_segment_limits(
 
     if feedrate_mm_s > 0.0 && chord_len > AXIS_INACTIVE_SPAN_EPS_MM {
         limits = limits.with_extra_sets(&[temporal::LimitSet {
-            axes: temporal::AxisSet::all(),
+            axes: temporal::AxisSet::spatial(),
             v_max: feedrate_mm_s,
             a_max: f64::INFINITY,
             j_max: f64::INFINITY,

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -167,6 +167,7 @@ impl ShaperState {
             (initial_v, initial_a, start_d2_override)
         };
 
+        let follower_history = self.follower_history_at(t_freeze, max_h, &self.uncommitted_moves);
         let plan_input = PlanInput {
             segments: &plan_segments,
             grid_strategy: ctx.grid_strategy,
@@ -179,6 +180,8 @@ impl ShaperState {
             initial_a,
             terminal_v: 0.0,
             safety_mode: ctx.safety_mode,
+            follower_pa: ctx.follower_pa,
+            follower_history: follower_history.as_ref(),
             start_d2_override,
         };
 
@@ -338,6 +341,36 @@ impl ShaperState {
             nurbs::eval::eval(&d2, t)
         });
         Some(accel)
+    }
+
+    /// Realized per-axis velocities over `[t_freeze - max_h, t_freeze]` from
+    /// the retained shaped pieces, for the shaper window's left edge. `None`
+    /// when no kernel is active or no uncommitted segment carries followers;
+    /// all-zero samples before any motion exists (cold start at rest).
+    fn follower_history_at(
+        &self,
+        t_freeze: f64,
+        max_h: f64,
+        uncommitted: &VecDeque<UncommittedMove>,
+    ) -> Option<temporal::FollowerHistory> {
+        const HISTORY_SAMPLES: usize = 32;
+        if max_h <= 0.0 || uncommitted.iter().all(|m| m.segment.followers.is_empty()) {
+            return None;
+        }
+        let dt = max_h / HISTORY_SAMPLES as f64;
+        let mut axis_velocity: [Vec<f64>; 3] = Default::default();
+        for m in 0..HISTORY_SAMPLES {
+            let tau = t_freeze - (m as f64 + 0.5) * dt;
+            for (axis, out) in axis_velocity.iter_mut().enumerate() {
+                let v = if tau >= 0.0 {
+                    self.axis_velocity_at(axis, tau).unwrap_or(0.0)
+                } else {
+                    0.0
+                };
+                out.push(v);
+            }
+        }
+        Some(temporal::FollowerHistory { dt, axis_velocity })
     }
 
     pub(crate) fn read_path_speed_at(&self, t: f64, fallback: f64) -> f64 {
@@ -585,6 +618,8 @@ fn try_rung2(
         initial_a: 0.0,
         terminal_v: 0.0,
         safety_mode: ctx.safety_mode,
+        follower_pa: ctx.follower_pa,
+        follower_history: None,
         start_d2_override: None,
     };
 
@@ -646,6 +681,8 @@ fn try_rung3(
         initial_a: 0.0,
         terminal_v: 0.0,
         safety_mode: ctx.safety_mode,
+        follower_pa: ctx.follower_pa,
+        follower_history: None,
         start_d2_override: None,
     };
 

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -70,6 +70,9 @@ impl ShaperState {
         new_segment: CubicSegment,
         ctx: &ReplanContext,
     ) -> Result<ReplanReport, ShapeError> {
+        if new_segment.virtual_path_mm.is_some() {
+            return Err(ShapeError::VirtualPathUnrouted);
+        }
         let max_h = self.axes.iter().map(|a| a.h).fold(0.0_f64, f64::max);
 
         let t_freeze =

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -124,6 +124,7 @@ fn replan_limits() -> temporal::Limits {
 
 fn replan_context() -> ReplanContext {
     ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits: replan_limits(),
         kernels: replan_kernels_planshaper(),
         fit_tolerance_mm: 0.005,
@@ -1185,6 +1186,7 @@ fn single_axis_harness(v_max: f64, a_max: f64) -> (ShaperState, ReplanContext) {
     let limits =
         temporal::Limits::axis_boxes([v_max, v_max, v_max], [a_max, a_max, a_max], [100_000.0; 3]);
     let ctx = ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits,
         kernels: [
             Some(PlanShaper::SmoothZv {
@@ -1284,6 +1286,7 @@ fn replan_with_positive_boundary_accel_and_short_first_segment_succeeds() {
 
     let limits = temporal::Limits::axis_boxes([300.0; 3], [5_000.0; 3], [10_000.0; 3]);
     let ctx = ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits,
         kernels: [
             Some(PlanShaper::SmoothZv {
@@ -1349,6 +1352,7 @@ fn corner_context_passthrough() -> ReplanContext {
         [10_000.0; 3],
     );
     ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits,
         kernels: [
             Some(PlanShaper::Passthrough),
@@ -1427,6 +1431,7 @@ fn witness_fallback_rung3_fires_when_rung1_and_rung2_both_infeasible() {
         [10_000.0; 3],
     );
     let ctx = ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits: tight_limits,
         kernels: [
             Some(PlanShaper::Passthrough),

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -1596,3 +1596,30 @@ fn emit_covers_window_starting_after_t_dispatched() {
 
     let _ = emit_partial_window(&mut state);
 }
+
+#[test]
+fn per_segment_limits_tolerates_follower_sets() {
+    let mut sets: Vec<temporal::LimitSet> =
+        temporal::Limits::axis_boxes([500.0; 3], [5_000.0; 3], [100_000.0; 3])
+            .sets()
+            .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: 75.0,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    let base = temporal::Limits::try_new(&sets, 4).unwrap();
+    let curve = nurbs::VectorNurbs::try_new(
+        1,
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![[0.0, 0.0, 0.0], [0.0, 0.0, 10.0]],
+    )
+    .unwrap();
+    let limits = super::state::per_segment_limits(&curve, &base, 15.0);
+    let (_, follower_set) = limits.follower_sets().next().unwrap();
+    assert_eq!(
+        follower_set.j_max, 3000.0,
+        "follower jerk cap must not be relaxed by spatial inactivity"
+    );
+}

--- a/rust/trajectory/src/tests.rs
+++ b/rust/trajectory/src/tests.rs
@@ -3,6 +3,8 @@ use super::*;
 #[test]
 fn shape_batch_rejects_empty_segments() {
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &[],
         grid_strategy: temporal::multi::GridStrategy::Fixed(100),
         worker_threads: 1,

--- a/rust/trajectory/tests/end_to_end.rs
+++ b/rust/trajectory/tests/end_to_end.rs
@@ -42,6 +42,7 @@ fn shape_batch_straight_line() {
         temporal: SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,
@@ -96,6 +97,7 @@ fn shape_batch_short_low_velocity_line_refits_at_five_microns() {
         temporal: SegmentInput {
             curve: &curve,
             limits,
+            followers: &[],
         },
         followers: &[],
         feedrate_mm_s: 1000.0 / 60.0,
@@ -149,6 +151,7 @@ fn shape_batch_two_segments() {
             temporal: SegmentInput {
                 curve: &curve1,
                 limits: default_limits(),
+                followers: &[],
             },
             followers: E_FOLLOWER_04,
             feedrate_mm_s: 100.0,
@@ -157,6 +160,7 @@ fn shape_batch_two_segments() {
             temporal: SegmentInput {
                 curve: &curve2,
                 limits: default_limits(),
+                followers: &[],
             },
             followers: E_FOLLOWER_04,
             feedrate_mm_s: 100.0,
@@ -211,6 +215,7 @@ fn shape_batch_beta_warning() {
         temporal: SegmentInput {
             curve: &curve,
             limits: default_limits(),
+            followers: &[],
         },
         followers: E_FOLLOWER_04,
         feedrate_mm_s: 100.0,

--- a/rust/trajectory/tests/end_to_end.rs
+++ b/rust/trajectory/tests/end_to_end.rs
@@ -23,7 +23,17 @@ fn make_straight_line(from: [f64; 3], to: [f64; 3]) -> VectorNurbs<f64, 3> {
 }
 
 fn default_limits() -> temporal::Limits {
-    temporal::Limits::axis_boxes([500.0; 3], [5_000.0; 3], [100_000.0; 3])
+    let mut sets: Vec<temporal::LimitSet> =
+        temporal::Limits::axis_boxes([500.0; 3], [5_000.0; 3], [100_000.0; 3])
+            .sets()
+            .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: 75.0,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    temporal::Limits::try_new(&sets, 4).unwrap()
 }
 
 fn test_shaper_config() -> ShaperConfig {
@@ -49,6 +59,8 @@ fn shape_batch_straight_line() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Fixed(20),
         worker_threads: 1,
@@ -104,6 +116,8 @@ fn shape_batch_short_low_velocity_line_refits_at_five_microns() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Fixed(25),
         worker_threads: 1,
@@ -168,6 +182,8 @@ fn shape_batch_two_segments() {
     ];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Fixed(20),
         worker_threads: 1,
@@ -222,6 +238,8 @@ fn shape_batch_beta_warning() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Fixed(20),
         worker_threads: 1,
@@ -260,6 +278,8 @@ fn shape_batch_beta_warning() {
 #[test]
 fn shape_batch_empty_input() {
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &[],
         grid_strategy: GridStrategy::Fixed(20),
         worker_threads: 1,

--- a/rust/trajectory/tests/follower_rows.rs
+++ b/rust/trajectory/tests/follower_rows.rs
@@ -1,0 +1,145 @@
+use geometry::segment::FollowerDemand;
+use nurbs::algebra::PiecewisePolynomialKernel;
+use nurbs::VectorNurbs;
+use temporal::multi::{GridStrategy, SegmentInput};
+use trajectory::{
+    shape_batch, AxisShaper, ShapeBatchInput, ShapeBatchOutput, ShapeSegmentInput, ShaperConfig,
+};
+
+const E_RATIO: f64 = 0.05;
+const E_V_MAX: f64 = 75.0;
+const E_FOLLOWER: &[FollowerDemand] = &[FollowerDemand {
+    axis_index: 3,
+    ratio: E_RATIO,
+}];
+
+fn limits() -> temporal::Limits {
+    let mut sets: Vec<temporal::LimitSet> =
+        temporal::Limits::axis_boxes([500.0; 3], [20_000.0; 3], [400_000.0; 3])
+            .sets()
+            .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: E_V_MAX,
+        a_max: 1500.0,
+        j_max: 3000.0,
+    });
+    temporal::Limits::try_new(&sets, 4).unwrap()
+}
+
+fn line(start: [f64; 3], end: [f64; 3]) -> VectorNurbs<f64, 3> {
+    VectorNurbs::try_new(1, vec![0.0, 0.0, 1.0, 1.0], vec![start, end]).unwrap()
+}
+
+fn solve(pa_k: f64) -> ShapeBatchOutput {
+    let a = line([0.0; 3], [60.0, 0.0, 0.0]);
+    let b = line([60.0, 0.0, 0.0], [60.0, 60.0, 0.0]);
+    let c = line([60.0, 60.0, 0.0], [0.0, 60.0, 0.0]);
+    let limits = limits();
+    let seg = |curve| ShapeSegmentInput {
+        temporal: SegmentInput {
+            curve,
+            limits,
+            followers: &[],
+        },
+        followers: E_FOLLOWER,
+        feedrate_mm_s: 200.0,
+    };
+    let segments = [seg(&a), seg(&b), seg(&c)];
+    let mut follower_pa = [0.0; temporal::MAX_AXES];
+    follower_pa[3] = pa_k;
+    let input = ShapeBatchInput {
+        segments: &segments,
+        follower_pa,
+        follower_history: None,
+        grid_strategy: GridStrategy::Fixed(201),
+        worker_threads: 1,
+        shaper: ShaperConfig {
+            x: AxisShaper::SmoothZv { frequency_hz: 40.0 },
+            y: AxisShaper::SmoothZv { frequency_hz: 40.0 },
+            z: AxisShaper::Passthrough,
+        },
+        fit_tolerance_mm: 0.5,
+        beta_max_iters: 3,
+        beta_convergence_ratio: 1.02,
+        initial_v: 0.0,
+        initial_a: 0.0,
+        terminal_v: 0.0,
+        start_d2_override: None,
+    };
+    shape_batch(&input).expect("follower batch should solve")
+}
+
+fn bell_kernel(frequency_hz: f64) -> PiecewisePolynomialKernel<f64> {
+    let t_sm = 0.8025 / frequency_hz;
+    let h = t_sm / 2.0;
+    let c = 15.0 / (16.0 * h.powi(5));
+    PiecewisePolynomialKernel::single_poly_from_absolute(
+        vec![c * h.powi(4), 0.0, -2.0 * c * h * h, 0.0, c],
+        (-h, h),
+    )
+}
+
+fn eval_kernel(kernel: &PiecewisePolynomialKernel<f64>, z: f64) -> f64 {
+    let (lo, hi) = kernel.support();
+    if z < lo || z > hi {
+        return 0.0;
+    }
+    kernel
+        .pieces
+        .iter()
+        .find(|p| z >= p.u_start - 1e-15 && z <= p.u_end + 1e-15)
+        .map_or(0.0, |p| p.evaluate(z))
+}
+
+fn total_duration(out: &ShapeBatchOutput) -> f64 {
+    out.segments.last().map_or(0.0, |s| s.t_end)
+}
+
+fn axis_velocity_at(out: &ShapeBatchOutput, axis: usize, tau: f64) -> f64 {
+    for seg in &out.segments {
+        if tau >= seg.t_start - 1e-12 && tau <= seg.t_end + 1e-12 {
+            let curve = nurbs::eval::derivative(&seg.axes[axis]);
+            let knots = curve.knots();
+            let u = tau.clamp(knots[0], knots[knots.len() - 1]);
+            return nurbs::eval::eval(&curve, u);
+        }
+    }
+    0.0
+}
+
+#[test]
+fn follower_batch_shaped_demand_holds_and_pa_only_tightens() {
+    let with_pa = solve(0.04);
+    let without_pa = solve(0.0);
+    let t_pa = total_duration(&with_pa);
+    let t_plain = total_duration(&without_pa);
+    assert!(
+        t_plain <= t_pa + 1e-9,
+        "PA rows only ever tighten: plain {t_plain} vs pa {t_pa}"
+    );
+
+    let kernel = bell_kernel(40.0);
+    let (k_lo, k_hi) = kernel.support();
+    let dt = 1e-3;
+    let total = t_plain;
+    let mut tau = 0.0;
+    while tau <= total {
+        let mut shaped = [0.0_f64; 2];
+        let mut z = k_lo;
+        while z <= k_hi {
+            let w = eval_kernel(&kernel, z) * dt;
+            for (axis, sh) in shaped.iter_mut().enumerate() {
+                let src = (tau - z).clamp(0.0, total);
+                *sh += w * axis_velocity_at(&without_pa, axis, src);
+            }
+            z += dt;
+        }
+        let demand = E_RATIO * (shaped[0] * shaped[0] + shaped[1] * shaped[1]).sqrt();
+        assert!(
+            demand <= E_V_MAX * (1.0 + 5e-2),
+            "t={tau:.4}: shaped follower demand {demand} > {E_V_MAX}"
+        );
+        tau += 5e-3;
+    }
+}

--- a/rust/trajectory/tests/jog_50mm_live_limits.rs
+++ b/rust/trajectory/tests/jog_50mm_live_limits.rs
@@ -32,6 +32,7 @@ fn jog_50mm_at_100mms_with_live_limits() {
         temporal: SegmentInput {
             curve: &curve,
             limits: live_limits(),
+            followers: &[],
         },
         followers: &[],
         feedrate_mm_s: 100.0,
@@ -94,6 +95,7 @@ fn jog_50mm_with_higher_scv() {
         temporal: SegmentInput {
             curve: &curve,
             limits,
+            followers: &[],
         },
         followers: &[],
         feedrate_mm_s: 100.0,
@@ -152,6 +154,7 @@ fn probe_with_feedrate(feedrate: f64, dist_mm: f64) -> f64 {
         temporal: SegmentInput {
             curve: &curve,
             limits,
+            followers: &[],
         },
         followers: &[],
         feedrate_mm_s: feedrate,
@@ -212,6 +215,7 @@ fn jog_50mm_with_z_jmax_uncapped() {
         temporal: SegmentInput {
             curve: &curve,
             limits,
+            followers: &[],
         },
         followers: &[],
         feedrate_mm_s: 100.0,
@@ -279,6 +283,7 @@ fn jog_50mm_low_accel_baseline() {
         temporal: SegmentInput {
             curve: &curve,
             limits,
+            followers: &[],
         },
         followers: &[],
         feedrate_mm_s: 100.0,

--- a/rust/trajectory/tests/jog_50mm_live_limits.rs
+++ b/rust/trajectory/tests/jog_50mm_live_limits.rs
@@ -39,6 +39,8 @@ fn jog_50mm_at_100mms_with_live_limits() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,
@@ -102,6 +104,8 @@ fn jog_50mm_with_higher_scv() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,
@@ -160,6 +164,8 @@ fn probe_with_feedrate(feedrate: f64, dist_mm: f64) -> f64 {
         feedrate_mm_s: feedrate,
     }];
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,
@@ -222,6 +228,8 @@ fn jog_50mm_with_z_jmax_uncapped() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,
@@ -290,6 +298,8 @@ fn jog_50mm_low_accel_baseline() {
     }];
 
     let input = ShapeBatchInput {
+        follower_pa: [0.0; temporal::MAX_AXES],
+        follower_history: None,
         segments: &segments,
         grid_strategy: GridStrategy::Adaptive {
             min_n: 20,

--- a/rust/trajectory/tests/live_jog_velocity_probe.rs
+++ b/rust/trajectory/tests/live_jog_velocity_probe.rs
@@ -20,6 +20,7 @@ fn live_shapers() -> [Option<AxisShaper>; 4] {
 
 fn live_ctx() -> ReplanContext {
     ReplanContext {
+        follower_pa: [0.0; temporal::MAX_AXES],
         limits: temporal::Limits::axis_boxes(
             [1000.0, 1000.0, 5.0],
             [70000.0, 70000.0, 100.0],


### PR DESCRIPTION
## Summary
- `temporal` gains follower axes (indices 3..8) in the limit axis space: spatial-xor-follower `LimitSet`s, coverage validation over the declared axis count, mixed sets rejected loudly.
- Base follower velocity/accel rows join the SOCP (convex, identity window); follower jerk caps fold into a new per-point path-jerk envelope (`j_path_at`); pressure-advance mixed-derivative rows (`|r(ṡ+k·s̈)| ≤ v` etc.) enter as SLP cut families with Fornberg-backed path snap (`s⁗`) for the PA-jerk row.
- Shaper folding: follower rows written on the shaped combination of plan variables via a frozen-time-map window operator with history constants; outer refreeze loop uses a Krasnoselskii–Mann damped freeze update (per the adversarial verification in `docs/research/topp-frozen-timemap-shaping-fixedpoint.md`), capped at 8 refreezes with a loud `FollowerSlpDiverged` error; a polish phase re-maximizes throughput after the violation-descent SLP converges. Cross-chain tail exchange supplies neighbor boundary-window velocities across stops; streaming supplies the committed-tail history.
- Follower-only moves plan on a virtual path (spec §2 fallback line): zero spatial geometry, arclength = largest follower displacement, feedrate + follower rows cap it. `Fatal::FollowerOnlyMoveUnsupported` is gone.
- Bridge/trajectory plumbing: follower `[limit]` sections convert to real temporal sets (`n_axes` from the axis registry); segments' demands (with `pa_k`) reach `SegmentInput`; kernels + streaming history reach the chain.
- Fix found on the Neptune bench: `per_segment_limits` indexed the 3-element spatial span with follower-set axes and aborted klippy on G28; inactive-set jerk relaxation is now spatial-only with a regression test.

## Test plan
- [x] `./scripts/ci.sh quick` green (ruff, full Rust workspace via nextest, clippy `-D warnings`, fmt, watchdog canary)
- [x] Brute-force convolution checks pin the shaper-folded rows (temporal unit + `trajectory/tests/follower_rows.rs` integration: 3-segment batch, shaped follower demand ≤ cap pointwise, PA only tightens)
- [x] Neptune bench: boots ready with `[axis e]` + `[limit extruder]`, homing and fast straight-line jogging behave identically to plan 2