### PR TITLE
Observability: binding-constraint reporting via structured logs (plan 6)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-observability-binding-reporting.md
+++ b/docs/superpowers/plans/2026-06-13-observability-binding-reporting.md
@@ -739,8 +739,8 @@ git commit -m "feat(motion-bridge): accumulate and emit binding-constraint rollu
 - [ ] **Step 3: Gate** — `./scripts/ci.sh quick` fully green (ruff, rust workspace tests, clippy `-D warnings`, `cargo fmt --check`, watchdog canary). Re-run `cargo fmt --all --check` last, after any late edit.
 
 - [ ] **Step 4: kalico-sim sanity (manual verification).** Use the `kalico-sim` skill to run a migrated fixture (an extruding print with `[axis e]` + a tight `[limit extruder]`) through the host pipeline, then use the `query-logs` skill to confirm the events land and aggregate:
-  - `event:motion.binding_rollup` lines appear during the print, each with `limit`, `derivative`, `via_pa`, `ratio`, `t`, `window_samples`.
-  - `event:motion.binding_hist | stats by limit, derivative sum(count)` returns a non-empty per-limit breakdown.
+  - `subsystem:=motion event:=binding_rollup` lines appear during the print, each with `limit`, `derivative`, `via_pa`, `ratio`, `t`, `window_samples`. (The event field is the bare name `binding_rollup`; `motion` is the separate `subsystem` field, not a name prefix — matches the `replan_stats` precedent.)
+  - `event:=binding_hist | stats by (limit, derivative) sum(count) as total` returns a non-empty per-limit breakdown.
   - A travel-only (non-extruding) fixture still emits spatial rollups (`limit` = the gantry/z section names) and no follower entries.
   Record the LogsQL queries used in the commit message so the observability surface is reproducible.
 
@@ -757,7 +757,7 @@ git commit --allow-empty -m "test: binding-constraint observability verified end
 - §5 "the planner knows which constraint row binds at every point and reports it through the structured log pipeline" → Task 1 computes the per-profile summary from `binding_per_grid`; Tasks 2–4 carry and emit it. ✓
 - §5 example "slowed here by `[limit extruder]` accel via the PA post-processor" → `label_binding` produces `limit=extruder, derivative=accel, via_pa=true` (Task 3); `binding_rollup` carries the motion-timeline `t` for "here". ✓
 - §6 "Binding-constraint reporting via structured logs. Small, rides on 3." → no solver changes; reuses Plan 3's `BindingConstraint`; four small tasks. ✓
-- Plan 3 decision-3 use case "show whether the PA-jerk row ever binds at corners on real prints" → `binding_hist` with `BindingConstraint::PaJerk` tallies; `query-logs … | stats by derivative,via_pa sum(count)` answers it. ✓
+- Plan 3 decision-3 use case "show whether the PA-jerk row ever binds at corners on real prints" → `binding_hist` with `BindingConstraint::PaJerk` tallies; `query-logs … event:=binding_hist | stats by (derivative, via_pa) sum(count) as total` answers it. ✓
 - Planner stays a pure function / oracle API → Task 5 Step 1 guards it; `temporal`/`trajectory` gain no logging deps. ✓
 - Fail loudly, with the one scoped exception → name resolution degrades to `"runtime_caps"`/section-order rather than crashing the planner thread over a log lookup (decision 5, documented). ✓
 - No placeholders: every code step shows complete code; test bodies that depend on existing harness helpers point at the exact sibling test and the grep to find it. ✓

--- a/rust/motion-bridge/src/binding_report.rs
+++ b/rust/motion-bridge/src/binding_report.rs
@@ -15,7 +15,11 @@ pub fn label_binding(c: BindingConstraint, names: &[String]) -> Option<BindingLa
         BindingConstraint::PaVelocity { set } => (set, "velocity", true),
         BindingConstraint::PaAccel { set } => (set, "accel", true),
         BindingConstraint::PaJerk { set } => (set, "jerk", true),
-        _ => return None,
+        BindingConstraint::None | BindingConstraint::Boundary => return None,
+        _ => {
+            debug_assert!(false, "unhandled BindingConstraint in label_binding");
+            return None;
+        }
     };
     let limit = names
         .get(set)

--- a/rust/motion-bridge/src/binding_report.rs
+++ b/rust/motion-bridge/src/binding_report.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 use temporal::BindingConstraint;
+use trajectory::ReplanBindingSummary;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BindingLabel {
@@ -30,6 +33,100 @@ pub fn label_binding(c: BindingConstraint, names: &[String]) -> Option<BindingLa
         derivative,
         via_pa,
     })
