### PR TITLE
Fail loudly when MCU runtime caps are missing instead of guessing 62 KB

### DIFF
--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -2432,16 +2432,19 @@ impl PyMotionBridge {
             let mcus_lock = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
             mcus.iter()
                 .map(|(handle, _, _)| {
-                    let caps = mcus_lock
-                        .get(handle)
-                        .and_then(|c| c.runtime_caps)
-                        .map(McuCaps::from)
-                        .unwrap_or_default();
-                    (*handle, caps)
+                    let conn = mcus_lock.get(handle).ok_or_else(|| {
+                        PyRuntimeError::new_err(format!(
+                            "init_planner: unknown mcu_handle {handle}"
+                        ))
+                    })?;
+                    let caps = resolve_motion_caps(conn.runtime_caps, &conn.label, *handle)
+                        .map_err(PyRuntimeError::new_err)?;
+                    Ok((*handle, caps))
                 })
-                .collect()
+                .collect::<PyResult<_>>()?
         };
-        let mcu_configs = build_mcu_configs(&mcus, &caps_by_handle);
+        let mcu_configs =
+            build_mcu_configs(&mcus, &caps_by_handle).map_err(PyRuntimeError::new_err)?;
         *self
             .mcu_axis_configs
             .lock()

--- a/rust/motion-bridge/src/dispatch.rs
+++ b/rust/motion-bridge/src/dispatch.rs
@@ -41,25 +41,24 @@ impl McuCaps {
     }
 }
 
-impl Default for McuCaps {
-    fn default() -> Self {
-        // Fallback for firmware predating QueryRuntimeCaps: 62 KB = Octopus Pro H7 SRAM budget.
-        Self {
-            total_piece_memory: 62 * 1024,
-        }
-    }
-}
-
 pub fn build_mcu_configs<S: ::std::hash::BuildHasher>(
     mcus: &[(u32, Vec<u8>, u8)],
     caps_by_handle: &HashMap<u32, McuCaps, S>,
-) -> Vec<McuAxisConfig> {
+) -> Result<Vec<McuAxisConfig>, String> {
     mcus.iter()
-        .map(|(handle, axes, tag)| McuAxisConfig {
-            mcu_id: *handle,
-            axes: axes.iter().map(|&a| a as usize).collect(),
-            kinematics: *tag,
-            caps: caps_by_handle.get(handle).copied().unwrap_or_default(),
+        .map(|(handle, axes, tag)| {
+            let caps = caps_by_handle.get(handle).copied().ok_or_else(|| {
+                format!(
+                    "no runtime caps recorded for mcu_handle {handle} — \
+                     refusing to size piece rings by guess"
+                )
+            })?;
+            Ok(McuAxisConfig {
+                mcu_id: *handle,
+                axes: axes.iter().map(|&a| a as usize).collect(),
+                kinematics: *tag,
+                caps,
+            })
         })
         .collect()
 }
@@ -156,7 +155,7 @@ mod topology_tests {
             (7u32, vec![AXIS_X as u8, AXIS_Y as u8, AXIS_E as u8], 0u8),
             (9u32, vec![AXIS_Z as u8], 1u8),
         ];
-        let cfgs = build_mcu_configs(&mcus, &caps);
+        let cfgs = build_mcu_configs(&mcus, &caps).unwrap();
         assert_eq!(cfgs.len(), 2);
         assert_eq!(cfgs[0].mcu_id, 7);
         assert_eq!(cfgs[0].axes, vec![AXIS_X, AXIS_Y, AXIS_E]);
@@ -173,12 +172,11 @@ mod topology_tests {
     }
 
     #[test]
-    fn build_mcu_configs_missing_caps_falls_back_to_default() {
+    fn build_mcu_configs_missing_caps_is_an_error() {
         let caps: HashMap<u32, McuCaps> = HashMap::new();
         let mcus = vec![(7u32, vec![AXIS_X as u8, AXIS_Y as u8], 0u8)];
-        let cfgs = build_mcu_configs(&mcus, &caps);
-        assert_eq!(cfgs.len(), 1);
-        assert_eq!(cfgs[0].caps, McuCaps::default());
+        let err = build_mcu_configs(&mcus, &caps).unwrap_err();
+        assert!(err.contains("mcu_handle 7"), "got: {err}");
     }
 }
 


### PR DESCRIPTION
## Summary
- `init_planner` now resolves piece-ring sizing through `resolve_motion_caps` (which existed and was unit-tested but never called) — an axis-driving MCU with no recorded `RuntimeCapsResponse` is a hard error naming the MCU label and handle, instead of a silent 62 KB guess that the MCU later rejects with a confusing `configure_axis` error.
- `build_mcu_configs` returns `Result` and errors on any handle missing from the caps map.
- `impl Default for McuCaps` (the 62 KB fallback) is deleted so the guess cannot be reintroduced.

## Test Plan
- [x] `cargo nextest run -p motion-bridge` — 275 passed
- [x] `cargo clippy -p motion-bridge --all-targets` clean, `cargo fmt --all --check` clean
- [x] New unit test `build_mcu_configs_missing_caps_is_an_error` replaces the old falls-back-to-default test