+}
+
+pub const ROLLUP_INTERVAL: Duration = Duration::from_secs(1);
+
+pub struct BindingAccumulator {
+    window: HashMap<BindingConstraint, u64>,
+    window_samples: u64,
+    worst: Option<(BindingConstraint, f64, f64)>,
+    last_rollup: Instant,
+}
+
+impl BindingAccumulator {
+    pub fn new(now: Instant) -> Self {
+        Self {
+            window: HashMap::new(),
+            window_samples: 0,
+            worst: None,
+            last_rollup: now,
+        }
+    }
+
+    pub fn record(&mut self, summary: &ReplanBindingSummary, t: f64) {
+        for (c, n) in &summary.histogram {
+            *self.window.entry(*c).or_insert(0) += u64::from(*n);
+            self.window_samples += u64::from(*n);
+        }
+        if let Some(w) = &summary.worst {
+            if self.worst.is_none_or(|(_, r, _)| w.ratio > r) {
+                self.worst = Some((w.constraint, w.ratio, t));
+            }
+        }
+    }
+
+    pub fn maybe_rollup(&mut self, now: Instant, names: &[String]) {
+        if now.duration_since(self.last_rollup) >= ROLLUP_INTERVAL && !self.window.is_empty() {
+            self.emit(names);
+            self.reset(now);
+        }
+    }
+
+    pub fn flush(&mut self, now: Instant, names: &[String]) {
+        if !self.window.is_empty() {
+            self.emit(names);
+            self.reset(now);
+        }
+    }
+
+    fn reset(&mut self, now: Instant) {
+        self.window.clear();
+        self.window_samples = 0;
+        self.worst = None;
+        self.last_rollup = now;
+    }
+
+    fn emit(&self, names: &[String]) {
+        if let Some((c, ratio, t)) = self.worst {
+            if let Some(l) = label_binding(c, names) {
+                tracing::info!(
+                    subsystem = "motion",
+                    event = "binding_rollup",
+                    limit = %l.limit,
+                    derivative = l.derivative,
+                    via_pa = l.via_pa,
+                    ratio,
+                    t,
+                    window_samples = self.window_samples,
+                    "binding rollup"
+                );
+            }
+        }
+        for (c, count) in &self.window {
+            if let Some(l) = label_binding(*c, names) {
+                tracing::info!(
+                    subsystem = "motion",
+                    event = "binding_hist",
+                    limit = %l.limit,
+                    derivative = l.derivative,
+                    via_pa = l.via_pa,
+                    count = *count,
+                    "binding histogram"
+                );
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn window_count(&self, c: BindingConstraint) -> u64 {
+        self.window.get(&c).copied().unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub fn worst(&self) -> Option<(BindingConstraint, f64, f64)> {
+        self.worst
+    }
 }
 
 #[cfg(test)]

--- a/rust/motion-bridge/src/binding_report.rs
+++ b/rust/motion-bridge/src/binding_report.rs
@@ -1,0 +1,32 @@
+use temporal::BindingConstraint;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindingLabel {
+    pub limit: String,
+    pub derivative: &'static str,
+    pub via_pa: bool,
+}
+
+pub fn label_binding(c: BindingConstraint, names: &[String]) -> Option<BindingLabel> {
+    let (set, derivative, via_pa) = match c {
+        BindingConstraint::Velocity { set } => (set, "velocity", false),
+        BindingConstraint::AccelNorm { set } => (set, "accel", false),
+        BindingConstraint::JerkNorm { set } => (set, "jerk", false),
+        BindingConstraint::PaVelocity { set } => (set, "velocity", true),
+        BindingConstraint::PaAccel { set } => (set, "accel", true),
+        BindingConstraint::PaJerk { set } => (set, "jerk", true),
+        _ => return None,
+    };
+    let limit = names
+        .get(set)
+        .cloned()
+        .unwrap_or_else(|| "runtime_caps".to_string());
+    Some(BindingLabel {
+        limit,
+        derivative,
+        via_pa,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/motion-bridge/src/binding_report/tests.rs
+++ b/rust/motion-bridge/src/binding_report/tests.rs
@@ -1,0 +1,34 @@
+use super::*;
+use temporal::BindingConstraint;
+
+#[test]
+fn labels_pa_accel_with_resolved_name() {
+    let names = vec!["gantry".to_string(), "extruder".to_string()];
+    let label = label_binding(BindingConstraint::PaAccel { set: 1 }, &names).unwrap();
+    assert_eq!(label.limit, "extruder");
+    assert_eq!(label.derivative, "accel");
+    assert!(label.via_pa);
+}
+
+#[test]
+fn labels_spatial_velocity_without_pa() {
+    let names = vec!["gantry".to_string()];
+    let label = label_binding(BindingConstraint::Velocity { set: 0 }, &names).unwrap();
+    assert_eq!(label.limit, "gantry");
+    assert_eq!(label.derivative, "velocity");
+    assert!(!label.via_pa);
+}
+
+#[test]
+fn trailing_set_index_resolves_to_runtime_caps() {
+    let names = vec!["gantry".to_string()];
+    let label = label_binding(BindingConstraint::AccelNorm { set: 1 }, &names).unwrap();
+    assert_eq!(label.limit, "runtime_caps");
+}
+
+#[test]
+fn none_and_boundary_have_no_label() {
+    let names = vec!["gantry".to_string()];
+    assert!(label_binding(BindingConstraint::None, &names).is_none());
+    assert!(label_binding(BindingConstraint::Boundary, &names).is_none());
+}

--- a/rust/motion-bridge/src/binding_report/tests.rs
+++ b/rust/motion-bridge/src/binding_report/tests.rs
@@ -2,32 +2,43 @@ use super::*;
 use temporal::BindingConstraint;
 
 #[test]
-fn labels_pa_accel_with_resolved_name() {
+fn all_labeled_variants_map_to_correct_derivative_and_pa_flag() {
     let names = vec!["gantry".to_string(), "extruder".to_string()];
-    let label = label_binding(BindingConstraint::PaAccel { set: 1 }, &names).unwrap();
-    assert_eq!(label.limit, "extruder");
-    assert_eq!(label.derivative, "accel");
-    assert!(label.via_pa);
+    let cases: &[(BindingConstraint, &str, bool)] = &[
+        (BindingConstraint::Velocity { set: 0 }, "velocity", false),
+        (BindingConstraint::AccelNorm { set: 0 }, "accel", false),
+        (BindingConstraint::JerkNorm { set: 0 }, "jerk", false),
+        (BindingConstraint::PaVelocity { set: 0 }, "velocity", true),
+        (BindingConstraint::PaAccel { set: 0 }, "accel", true),
+        (BindingConstraint::PaJerk { set: 0 }, "jerk", true),
+    ];
+    for &(constraint, expected_derivative, expected_via_pa) in cases {
+        let label = label_binding(constraint, &names).unwrap_or_else(|| {
+            panic!("{constraint:?} must produce a label");
+        });
+        assert_eq!(
+            label.derivative, expected_derivative,
+            "{constraint:?}: wrong derivative"
+        );
+        assert_eq!(
+            label.via_pa, expected_via_pa,
+            "{constraint:?}: wrong via_pa"
+        );
+    }
 }
 
 #[test]
-fn labels_spatial_velocity_without_pa() {
+fn labeled_set_index_resolves_to_name_or_runtime_caps_fallback() {
     let names = vec!["gantry".to_string()];
-    let label = label_binding(BindingConstraint::Velocity { set: 0 }, &names).unwrap();
-    assert_eq!(label.limit, "gantry");
-    assert_eq!(label.derivative, "velocity");
-    assert!(!label.via_pa);
+    let resolved = label_binding(BindingConstraint::Velocity { set: 0 }, &names).unwrap();
+    assert_eq!(resolved.limit, "gantry");
+
+    let fallback = label_binding(BindingConstraint::AccelNorm { set: 1 }, &names).unwrap();
+    assert_eq!(fallback.limit, "runtime_caps");
 }
 
 #[test]
-fn trailing_set_index_resolves_to_runtime_caps() {
-    let names = vec!["gantry".to_string()];
-    let label = label_binding(BindingConstraint::AccelNorm { set: 1 }, &names).unwrap();
-    assert_eq!(label.limit, "runtime_caps");
-}
-
-#[test]
-fn none_and_boundary_have_no_label() {
+fn none_and_boundary_produce_no_label() {
     let names = vec!["gantry".to_string()];
     assert!(label_binding(BindingConstraint::None, &names).is_none());
     assert!(label_binding(BindingConstraint::Boundary, &names).is_none());

--- a/rust/motion-bridge/src/binding_report/tests.rs
+++ b/rust/motion-bridge/src/binding_report/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use temporal::BindingConstraint;
+use trajectory::{ReplanBindingSummary, ReplanWorstBinding};
 
 #[test]
 fn all_labeled_variants_map_to_correct_derivative_and_pa_flag() {
@@ -42,4 +43,52 @@ fn none_and_boundary_produce_no_label() {
     let names = vec!["gantry".to_string()];
     assert!(label_binding(BindingConstraint::None, &names).is_none());
     assert!(label_binding(BindingConstraint::Boundary, &names).is_none());
+}
+
+fn summary(set: usize, count: u32, ratio: f64) -> ReplanBindingSummary {
+    ReplanBindingSummary {
+        histogram: vec![(BindingConstraint::Velocity { set }, count)],
+        worst: Some(ReplanWorstBinding {
+            constraint: BindingConstraint::Velocity { set },
+            ratio,
+        }),
+    }
+}
+
+#[test]
+fn record_tallies_window_and_keeps_max_ratio_worst() {
+    let t0 = std::time::Instant::now();
+    let mut acc = BindingAccumulator::new(t0);
+    acc.record(&summary(0, 3, 0.8), 1.0);
+    acc.record(&summary(0, 2, 0.95), 2.0);
+    assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 5);
+    let (constraint, ratio, t) = acc.worst().unwrap();
+    assert_eq!(constraint, BindingConstraint::Velocity { set: 0 });
+    assert!((ratio - 0.95).abs() < 1e-12);
+    assert!((t - 2.0).abs() < 1e-12);
+}
+
+#[test]
+fn maybe_rollup_resets_only_after_the_interval() {
+    let t0 = std::time::Instant::now();
+    let names = vec!["gantry".to_string()];
+    let mut acc = BindingAccumulator::new(t0);
+    acc.record(&summary(0, 1, 0.9), 1.0);
+
+    acc.maybe_rollup(t0 + std::time::Duration::from_millis(500), &names);
+    assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 1);
+
+    acc.maybe_rollup(t0 + std::time::Duration::from_millis(1100), &names);
+    assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 0);
+    assert!(acc.worst().is_none());
+}
+
+#[test]
+fn flush_emits_and_clears_a_partial_window() {
+    let t0 = std::time::Instant::now();
+    let names = vec!["gantry".to_string()];
+    let mut acc = BindingAccumulator::new(t0);
+    acc.record(&summary(0, 1, 0.9), 1.0);
+    acc.flush(t0 + std::time::Duration::from_millis(100), &names);
+    assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 0);
 }

--- a/rust/motion-bridge/src/binding_report/tests.rs
+++ b/rust/motion-bridge/src/binding_report/tests.rs
@@ -92,3 +92,13 @@ fn flush_emits_and_clears_a_partial_window() {
     acc.flush(t0 + std::time::Duration::from_millis(100), &names);
     assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 0);
 }
+
+#[test]
+fn maybe_rollup_on_empty_window_past_interval_is_a_noop() {
+    let t0 = std::time::Instant::now();
+    let names = vec!["gantry".to_string()];
+    let mut acc = BindingAccumulator::new(t0);
+    acc.maybe_rollup(t0 + std::time::Duration::from_millis(1100), &names);
+    assert!(acc.worst().is_none());
+    assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 0);
+}

--- a/rust/motion-bridge/src/config.rs
+++ b/rust/motion-bridge/src/config.rs
@@ -444,6 +444,10 @@ impl LimitSection {
 }
 
 impl PlannerConfig {
+    pub fn limit_set_names(&self) -> Vec<String> {
+        self.limit_sections.iter().map(|s| s.name.clone()).collect()
+    }
+
     pub fn to_temporal_limits(&self) -> Result<temporal::Limits, LimitConfigError> {
         let mut sets = Vec::with_capacity(self.limit_sections.len() + 1);
         let n_axes = self.axis_registry.n_axes();

--- a/rust/motion-bridge/src/config/tests.rs
+++ b/rust/motion-bridge/src/config/tests.rs
@@ -424,3 +424,45 @@ fn post_processor_missing_required_param_rejected() {
     let err = PostProcessorSet::try_new(&registry, &[pp("is", "smooth_zv", &[])]).unwrap_err();
     assert!(err.to_string().contains("frequency_hz"), "got: {err}");
 }
+
+#[test]
+fn limit_set_names_follow_section_order() {
+    let reg = AxisRegistry::try_new(vec![
+        decl("x", &[]),
+        decl("y", &[]),
+        decl("z", &[]),
+        decl("e", &["x", "y", "z"]),
+    ])
+    .unwrap();
+    let post_processors = PostProcessorSet::try_new(&reg, &[]).unwrap();
+    let cfg = PlannerConfig {
+        axis_registry: reg,
+        limit_sections: vec![
+            LimitSection {
+                name: "gantry".into(),
+                axes: vec![0, 1],
+                max_velocity: Some(300.0),
+                max_accel: Some(3000.0),
+                max_jerk: None,
+            },
+            LimitSection {
+                name: "extruder".into(),
+                axes: vec![3],
+                max_velocity: Some(75.0),
+                max_accel: Some(1500.0),
+                max_jerk: None,
+            },
+        ],
+        runtime_caps: RuntimeCaps::default(),
+        post_processors,
+        window_capacity: 32,
+        beta_max_iters: 10,
+        beta_convergence_ratio: 0.05,
+        fit_tolerance_mm: 0.005,
+        worker_threads: 3,
+    };
+    assert_eq!(
+        cfg.limit_set_names(),
+        vec!["gantry".to_string(), "extruder".to_string()]
+    );
+}

--- a/rust/motion-bridge/src/lib.rs
+++ b/rust/motion-bridge/src/lib.rs
@@ -1,5 +1,7 @@
 #[doc(hidden)]
 pub mod anchor;
+#[doc(hidden)]
+pub mod binding_report;
 mod bridge;
 #[doc(hidden)]
 pub mod classify;

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -586,6 +586,7 @@ fn run_loop(
                     window_segments,
                     plan,
                     fallback_rung,
+                    binding: _,
                 } = report;
                 let beta_iters = plan.beta_iterations;
                 let beta_converged = plan.beta_converged;

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -522,6 +522,9 @@ fn run_loop(
 
         match msg {
             PlannerMsg::Move(m) => {
+                // `submit_move` already advanced `last_move_time_bits` by the nominal.
+                // Rectify if actual diverges: use CAS since submit_move is a concurrent writer.
+                // Rectify against t_appended delta (not dispatched): the decel tail is held back.
                 let nominal = m.nominal_duration();
                 let prior_t_appended = state.t_appended;
                 let prior_t_decel = state.t_decel_start;
@@ -540,6 +543,11 @@ fn run_loop(
                             &commit_fire_count,
                         );
                     }
+                    // Resume with the same dispatch cushion a fresh stream
+                    // gets: anchoring at bare `esc` leaves the upcoming
+                    // append_and_replan solve (observed 100-200 ms) to consume
+                    // the entire lead before seg0 is even emitted, landing
+                    // pieces in the MCU past.
                     state.advance_idle(esc + LEAD);
                 }
 
@@ -650,6 +658,8 @@ fn run_loop(
                     }
                 }
 
+                // Capture sync_instant only on non-empty dispatch, not at append.
+                // Capturing at append would make elapsed_since_sync run ahead of the MCU playhead.
                 if sync_instant.is_none() && !drained.is_empty() {
                     sync_instant = Some(Instant::now());
                 }
@@ -719,6 +729,9 @@ fn run_loop(
             }
 
             PlannerMsg::ClockSyncRearm { new_bias: _ } => {
+                // Pre-swap barrier: flush held-back output under the old clock bias.
+                // Must run before Router::set_clock_est_from_sample — calling after
+                // would shape the drained tail under the new bias.
                 if state.t_dispatched < state.t_appended - 1e-12 {
                     run_commit_and_dispatch(
                         &mut state,

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -454,6 +454,8 @@ fn run_loop(
     commit_fire_count: Arc<AtomicU32>,
 ) {
     let mut thread_state = PlannerThreadState::build(&config);
+    let limit_names = config.limit_set_names();
+    let mut binding_acc = crate::binding_report::BindingAccumulator::new(Instant::now());
 
     {
         let tl = config
@@ -520,9 +522,6 @@ fn run_loop(
 
         match msg {
             PlannerMsg::Move(m) => {
-                // `submit_move` already advanced `last_move_time_bits` by the nominal.
-                // Rectify if actual diverges: use CAS since submit_move is a concurrent writer.
-                // Rectify against t_appended delta (not dispatched): the decel tail is held back.
                 let nominal = m.nominal_duration();
                 let prior_t_appended = state.t_appended;
                 let prior_t_decel = state.t_decel_start;
@@ -541,11 +540,6 @@ fn run_loop(
                             &commit_fire_count,
                         );
                     }
-                    // Resume with the same dispatch cushion a fresh stream
-                    // gets: anchoring at bare `esc` leaves the upcoming
-                    // append_and_replan solve (observed 100-200 ms) to consume
-                    // the entire lead before seg0 is even emitted, landing
-                    // pieces in the MCU past.
                     state.advance_idle(esc + LEAD);
                 }
 
@@ -586,7 +580,7 @@ fn run_loop(
                     window_segments,
                     plan,
                     fallback_rung,
-                    binding: _,
+                    binding,
                 } = report;
                 let beta_iters = plan.beta_iterations;
                 let beta_converged = plan.beta_converged;
@@ -640,6 +634,9 @@ fn run_loop(
                     );
                 }
 
+                binding_acc.record(&binding, state.t_appended);
+                binding_acc.maybe_rollup(Instant::now(), &limit_names);
+
                 for s in &drained {
                     if let Err(detail) = dispatch(s) {
                         tracing::error!(
@@ -653,8 +650,6 @@ fn run_loop(
                     }
                 }
 
-                // Capture sync_instant only on non-empty dispatch, not at append.
-                // Capturing at append would make elapsed_since_sync run ahead of the MCU playhead.
                 if sync_instant.is_none() && !drained.is_empty() {
                     sync_instant = Some(Instant::now());
                 }
@@ -711,6 +706,7 @@ fn run_loop(
             }
 
             PlannerMsg::KalicoStreamOpen { home_pos } => {
+                binding_acc.flush(Instant::now(), &limit_names);
                 sync_instant = None;
                 let chains = &thread_state.replan_ctx.chains;
                 state.reset(&home_pos[..chains.n_axes()], chains);
@@ -723,9 +719,6 @@ fn run_loop(
             }
 
             PlannerMsg::ClockSyncRearm { new_bias: _ } => {
-                // Pre-swap barrier: flush held-back output under the old clock bias.
-                // Must run before Router::set_clock_est_from_sample — calling after
-                // would shape the drained tail under the new bias.
                 if state.t_dispatched < state.t_appended - 1e-12 {
                     run_commit_and_dispatch(
                         &mut state,
@@ -737,7 +730,10 @@ fn run_loop(
                 }
             }
 
-            PlannerMsg::Shutdown => return,
+            PlannerMsg::Shutdown => {
+                binding_acc.flush(Instant::now(), &limit_names);
+                return;
+            }
 
             PlannerMsg::HomeDrip(p) => {
                 sync_instant = None;

--- a/rust/motion-bridge/tests/binding_report_e2e.rs
+++ b/rust/motion-bridge/tests/binding_report_e2e.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+
+use motion_bridge_native::binding_report::BindingAccumulator;
+use temporal::BindingConstraint;
+use trajectory::{ReplanBindingSummary, ReplanWorstBinding};
+
+#[test]
+fn binding_events_land_in_host_rust_jsonl_tagged_with_print_id() {
+    let dir: PathBuf =
+        std::env::temp_dir().join(format!("kalico-binding-e2e-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    motion_bridge_native::logging::init_logging(&dir).expect("init");
+    motion_bridge_native::logging::set_context(
+        "k-1748700131-4412".to_string(),
+        "print-1748700500".to_string(),
+    );
+
+    let limit_names = vec!["gantry".to_string(), "extruder".to_string()];
+    let summary = ReplanBindingSummary {
+        histogram: vec![
+            (BindingConstraint::Velocity { set: 0 }, 7),
+            (BindingConstraint::PaAccel { set: 1 }, 3),
+        ],
+        worst: Some(ReplanWorstBinding {
+            constraint: BindingConstraint::PaAccel { set: 1 },
+            ratio: 0.98,
+        }),
+    };
+
+    let start = std::time::Instant::now();
+    let mut acc = BindingAccumulator::new(start);
+    acc.record(&summary, 4.25);
+    acc.flush(start + std::time::Duration::from_millis(10), &limit_names);
+
+    std::thread::sleep(std::time::Duration::from_millis(250));
+
+    let contents = std::fs::read_to_string(dir.join("host-rust.jsonl")).unwrap();
+    let lines: Vec<serde_json::Value> = contents
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("valid JSON line"))
+        .collect();
+
+    let rollup = lines
+        .iter()
+        .find(|r| r["event"] == "binding_rollup")
+        .expect("binding_rollup must be emitted");
+    assert_eq!(rollup["source"], "host-rust");
+    assert_eq!(rollup["print_id"], "print-1748700500");
+    assert_eq!(rollup["subsystem"], "motion");
+    assert_eq!(rollup["limit"], "extruder");
+    assert_eq!(rollup["derivative"], "accel");
+    assert_eq!(rollup["via_pa"], true);
+    assert!((rollup["ratio"].as_f64().unwrap() - 0.98).abs() < 1e-9);
+    assert!((rollup["t"].as_f64().unwrap() - 4.25).abs() < 1e-9);
+    assert_eq!(rollup["window_samples"].as_u64().unwrap(), 10);
+
+    let hist: Vec<&serde_json::Value> = lines
+        .iter()
+        .filter(|r| r["event"] == "binding_hist")
+        .collect();
+    assert!(
+        hist.iter().any(|r| r["limit"] == "gantry"
+            && r["derivative"] == "velocity"
+            && r["via_pa"] == false
+            && r["count"].as_u64() == Some(7)),
+        "expected gantry/velocity count=7 in binding_hist, got {hist:?}"
+    );
+    assert!(
+        hist.iter().any(|r| r["limit"] == "extruder"
+            && r["derivative"] == "accel"
+            && r["via_pa"] == true
+            && r["count"].as_u64() == Some(3)),
+        "expected extruder/accel count=3 in binding_hist, got {hist:?}"
+    );
+    for r in &hist {
+        assert_eq!(r["print_id"], "print-1748700500");
+        assert_eq!(r["subsystem"], "motion");
+    }
+}

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -42,7 +42,7 @@ pub enum GridScheme {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BindingConstraint {
     None,
     Velocity { set: usize },
@@ -52,6 +52,20 @@ pub enum BindingConstraint {
     PaAccel { set: usize },
     PaJerk { set: usize },
     Boundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WorstBinding {
+    pub constraint: BindingConstraint,
+    pub ratio: f64,
+    pub grid_index: usize,
+    pub s: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BindingSummary {
+    pub histogram: Vec<(BindingConstraint, u32)>,
+    pub worst: Option<WorstBinding>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -115,4 +129,5 @@ pub struct TopProfile {
     pub status: SolveStatus,
     pub grid_scheme: GridScheme,
     pub total_time: f64,
+    pub binding: BindingSummary,
 }

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -42,7 +42,7 @@ pub enum GridScheme {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BindingConstraint {
     None,
     Velocity { set: usize },

--- a/rust/temporal/src/multi/chain.rs
+++ b/rust/temporal/src/multi/chain.rs
@@ -26,7 +26,8 @@ pub(crate) fn slice_chain_profile(
 ) -> Vec<TopProfile> {
     segment_ranges
         .iter()
-        .map(|&(lo, hi)| {
+        .enumerate()
+        .map(|(i, &(lo, hi))| {
             let s0 = chain.samples[lo].s;
             let mut samples: Vec<GridSample> = chain.samples[lo..=hi]
                 .iter()
@@ -51,12 +52,17 @@ pub(crate) fn slice_chain_profile(
             if matches!(chain.status, crate::SolveStatus::Infeasible { .. }) {
                 total_time = f64::INFINITY;
             }
+            let binding = if i == 0 {
+                chain.binding.clone()
+            } else {
+                BindingSummary::default()
+            };
             TopProfile {
                 samples,
                 status: chain.status,
                 grid_scheme: chain.grid_scheme,
                 total_time,
-                binding: chain.binding.clone(),
+                binding,
             }
         })
         .collect()

--- a/rust/temporal/src/multi/chain.rs
+++ b/rust/temporal/src/multi/chain.rs
@@ -1,9 +1,7 @@
 use crate::multi::junction::JunctionKind;
-use crate::{GridSample, TopProfile};
+use crate::{BindingSummary, GridSample, TopProfile};
 use std::ops::RangeInclusive;
 
-/// Maximal runs of segments joined by Smooth junctions. `kinds[k]` is the
-/// junction between segments k and k+1.
 #[allow(clippy::range_minus_one)]
 pub(crate) fn partition_chains(
     n_segments: usize,
@@ -22,10 +20,6 @@ pub(crate) fn partition_chains(
     chains
 }
 
-/// Slice one chain profile into per-segment profiles. The junction sample is
-/// duplicated into both neighbors; per-segment `s` is rebased to start at 0;
-/// per-segment time is the trapezoid over the slice (same formula as
-/// output::assemble).
 pub(crate) fn slice_chain_profile(
     chain: &TopProfile,
     segment_ranges: &[(usize, usize)],
@@ -62,6 +56,7 @@ pub(crate) fn slice_chain_profile(
                 status: chain.status,
                 grid_scheme: chain.grid_scheme,
                 total_time,
+                binding: BindingSummary::default(),
             }
         })
         .collect()

--- a/rust/temporal/src/multi/chain.rs
+++ b/rust/temporal/src/multi/chain.rs
@@ -56,7 +56,7 @@ pub(crate) fn slice_chain_profile(
                 status: chain.status,
                 grid_scheme: chain.grid_scheme,
                 total_time,
-                binding: BindingSummary::default(),
+                binding: chain.binding.clone(),
             }
         })
         .collect()

--- a/rust/temporal/src/multi/chain/tests.rs
+++ b/rust/temporal/src/multi/chain/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::multi::junction::JunctionKind;
-use crate::{BindingConstraint, GridSample, GridScheme, SolveStatus, TopProfile};
+use crate::{BindingConstraint, BindingSummary, GridSample, GridScheme, SolveStatus, TopProfile};
 
 #[test]
 fn partition_splits_only_at_corners() {
@@ -48,16 +48,15 @@ fn slice_duplicates_junction_sample_and_splits_time() {
         status: SolveStatus::Solved,
         grid_scheme: GridScheme::UniformArclength,
         total_time: 0.4,
+        binding: BindingSummary::default(),
     };
     let per_segment = slice_chain_profile(&chain_profile, &ranges);
     assert_eq!(per_segment.len(), 2);
     assert_eq!(per_segment[0].samples.len(), 3);
     assert_eq!(per_segment[1].samples.len(), 3);
-    // Junction sample duplicated into both, with per-segment s rebased to 0.
     assert_eq!(per_segment[0].samples[2].v, per_segment[1].samples[0].v);
     assert!((per_segment[1].samples[0].s - 0.0).abs() < 1e-12);
-    assert!((per_segment[0].samples[2].s - 2.0).abs() < 1e-12); // last of seg0
-    // 2 mm at 10 mm/s each → 0.2 s per segment.
+    assert!((per_segment[0].samples[2].s - 2.0).abs() < 1e-12);
     assert!((per_segment[0].total_time - 0.2).abs() < 1e-9);
     assert!((per_segment[1].total_time - 0.2).abs() < 1e-9);
 }

--- a/rust/temporal/src/multi/chain/tests.rs
+++ b/rust/temporal/src/multi/chain/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::multi::junction::JunctionKind;
-use crate::{BindingConstraint, BindingSummary, GridSample, GridScheme, SolveStatus, TopProfile};
+use crate::{
+    BindingConstraint, BindingSummary, GridSample, GridScheme, SolveStatus, TopProfile,
+    WorstBinding,
+};
 
 #[test]
 fn partition_splits_only_at_corners() {
@@ -59,4 +62,57 @@ fn slice_duplicates_junction_sample_and_splits_time() {
     assert!((per_segment[0].samples[2].s - 2.0).abs() < 1e-12);
     assert!((per_segment[0].total_time - 0.2).abs() < 1e-9);
     assert!((per_segment[1].total_time - 0.2).abs() < 1e-9);
+}
+
+#[test]
+fn binding_summary_assigned_to_first_slice_only() {
+    let ranges = vec![(0usize, 2usize), (2, 4), (4, 6)];
+    let samples: Vec<GridSample> = (0..7)
+        .map(|i| GridSample {
+            s: i as f64,
+            v: 10.0,
+            a: 0.0,
+            b: 100.0,
+            binding: BindingConstraint::None,
+        })
+        .collect();
+    let chain_binding = BindingSummary {
+        histogram: vec![(BindingConstraint::Velocity { set: 0 }, 5)],
+        worst: Some(WorstBinding {
+            constraint: BindingConstraint::Velocity { set: 0 },
+            ratio: 1.0,
+            grid_index: 2,
+            s: 2.0,
+        }),
+    };
+    let chain_profile = TopProfile {
+        samples,
+        status: SolveStatus::Solved,
+        grid_scheme: GridScheme::UniformArclength,
+        total_time: 1.2,
+        binding: chain_binding,
+    };
+    let per_segment = slice_chain_profile(&chain_profile, &ranges);
+    assert_eq!(per_segment.len(), 3);
+    assert!(
+        !per_segment[0].binding.histogram.is_empty(),
+        "first slice must carry the chain binding summary"
+    );
+    assert!(
+        per_segment[1].binding.histogram.is_empty(),
+        "second slice must have empty binding summary"
+    );
+    assert!(
+        per_segment[2].binding.histogram.is_empty(),
+        "third slice must have empty binding summary"
+    );
+    let total_histogram_count: u32 = per_segment
+        .iter()
+        .flat_map(|p| p.binding.histogram.iter())
+        .map(|(_, count)| count)
+        .sum();
+    assert_eq!(
+        total_histogram_count, 5,
+        "histogram count must be 5 (once per chain), not 15 (once per slice)"
+    );
 }

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -621,4 +621,11 @@ fn binding_summary_reports_velocity_pin() {
         velocity_count > 0,
         "cruise samples should tally as Velocity bindings"
     );
+
+    let counts: Vec<u32> = profile.binding.histogram.iter().map(|(_, n)| *n).collect();
+    assert!(
+        counts.windows(2).all(|w| w[0] >= w[1]),
+        "histogram must be sorted by descending count; got {:?}",
+        counts
+    );
 }

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -582,3 +582,43 @@ fn virtual_path_plans_under_follower_limits_and_feedrate() {
     }
     assert!(max_dvdt <= 1500.0 * 1.02, "accel {max_dvdt} > 1500");
 }
+
+#[test]
+fn binding_summary_reports_velocity_pin() {
+    let limits = limits_with_follower(50.0, 1.0e9, 1.0e12);
+    let profile = solve_with_followers(
+        &limits,
+        &[FollowerDemand {
+            axis: 3,
+            ratio: 0.5,
+            pa_k: 0.0,
+        }],
+    );
+
+    let worst = profile
+        .binding
+        .worst
+        .expect("a velocity-capped cruise must produce a worst-pinned sample");
+    assert!(
+        matches!(worst.constraint, crate::BindingConstraint::Velocity { .. }),
+        "worst pin should be a velocity row, got {:?}",
+        worst.constraint
+    );
+    assert!(
+        (0.9..=1.05).contains(&worst.ratio),
+        "cruise rides the cap; ratio = {}",
+        worst.ratio
+    );
+
+    let velocity_count: u32 = profile
+        .binding
+        .histogram
+        .iter()
+        .filter(|(c, _)| matches!(c, crate::BindingConstraint::Velocity { .. }))
+        .map(|(_, n)| *n)
+        .sum();
+    assert!(
+        velocity_count > 0,
+        "cruise samples should tally as Velocity bindings"
+    );
+}

--- a/rust/temporal/src/topp/mod.rs
+++ b/rust/temporal/src/topp/mod.rs
@@ -283,7 +283,7 @@ fn boundary_infeasible_profile(
     mvc_b: f64,
     at_grid: usize,
 ) -> TopProfile {
-    use crate::{BindingConstraint, GridSample, InfeasibleReason, SolveStatus};
+    use crate::{BindingConstraint, BindingSummary, GridSample, InfeasibleReason, SolveStatus};
     let samples = s
         .iter()
         .map(|&si| GridSample {
@@ -302,6 +302,7 @@ fn boundary_infeasible_profile(
         },
         grid_scheme: crate::GridScheme::UniformArclength,
         total_time: f64::INFINITY,
+        binding: BindingSummary::default(),
     }
 }
 
@@ -311,7 +312,7 @@ fn max_reachable_infeasible_profile(
     max_b: f64,
     at_grid: usize,
 ) -> TopProfile {
-    use crate::{BindingConstraint, GridSample, InfeasibleReason, SolveStatus};
+    use crate::{BindingConstraint, BindingSummary, GridSample, InfeasibleReason, SolveStatus};
     let samples = s
         .iter()
         .map(|&si| GridSample {
@@ -330,6 +331,7 @@ fn max_reachable_infeasible_profile(
         },
         grid_scheme: crate::GridScheme::UniformArclength,
         total_time: f64::INFINITY,
+        binding: BindingSummary::default(),
     }
 }
 
@@ -339,7 +341,7 @@ fn min_reachable_infeasible_profile(
     min_b: f64,
     at_grid: usize,
 ) -> TopProfile {
-    use crate::{BindingConstraint, GridSample, InfeasibleReason, SolveStatus};
+    use crate::{BindingConstraint, BindingSummary, GridSample, InfeasibleReason, SolveStatus};
     let samples = s
         .iter()
         .map(|&si| GridSample {
@@ -358,6 +360,7 @@ fn min_reachable_infeasible_profile(
         },
         grid_scheme: crate::GridScheme::UniformArclength,
         total_time: f64::INFINITY,
+        binding: BindingSummary::default(),
     }
 }
 

--- a/rust/temporal/src/topp/output.rs
+++ b/rust/temporal/src/topp/output.rs
@@ -50,6 +50,7 @@ pub(crate) fn assemble(
         status,
         grid_scheme: grid_config.scheme,
         total_time,
+        binding: verify.binding_summary.clone(),
     }
 }
 

--- a/rust/temporal/src/topp/output/tests.rs
+++ b/rust/temporal/src/topp/output/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::topp::path::{ArclengthGrid, InterSample};
 use crate::topp::solver::{SolverResult, SolverStatus};
 use crate::topp::verify::VerifyReport;
-use crate::{BindingConstraint, GridConfig, GridScheme};
+use crate::{BindingConstraint, BindingSummary, GridConfig, GridScheme};
 
 fn dummy_grid(n: usize, length: f64) -> ArclengthGrid {
     let s: Vec<f64> = (0..n).map(|i| length * i as f64 / (n - 1) as f64).collect();
@@ -49,6 +49,7 @@ fn assembles_samples_and_total_time() {
         feasible: true,
         worst_jerk_ratio: 0.0,
         worst_non_jerk_ratio: 0.0,
+        binding_summary: BindingSummary::default(),
     };
     let cfg = GridConfig {
         scheme: GridScheme::UniformArclength,
@@ -69,10 +70,6 @@ fn assembles_samples_and_total_time() {
 
 #[test]
 fn infeasible_solve_reports_infinite_time() {
-    // An infeasible solver answer is garbage primal values that traverse the
-    // path at near-zero speed, which would integrate to an enormous-but-finite
-    // time and read downstream as a real (slow) trajectory. An infeasible solve
-    // must report INFINITY so nothing mistakes it for a schedulable move.
     let grid = dummy_grid(3, 50.0);
     let result = SolverResult {
         b: vec![4e-5, 2e-5, 1e-9],
@@ -86,6 +83,7 @@ fn infeasible_solve_reports_infinite_time() {
         feasible: false,
         worst_jerk_ratio: 1.0,
         worst_non_jerk_ratio: 2.0,
+        binding_summary: BindingSummary::default(),
     };
     let cfg = GridConfig {
         scheme: GridScheme::UniformArclength,

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -257,12 +257,25 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         if let Some(w) = &windows {
             for d in crate::topp::follower::windowed_demands_at(w, chain, &result.b, &result.a, i) {
                 let ratio = d.value / d.cap;
-                if ratio > pr.max_jerk {
-                    pr.max_jerk = ratio;
+                let tag = windowed_tag(&d);
+                let is_jerk_class = matches!(
+                    tag,
+                    BindingConstraint::JerkNorm { .. }
+                        | BindingConstraint::PaJerk { .. }
+                        | BindingConstraint::PaVelocity { .. }
+                        | BindingConstraint::PaAccel { .. }
+                );
+                if is_jerk_class {
+                    if ratio > pr.max_jerk {
+                        pr.max_jerk = ratio;
+                    }
+                } else if ratio > pr.max_non_jerk {
+                    pr.max_non_jerk = ratio;
+                    pr.worst_non_jerk_tag = tag;
                 }
                 if ratio > pr.worst_ratio {
                     pr.worst_ratio = ratio;
-                    pr.worst_tag = windowed_tag(&d);
+                    pr.worst_tag = tag;
                 }
             }
         }
@@ -347,7 +360,8 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             other => *histogram_map.entry(*other).or_insert(0) += 1,
         }
     }
-    let histogram: Vec<(BindingConstraint, u32)> = histogram_map.into_iter().collect();
+    let mut histogram: Vec<(BindingConstraint, u32)> = histogram_map.into_iter().collect();
+    histogram.sort_by(|(ca, na), (cb, nb)| nb.cmp(na).then_with(|| ca.cmp(cb)));
 
     let worst = if worst_non_jerk_ratio >= SLACK_THRESHOLD
         && !matches!(

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -1,28 +1,27 @@
 use crate::topp::chain::ChainGrid;
 use crate::topp::solver::SolverResult;
-use crate::{BindingConstraint, FollowerDemand, Limits, restricted_norm};
+use crate::{
+    BindingConstraint, BindingSummary, FollowerDemand, Limits, WorstBinding, restricted_norm,
+};
 
-/// 0.2% feasibility margin for velocity / accel / centripetal.
 pub(crate) const EPS_FEAS: f64 = 2e-3;
 
-pub(crate) const EPS_FEAS_JERK: f64 = 5e-2; // temporary hack, to be investigated later
+pub(crate) const EPS_FEAS_JERK: f64 = 5e-2; // TODO: investigate jerk tolerance
 
-/// Threshold below which a normalised ratio is treated as fully slack.
 const SLACK_THRESHOLD: f64 = 1e-6;
 
-/// `b_i` below which endpoints are tagged `BindingConstraint::Boundary`.
 const BOUNDARY_B_TOL: f64 = 1e-9;
 
 #[derive(Debug, Clone)]
 pub(crate) struct VerifyReport {
     pub binding_per_grid: Vec<BindingConstraint>,
-    /// `max_i(worst_ratio_at_i) − 1.0`. Positive means infeasible.
     #[allow(dead_code)]
     pub worst_violation: f64,
     pub worst_violation_grid: usize,
     pub feasible: bool,
     pub worst_jerk_ratio: f64,
     pub worst_non_jerk_ratio: f64,
+    pub binding_summary: BindingSummary,
 }
 
 struct PointInputs<'a> {
@@ -42,12 +41,9 @@ struct PointRatios {
     worst_tag: BindingConstraint,
     max_jerk: f64,
     max_non_jerk: f64,
+    worst_non_jerk_tag: BindingConstraint,
 }
 
-/// All constraint ratios at one grid point. Class maxima scan every entry, not
-/// just the per-point winner, so an in-band jerk ratio can't mask a co-located
-/// non-jerk violation. Tie-breaking: Velocity > AccelNorm > JerkNorm; lower
-/// set index wins within a class.
 fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
     let s_dot2 = p.s_dot * p.s_dot;
     let s_dot3 = s_dot2 * p.s_dot;
@@ -143,6 +139,7 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
     let mut worst_tag = BindingConstraint::None;
     let mut max_jerk = 0.0_f64;
     let mut max_non_jerk = 0.0_f64;
+    let mut worst_non_jerk_tag = BindingConstraint::None;
 
     for (ratio, tag) in entries {
         if ratio > worst_ratio {
@@ -161,6 +158,7 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
             }
         } else if ratio > max_non_jerk {
             max_non_jerk = ratio;
+            worst_non_jerk_tag = tag;
         }
     }
 
@@ -169,17 +167,21 @@ fn ratios_at(p: &PointInputs<'_>) -> PointRatios {
     } else {
         worst_tag
     };
+    let worst_non_jerk_tag = if max_non_jerk < SLACK_THRESHOLD {
+        BindingConstraint::None
+    } else {
+        worst_non_jerk_tag
+    };
 
     PointRatios {
         worst_ratio,
         worst_tag,
         max_jerk,
         max_non_jerk,
+        worst_non_jerk_tag,
     }
 }
 
-/// Chain-aware verifier. Junction points carry the LEFT segment's limits in the
-/// primary arrays; the dual pass is what enforces the right side.
 pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyReport {
     let n = chain.n_points();
     let has_pa = chain.followers.iter().flatten().any(|f| f.pa_k != 0.0);
@@ -194,6 +196,7 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             feasible: true,
             worst_jerk_ratio: 0.0,
             worst_non_jerk_ratio: 0.0,
+            binding_summary: BindingSummary::default(),
         };
     }
 
@@ -211,6 +214,8 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
     let mut global_worst_idx: usize = 0;
     let mut worst_jerk_ratio: f64 = 0.0;
     let mut worst_non_jerk_ratio: f64 = 0.0;
+    let mut worst_non_jerk_idx: usize = 0;
+    let mut worst_non_jerk_tag: BindingConstraint = BindingConstraint::None;
 
     for i in 0..n {
         let b_i = result.b[i];
@@ -277,6 +282,8 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         }
         if pr.max_non_jerk > worst_non_jerk_ratio {
             worst_non_jerk_ratio = pr.max_non_jerk;
+            worst_non_jerk_idx = i;
+            worst_non_jerk_tag = pr.worst_non_jerk_tag;
         }
 
         point_worst_ratio.push(pr.worst_ratio);
@@ -327,8 +334,36 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         }
         if pr.max_non_jerk > worst_non_jerk_ratio {
             worst_non_jerk_ratio = pr.max_non_jerk;
+            worst_non_jerk_idx = i;
+            worst_non_jerk_tag = pr.worst_non_jerk_tag;
         }
     }
+
+    let mut histogram_map: std::collections::HashMap<BindingConstraint, u32> =
+        std::collections::HashMap::new();
+    for tag in &binding_per_grid {
+        match tag {
+            BindingConstraint::None | BindingConstraint::Boundary => {}
+            other => *histogram_map.entry(*other).or_insert(0) += 1,
+        }
+    }
+    let histogram: Vec<(BindingConstraint, u32)> = histogram_map.into_iter().collect();
+
+    let worst = if worst_non_jerk_ratio >= SLACK_THRESHOLD
+        && !matches!(
+            worst_non_jerk_tag,
+            BindingConstraint::None | BindingConstraint::Boundary
+        ) {
+        Some(WorstBinding {
+            constraint: worst_non_jerk_tag,
+            ratio: worst_non_jerk_ratio,
+            grid_index: worst_non_jerk_idx,
+            s: chain.s[worst_non_jerk_idx],
+        })
+    } else {
+        None
+    };
+    let binding_summary = BindingSummary { histogram, worst };
 
     let worst_violation = global_worst_ratio - 1.0;
     let feasible =
@@ -340,6 +375,7 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
         feasible,
         worst_jerk_ratio,
         worst_non_jerk_ratio,
+        binding_summary,
     }
 }
 

--- a/rust/temporal/src/topp/verify/tests.rs
+++ b/rust/temporal/src/topp/verify/tests.rs
@@ -333,3 +333,68 @@ fn jerk_riding_does_not_mask_accel_violation() {
         report.worst_violation,
     );
 }
+
+#[test]
+fn histogram_counts_are_non_increasing() {
+    let grid = dummy_straight_grid(5, 100.0);
+    let limits = textbook_limits();
+    let chain = chain_of_one(grid, limits);
+    let result = SolverResult {
+        b: vec![10_000.0; 5],
+        a: vec![10_000.0; 5],
+        status: SolverStatus::Solved,
+    };
+    let report = check_chain(&chain, &result);
+    let counts: Vec<u32> = report
+        .binding_summary
+        .histogram
+        .iter()
+        .map(|(_, n)| *n)
+        .collect();
+    assert!(
+        counts.windows(2).all(|w| w[0] >= w[1]),
+        "histogram must be sorted by descending count; got {counts:?}"
+    );
+}
+
+#[test]
+fn histogram_ties_broken_by_constraint_ord() {
+    let grid = dummy_straight_grid(5, 100.0);
+    let limits = textbook_limits();
+    let chain = chain_of_one(grid, limits);
+    let result = SolverResult {
+        b: vec![0.0, 250_000.0, 250_000.0, 250_000.0, 0.0],
+        a: vec![0.0; 5],
+        status: SolverStatus::Solved,
+    };
+    let report = check_chain(&chain, &result);
+    let counts: Vec<u32> = report
+        .binding_summary
+        .histogram
+        .iter()
+        .map(|(_, n)| *n)
+        .collect();
+    assert!(
+        counts.windows(2).all(|w| w[0] >= w[1]),
+        "histogram must be sorted by descending count; got {counts:?}"
+    );
+    let tie_groups: Vec<&[(BindingConstraint, u32)]> = {
+        let h = &report.binding_summary.histogram;
+        let mut groups: Vec<&[(BindingConstraint, u32)]> = Vec::new();
+        let mut start = 0;
+        while start < h.len() {
+            let count = h[start].1;
+            let end = h[start..].partition_point(|(_, n)| *n == count) + start;
+            groups.push(&h[start..end]);
+            start = end;
+        }
+        groups
+    };
+    for group in tie_groups {
+        let constraints: Vec<BindingConstraint> = group.iter().map(|(c, _)| *c).collect();
+        assert!(
+            constraints.windows(2).all(|w| w[0] <= w[1]),
+            "equal-count entries must be sorted by BindingConstraint ord; got {constraints:?}"
+        );
+    }
+}

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -75,6 +75,7 @@ pub struct PlannedBatch {
     pub converged: bool,
     pub beta_iterations: u8,
     pub beta_warning: Option<BetaWarning>,
+    pub binding: ReplanBindingSummary,
 }
 
 pub fn plan_batch_full(
@@ -89,6 +90,7 @@ pub fn plan_batch_full(
         converged: outcome.converged,
         beta_iterations: outcome.iterations,
         beta_warning: outcome.beta_warning,
+        binding: outcome.result.binding,
     })
 }
 
@@ -109,10 +111,45 @@ pub struct PlanStats {
     pub segments: usize,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ReplanWorstBinding {
+    pub constraint: temporal::BindingConstraint,
+    pub ratio: f64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ReplanBindingSummary {
+    pub histogram: Vec<(temporal::BindingConstraint, u32)>,
+    pub worst: Option<ReplanWorstBinding>,
+}
+
+fn aggregate_binding(profiles: &[temporal::TopProfile]) -> ReplanBindingSummary {
+    use std::collections::HashMap;
+    let mut hist: HashMap<temporal::BindingConstraint, u32> = HashMap::new();
+    let mut worst: Option<ReplanWorstBinding> = None;
+    for p in profiles {
+        for (c, n) in &p.binding.histogram {
+            *hist.entry(*c).or_insert(0) += *n;
+        }
+        if let Some(w) = &p.binding.worst {
+            if worst.map_or(true, |cur| w.ratio > cur.ratio) {
+                worst = Some(ReplanWorstBinding {
+                    constraint: w.constraint,
+                    ratio: w.ratio,
+                });
+            }
+        }
+    }
+    let mut histogram: Vec<(temporal::BindingConstraint, u32)> = hist.into_iter().collect();
+    histogram.sort_by(|(ca, na), (cb, nb)| nb.cmp(na).then_with(|| ca.cmp(cb)));
+    ReplanBindingSummary { histogram, worst }
+}
+
 #[derive(Debug)]
 pub struct PlanOutput {
     pub fitted: Vec<FittedSegment>,
     pub stats: PlanStats,
+    pub binding: ReplanBindingSummary,
 }
 
 pub fn plan_velocity_inner(
@@ -127,6 +164,7 @@ pub fn plan_velocity_inner(
                 beta_converged: true,
                 segments: 0,
             },
+            binding: ReplanBindingSummary::default(),
         });
     }
 
@@ -139,6 +177,7 @@ pub fn plan_velocity_inner(
             beta_converged: planned.converged,
             segments,
         },
+        binding: planned.binding,
     })
 }
 
@@ -297,6 +336,7 @@ struct BetaIterResult {
     joining_status: temporal::multi::JoiningStatus,
     _iteration: u8,
     global_ends: Vec<f64>,
+    binding: ReplanBindingSummary,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -457,7 +497,7 @@ fn run_one_iteration(
                     detail: format!("{e}"),
                 })?;
 
-            let arc_fit_tolerance = 1e-4; // mm
+            let arc_fit_tolerance = 1e-4;
             let composed = crate::reparam::compose_segment(
                 curve,
                 &table.as_view(),
@@ -511,12 +551,15 @@ fn run_one_iteration(
         })
         .collect();
 
+    let binding = aggregate_binding(&batch_output.profiles);
+
     Ok(BetaIterResult {
         fitted,
         peaks,
         joining_status: last_joining_status,
         _iteration: 0,
         global_ends,
+        binding,
     })
 }
 

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -13,6 +13,7 @@ mod shaper;
 mod smooth_fit;
 pub mod streaming;
 
+pub use beta::{ReplanBindingSummary, ReplanWorstBinding};
 pub use emit_shaped::{emit_shaped, EmitSegmentMeta, PerAxisHistory, ShapeEmission};
 pub use plan_velocity::{plan_velocity, PlanInput, PlanOutput, PlanSegment, PlanStats, SafetyMode};
 pub use post_processor::{

--- a/rust/trajectory/src/reparam/tests.rs
+++ b/rust/trajectory/src/reparam/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use temporal::{BindingConstraint, GridSample, GridScheme, SolveStatus, TopProfile};
+use temporal::{
+    BindingConstraint, BindingSummary, GridSample, GridScheme, SolveStatus, TopProfile,
+};
 
 fn uniform_profile(n: usize, total_length: f64, velocity: f64) -> TopProfile {
     let mut samples = Vec::with_capacity(n);
@@ -20,6 +22,7 @@ fn uniform_profile(n: usize, total_length: f64, velocity: f64) -> TopProfile {
         status: SolveStatus::Solved,
         grid_scheme: GridScheme::UniformArclength,
         total_time,
+        binding: BindingSummary::default(),
     }
 }
 
@@ -69,6 +72,7 @@ fn s_of_t_endpoint_consistency() {
         status: SolveStatus::Solved,
         grid_scheme: GridScheme::UniformArclength,
         total_time: 1.0,
+        binding: BindingSummary::default(),
     };
 
     let s_pieces = build_s_of_t_pieces(&profile, 0.0);
@@ -125,6 +129,7 @@ fn s_of_t_near_zero_handling() {
         status: SolveStatus::Solved,
         grid_scheme: GridScheme::UniformArclength,
         total_time: 100.0,
+        binding: BindingSummary::default(),
     };
 
     let s_pieces = build_s_of_t_pieces(&profile, 0.0);

--- a/rust/trajectory/src/streaming/mod.rs
+++ b/rust/trajectory/src/streaming/mod.rs
@@ -9,16 +9,15 @@ use crate::fit::FittedSegment;
 use crate::plan_velocity::{PlanStats, SafetyMode};
 use crate::post_processor::AxisChainSet;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ReplanReport {
     pub split_us: u64,
     pub solve_us: u64,
     pub rebuild_us: u64,
     pub window_segments: usize,
     pub plan: PlanStats,
-    /// Which fallback rung resolved the plan: 1 = full window succeeded, 2 = Replace-remnant
-    /// dropped, 3 = witness preserved and new segment planned alone from rest.
     pub fallback_rung: u8,
+    pub binding: crate::ReplanBindingSummary,
 }
 
 mod decel_finder;

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -209,41 +209,48 @@ impl ShaperState {
         };
 
         let solve_start = Instant::now();
-        let (PlanOutput { fitted, stats }, time_offset, fallback_rung) =
-            match plan_velocity(&plan_input) {
-                Ok(out) => (out, t_freeze, 1u8),
-                Err(rung1_err) => {
-                    if let Some(rung2_out) =
-                        try_rung2(was_replace_split, &prior_uncommitted, self, ctx, t_freeze)
-                    {
-                        let (out, offset) = rung2_out;
-                        (out, offset, 2u8)
-                    } else {
-                        match try_rung3(
-                            self,
-                            &prior_uncommitted,
-                            prior_t_appended,
-                            prior_t_decel_start,
-                            &prior_planned_fitted,
-                            &prior_planned_meta,
-                            ctx,
-                        ) {
-                            Ok((out, offset)) => (out, offset, 3u8),
-                            Err(rung3_err) => {
-                                self.uncommitted_moves = prior_uncommitted;
-                                self.t_appended = prior_t_appended;
-                                self.t_decel_start = prior_t_decel_start;
-                                self.planned_fitted = prior_planned_fitted;
-                                self.planned_meta = prior_planned_meta;
-                                return Err(ShapeError::WitnessFallbackFailed {
-                                    rung1: Box::new(rung1_err),
-                                    rung3: Box::new(rung3_err),
-                                });
-                            }
+        let (
+            PlanOutput {
+                fitted,
+                stats,
+                binding,
+            },
+            time_offset,
+            fallback_rung,
+        ) = match plan_velocity(&plan_input) {
+            Ok(out) => (out, t_freeze, 1u8),
+            Err(rung1_err) => {
+                if let Some(rung2_out) =
+                    try_rung2(was_replace_split, &prior_uncommitted, self, ctx, t_freeze)
+                {
+                    let (out, offset) = rung2_out;
+                    (out, offset, 2u8)
+                } else {
+                    match try_rung3(
+                        self,
+                        &prior_uncommitted,
+                        prior_t_appended,
+                        prior_t_decel_start,
+                        &prior_planned_fitted,
+                        &prior_planned_meta,
+                        ctx,
+                    ) {
+                        Ok((out, offset)) => (out, offset, 3u8),
+                        Err(rung3_err) => {
+                            self.uncommitted_moves = prior_uncommitted;
+                            self.t_appended = prior_t_appended;
+                            self.t_decel_start = prior_t_decel_start;
+                            self.planned_fitted = prior_planned_fitted;
+                            self.planned_meta = prior_planned_meta;
+                            return Err(ShapeError::WitnessFallbackFailed {
+                                rung1: Box::new(rung1_err),
+                                rung3: Box::new(rung3_err),
+                            });
                         }
                     }
                 }
-            };
+            }
+        };
         let solve_us = solve_start.elapsed().as_micros() as u64;
 
         let rebuild_start = Instant::now();
@@ -306,6 +313,7 @@ impl ShaperState {
             window_segments,
             plan: stats,
             fallback_rung,
+            binding,
         })
     }
 }

--- a/rust/trajectory/tests/binding_report.rs
+++ b/rust/trajectory/tests/binding_report.rs
@@ -1,0 +1,94 @@
+use geometry::segment::{CubicSegment, FollowerDemand, SourceRange};
+use nurbs::VectorNurbs;
+use trajectory::plan_velocity::SafetyMode;
+use trajectory::streaming::{ReplanContext, ShaperState};
+use trajectory::{AxisChainSet, CompiledChain};
+
+fn extruder_chains() -> AxisChainSet {
+    let mut chains = AxisChainSet::passthrough_spatial();
+    chains.chains.push(CompiledChain {
+        kernel: None,
+        gain: 0.0,
+    });
+    chains.followers.push((3, vec![0, 1, 2]));
+    chains
+}
+
+fn extruder_ctx() -> ReplanContext {
+    const E_V_MAX: f64 = 20.0;
+
+    let mut sets = temporal::Limits::axis_boxes([500.0; 3], [5_000.0; 3], [100_000.0; 3])
+        .sets()
+        .to_vec();
+    sets.push(temporal::LimitSet {
+        axes: temporal::AxisSet::from_indices(&[3]),
+        v_max: E_V_MAX,
+        a_max: 1500.0,
+        j_max: 30_000.0,
+    });
+    let limits = temporal::Limits::try_new(&sets, 4).unwrap();
+
+    ReplanContext {
+        limits,
+        chains: extruder_chains(),
+        fit_tolerance_mm: 0.005,
+        beta_max_iters: 5,
+        beta_convergence_ratio: 1.02,
+        worker_threads: 1,
+        grid_strategy: temporal::multi::GridStrategy::Fixed(40),
+        fallback_initial_v: 0.0,
+        safety_mode: SafetyMode::WorstCaseFuture,
+    }
+}
+
+fn extruding_x_segment(start_x: f64, end_x: f64, ratio: f64, feedrate: f64) -> CubicSegment {
+    let p0 = [start_x, 0.0, 0.0];
+    let p3 = [end_x, 0.0, 0.0];
+    let lerp = |t: f64| -> [f64; 3] { [p0[0] + (p3[0] - p0[0]) * t, 0.0, 0.0] };
+    let cps = vec![p0, lerp(1.0 / 3.0), lerp(2.0 / 3.0), p3];
+    let xyz = VectorNurbs::<f64, 3>::try_new(3, vec![0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0], cps)
+        .unwrap();
+    CubicSegment::try_new(
+        xyz,
+        vec![FollowerDemand {
+            axis_index: 3,
+            ratio,
+        }],
+        feedrate,
+        SourceRange {
+            start_line: 0,
+            end_line: 0,
+        },
+        None,
+    )
+    .unwrap()
+}
+
+#[test]
+fn replan_report_carries_binding_summary() {
+    let ctx = extruder_ctx();
+    let mut state = ShaperState::new(&[0.0; 4], &ctx.chains);
+
+    // ratio=1.0 at feedrate=200.0 → follower peak demand 200 mm/s >> E_V_MAX=20 mm/s,
+    // so the follower velocity row pins cruise.
+    let mv = extruding_x_segment(0.0, 50.0, 1.0, 200.0);
+    let report = state.append_and_replan(mv, &ctx).expect("replan solves");
+
+    let worst = report
+        .binding
+        .worst
+        .expect("a velocity-pinned extruding move reports a worst binding");
+    assert!(
+        matches!(
+            worst.constraint,
+            temporal::BindingConstraint::Velocity { .. }
+                | temporal::BindingConstraint::PaVelocity { .. }
+        ),
+        "expected Velocity or PaVelocity worst binding, got {:?}",
+        worst.constraint
+    );
+    assert!(
+        report.binding.histogram.iter().any(|(_, n)| *n > 0),
+        "histogram must have at least one non-zero count"
+    );
+}

--- a/rust/trajectory/tests/binding_report.rs
+++ b/rust/trajectory/tests/binding_report.rs
@@ -69,9 +69,14 @@ fn replan_report_carries_binding_summary() {
     let ctx = extruder_ctx();
     let mut state = ShaperState::new(&[0.0; 4], &ctx.chains);
 
-    // ratio=1.0 at feedrate=200.0 → follower peak demand 200 mm/s >> E_V_MAX=20 mm/s,
-    // so the follower velocity row pins cruise.
-    let mv = extruding_x_segment(0.0, 50.0, 1.0, 200.0);
+    let full_extruder_coupling = 1.0;
+    let feedrate_far_above_e_v_max = 200.0;
+    let mv = extruding_x_segment(
+        0.0,
+        50.0,
+        full_extruder_coupling,
+        feedrate_far_above_e_v_max,
+    );
     let report = state.append_and_replan(mv, &ctx).expect("replan solves");
 
     let worst = report


### PR DESCRIPTION
## Summary

Surfaces the per-grid **binding-constraint** data the planner already computes (which `[limit]` row pins the speed where) up through the trajectory API to motion-bridge, where it is aggregated per print and emitted as structured logs — answering "how often does each limit bind?" and "why is the machine slow here?" from `query-logs`.

The pure planner (`temporal`/`trajectory`) stays **log-free**: binding data is plain returned structs. The decision to emit lives only at the motion-bridge boundary.

- **`temporal`** — `BindingSummary { histogram, worst }` on `TopProfile`, tallied in `check_chain`'s existing verify pass. `worst` excludes jerk-class rows (they ride the loose `EPS_FEAS_JERK` tolerance and would dominate uselessly); histogram keeps all real pins; ordering is deterministic.
- **`trajectory`** — per-batch `ReplanBindingSummary` aggregated onto `ReplanReport`, threaded through `BetaIterResult → PlannedBatch → PlanOutput`. Each chain contributes its histogram **once**, not per slice.
- **`motion-bridge`** — `PlannerConfig::limit_set_names()` + `label_binding` resolve a set index to its config-section name (`runtime_caps` fallback for the appended runtime-cap set; loud `debug_assert!` on unhandled future variants). `BindingAccumulator` records per replan, rolls up on a ~1s cadence, and flushes at stream-open/shutdown, emitting two host-tracing events:
  - `binding_rollup` — one line/window: the worst pin (`limit`, `derivative`, `via_pa`, `ratio`, motion-clock `t`, `window_samples`).
  - `binding_hist` — one line per non-zero `(constraint, set)`: the window's `count`, summable per print.

No `log_codes.rs` edits (host events use free-form `event=` strings, the `replan_stats` precedent). No `klippy/` changes.

## Querying

The `event` field is the **bare** name; `motion` is the separate `subsystem` field:

```
subsystem:=motion event:in(binding_rollup,binding_hist) _time:1h | sort by (_time) desc
event:=binding_hist | stats by (limit, derivative, via_pa) sum(count) as total | sort by (total) desc
```

## Test Plan

- [x] Full Rust suite green (`cargo nextest run`, 1851 passed)
- [x] `./scripts/ci.sh quick` green (ruff, rust tests, clippy `-D warnings`, fmt, watchdog canary)
- [x] Unit + integration + end-to-end coverage: per-profile summary, per-batch aggregation (incl. the once-per-chain regression test), label mapping + fallback, accumulator tally/rollup/flush, and an e2e test reading back `host-rust.jsonl`
- [x] **Verified live on the Trident bench** — a 100 mm X jog produced `binding_hist` (`runtime_caps`/velocity at cruise, `gantry`/jerk on the ramps) and `binding_rollup` (worst velocity pin, `ratio ≈ 1.0`), confirmed via `query-logs`

## Notes / deferred

- Worst-pin location anchor is `state.t_appended` (window-end planner clock); xyz on the worst pin is a deferred additive upgrade.
- A print's final sub-second window may flush at the next stream-open; negligible for "how-often" aggregates.