### PR TITLE
Structured logging: make host-rust log lines filterable in VictoriaLogs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -663,11 +663,11 @@ dependencies = [
  "kalico-native-transport",
  "kalico-protocol",
  "libc",
- "log",
  "runtime",
  "serde",
  "servo-ident",
  "toml 0.8.23",
+ "tracing",
 ]
 
 [[package]]
@@ -701,8 +701,8 @@ dependencies = [
  "env_logger",
  "kalico-protocol",
  "libc",
- "log",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/kalico-ethercat-rt/Cargo.toml
+++ b/rust/kalico-ethercat-rt/Cargo.toml
@@ -39,7 +39,7 @@ runtime = { path = "../runtime", default-features = false, features = ["host"] }
 kalico-protocol = { path = "../kalico-protocol" }
 kalico-native-transport = { path = "../kalico-native-transport" }
 libc = "0.2"                                       # raw clock_gettime(CLOCK_MONOTONIC)
-log = "0.4"
+tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 

--- a/rust/kalico-ethercat-rt/src/curves.rs
+++ b/rust/kalico-ethercat-rt/src/curves.rs
@@ -72,10 +72,12 @@ impl AxisRing {
     pub fn push_from_bytes(&mut self, piece_count: u8, bytes: &[u8]) -> u8 {
         let n = piece_count as usize;
         if bytes.len() < n * 32 {
-            log::warn!(
-                "AxisRing::push_from_bytes: short payload ({} < {})",
-                bytes.len(),
-                n * 32
+            tracing::warn!(
+                subsystem = "ethercat",
+                event = "push_from_bytes_short_payload",
+                payload_len = bytes.len(),
+                required_len = n * 32,
+                "AxisRing::push_from_bytes: short payload"
             );
             return 0;
         }
@@ -83,7 +85,13 @@ impl AxisRing {
         for chunk in bytes[..n * 32].chunks_exact(32) {
             let entry = parse_piece_entry(chunk);
             if self.desc.push(&mut self.storage, entry).is_err() {
-                log::warn!("AxisRing::push_from_bytes: ring full at entry {pushed}/{piece_count}");
+                tracing::warn!(
+                    subsystem = "ethercat",
+                    event = "push_from_bytes_ring_full",
+                    pushed,
+                    piece_count,
+                    "AxisRing::push_from_bytes: ring full"
+                );
                 break;
             }
             pushed += 1;

--- a/rust/kalico-host-rt/src/host_io/events.rs
+++ b/rust/kalico-host-rt/src/host_io/events.rs
@@ -116,7 +116,12 @@ impl RuntimeEventDispatcher {
             match tx.try_send(event) {
                 Ok(()) => {}
                 Err(TrySendError::Full(e)) => {
-                    log::warn!("runtime-event subscriber overflow; dropping: {e:?}");
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "runtime_event_subscriber_overflow",
+                        error = ?e,
+                        "runtime-event subscriber overflow; dropping"
+                    );
                 }
                 Err(TrySendError::Disconnected(_)) => {
                     self.subscriber = None;
@@ -164,7 +169,11 @@ impl HostEventDispatcher {
             match tx.try_send(event) {
                 Ok(()) => {}
                 Err(TrySendError::Full(_)) => {
-                    log::warn!("host-event subscriber overflow; dropping");
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "host_event_subscriber_overflow",
+                        "host-event subscriber overflow; dropping"
+                    );
                 }
                 Err(TrySendError::Disconnected(_)) => {
                     self.subscriber = None;
@@ -268,24 +277,22 @@ impl EventDispatcher {
             }
             RuntimeEvent::Fault(e) => {
                 let signed_code = e.fault_code as i16 as i32;
-                log::warn!(
-                    "[KALICO-FAULT] received FaultEvent \
-                     fault_code={} (wire_u16={}) fault_detail={:#010x} \
-                     segment_id={:#010x} synthesized={} \
-                     (segment_id is the -311 stacked PC = addr2line target: \
-                     the instruction the interrupted context was about to \
-                     execute, i.e. the code holding the CPU/PRIMASK across the \
-                     late tick; 0 for non-311 faults. \
-                     see runtime::error::FaultCode: \
-                     -308=PieceStartInPast -309=RingFull \
-                     -310=StepsPerSampleExceeded -311=TickIntervalExceeded \
-                     -302=MathNonFinite -303=PieceAdvanceUnderflow \
-                     -300=StepQueueOverflow)",
-                    signed_code,
-                    e.fault_code,
-                    e.fault_detail,
-                    e.segment_id,
-                    e.synthesized,
+                tracing::warn!(
+                    subsystem = "mcu-comms",
+                    event = "fault_event_received",
+                    fault_code = signed_code,
+                    wire_u16 = e.fault_code,
+                    fault_detail = e.fault_detail,
+                    segment_id = e.segment_id,
+                    synthesized = e.synthesized,
+                    "[KALICO-FAULT] received FaultEvent (segment_id is the -311 \
+                     stacked PC = addr2line target: the instruction the \
+                     interrupted context was about to execute, i.e. the code \
+                     holding the CPU/PRIMASK across the late tick; 0 for non-311 \
+                     faults; see runtime::error::FaultCode: -308=PieceStartInPast \
+                     -309=RingFull -310=StepsPerSampleExceeded \
+                     -311=TickIntervalExceeded -302=MathNonFinite \
+                     -303=PieceAdvanceUnderflow -300=StepQueueOverflow)"
                 );
                 self.fault_latch.dispatch(e.clone());
                 self.runtime_event_dispatcher

--- a/rust/kalico-host-rt/src/host_io/identify.rs
+++ b/rust/kalico-host-rt/src/host_io/identify.rs
@@ -134,7 +134,12 @@ fn wait_for_klipper_frame(
         match io.poll_frames_until(deadline)? {
             PollOutcome::Frames { frames, errors } => {
                 for e in errors {
-                    log::warn!("identify stream error: {e}");
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "identify_stream_error",
+                        error = %e,
+                        "identify stream error"
+                    );
                 }
                 let mut saw_nak = false;
                 for f in frames {

--- a/rust/kalico-host-rt/src/host_io/kalico_native.rs
+++ b/rust/kalico-host-rt/src/host_io/kalico_native.rs
@@ -111,7 +111,11 @@ pub fn dispatch_kalico_frame(
     payload: &[u8],
 ) -> KalicoDispatchResult {
     let Some((header, body)) = decode_message_header(payload) else {
-        log::warn!("kalico frame too short for per-message header");
+        tracing::warn!(
+            subsystem = "mcu-comms",
+            event = "header_too_short",
+            "kalico frame too short for per-message header"
+        );
         return KalicoDispatchResult::Ignored;
     };
 
@@ -120,7 +124,12 @@ pub fn dispatch_kalico_frame(
     }
 
     let Some(kind) = MessageKind::from_u16(header.kind_raw) else {
-        log::warn!("unknown kalico message kind 0x{:04x}", header.kind_raw);
+        tracing::warn!(
+            subsystem = "mcu-comms",
+            event = "unknown_message_kind",
+            kind_raw = header.kind_raw,
+            "unknown kalico message kind"
+        );
         return KalicoDispatchResult::Ignored;
     };
 
@@ -129,9 +138,11 @@ pub fn dispatch_kalico_frame(
     }
 
     if header.correlation_id == 0 {
-        log::warn!(
-            "kalico control-channel frame with correlation_id=0 (kind 0x{:04x})",
-            header.kind_raw
+        tracing::warn!(
+            subsystem = "mcu-comms",
+            event = "control_frame_zero_correlation_id",
+            kind_raw = header.kind_raw,
+            "kalico control-channel frame with correlation_id=0"
         );
         return KalicoDispatchResult::Ignored;
     }
@@ -142,10 +153,12 @@ pub fn dispatch_kalico_frame(
         }));
         KalicoDispatchResult::Handled
     } else {
-        log::warn!(
-            "no pending kalico call for correlation_id {} (kind 0x{:04x})",
-            header.correlation_id,
-            header.kind_raw
+        tracing::warn!(
+            subsystem = "mcu-comms",
+            event = "no_pending_call",
+            correlation_id = header.correlation_id,
+            kind_raw = header.kind_raw,
+            "no pending kalico call for correlation_id"
         );
         KalicoDispatchResult::Ignored
     }
@@ -153,10 +166,12 @@ pub fn dispatch_kalico_frame(
 
 fn handle_identify_response(state: &mut KalicoNativeState, payload: &[u8]) -> KalicoDispatchResult {
     if payload.len() != BOOTSTRAP_IDENTIFY_RESPONSE_LEN {
-        log::error!(
-            "kalico IdentifyResponse wrong length: got {}, expected {}",
-            payload.len(),
-            BOOTSTRAP_IDENTIFY_RESPONSE_LEN
+        tracing::error!(
+            subsystem = "mcu-comms",
+            event = "identify_response_wrong_length",
+            got = payload.len(),
+            expected = BOOTSTRAP_IDENTIFY_RESPONSE_LEN,
+            "kalico IdentifyResponse wrong length"
         );
         if let Some(c) = state.identify_pending.take() {
             let _ = c.send(Err(TransportError::Parse(format!(
@@ -168,7 +183,11 @@ fn handle_identify_response(state: &mut KalicoNativeState, payload: &[u8]) -> Ka
         return KalicoDispatchResult::Ignored;
     }
     let Some((_cid, resp)) = decode_identify_response(payload) else {
-        log::error!("kalico IdentifyResponse failed to decode");
+        tracing::error!(
+            subsystem = "mcu-comms",
+            event = "identify_response_decode_failed",
+            "kalico IdentifyResponse failed to decode"
+        );
         if let Some(c) = state.identify_pending.take() {
             let _ = c.send(Err(TransportError::Parse(
                 "IdentifyResponse failed to decode".into(),
@@ -182,7 +201,12 @@ fn handle_identify_response(state: &mut KalicoNativeState, payload: &[u8]) -> Ka
             "kalico proto_version mismatch — host 0x{:02x}, MCU 0x{:02x}",
             PROTO_VERSION, resp.proto_version
         );
-        log::error!("{msg}");
+        tracing::error!(
+            subsystem = "mcu-comms",
+            event = "proto_version_mismatch",
+            error = %msg,
+            "kalico proto_version mismatch"
+        );
         if let Some(c) = state.identify_pending.take() {
             let _ = c.send(Err(TransportError::Parse(msg)));
         }
@@ -192,7 +216,12 @@ fn handle_identify_response(state: &mut KalicoNativeState, payload: &[u8]) -> Ka
         let host_hex = hex32(&SCHEMA_HASH);
         let mcu_hex = hex32(&resp.schema_hash);
         let msg = format!("kalico schema_hash mismatch — host {host_hex}, MCU {mcu_hex}");
-        log::error!("{msg}");
+        tracing::error!(
+            subsystem = "mcu-comms",
+            event = "schema_hash_mismatch",
+            error = %msg,
+            "kalico schema_hash mismatch"
+        );
         if let Some(c) = state.identify_pending.take() {
             let _ = c.send(Err(TransportError::Parse(msg)));
         }
@@ -215,10 +244,12 @@ fn handle_identify_response(state: &mut KalicoNativeState, payload: &[u8]) -> Ka
         state_epoch = ?state.reset_epoch,
         "kalico identify complete"
     );
-    log::info!(
-        "kalico identified: reset_epoch=0x{:08x}, caps=0x{:016x}, schema_hash matches",
-        resp.reset_epoch,
-        resp.capabilities,
+    tracing::info!(
+        subsystem = "mcu-comms",
+        event = "identified",
+        reset_epoch = resp.reset_epoch,
+        capabilities = resp.capabilities,
+        "kalico identified, schema_hash matches"
     );
     KalicoDispatchResult::Handled
 }
@@ -238,7 +269,12 @@ fn lift_event_to_runtime_event(
                 synthesized: false,
             })),
             Err(e) => {
-                log::warn!("kalico FaultEvent decode failed: {e:?}");
+                tracing::warn!(
+                    subsystem = "mcu-comms",
+                    event = "fault_event_decode_failed",
+                    error = ?e,
+                    "kalico FaultEvent decode failed"
+                );
                 KalicoDispatchResult::Ignored
             }
         },
@@ -247,7 +283,12 @@ fn lift_event_to_runtime_event(
                 retired_counts: hb.retired_counts,
             }),
             Err(e) => {
-                log::warn!("kalico StatusHeartbeat decode failed: {e:?}");
+                tracing::warn!(
+                    subsystem = "mcu-comms",
+                    event = "status_heartbeat_decode_failed",
+                    error = ?e,
+                    "kalico StatusHeartbeat decode failed"
+                );
                 KalicoDispatchResult::Ignored
             }
         },
@@ -263,7 +304,12 @@ fn lift_event_to_runtime_event(
                 host_recv: Instant::now(),
             })),
             Err(e) => {
-                log::warn!("kalico McuLog decode failed: {e:?}");
+                tracing::warn!(
+                    subsystem = "mcu-comms",
+                    event = "mcu_log_decode_failed",
+                    error = ?e,
+                    "kalico McuLog decode failed"
+                );
                 KalicoDispatchResult::Ignored
             }
         },
@@ -273,12 +319,22 @@ fn lift_event_to_runtime_event(
                 trip_clock: t.trip_clock,
             })),
             Err(e) => {
-                log::warn!("kalico EndstopTrip decode failed: {e:?}");
+                tracing::warn!(
+                    subsystem = "mcu-comms",
+                    event = "endstop_trip_decode_failed",
+                    error = ?e,
+                    "kalico EndstopTrip decode failed"
+                );
                 KalicoDispatchResult::Ignored
             }
         },
         _ => {
-            log::warn!("unexpected event kind on events channel: {kind:?}");
+            tracing::warn!(
+                subsystem = "mcu-comms",
+                event = "unexpected_event_kind",
+                kind = ?kind,
+                "unexpected event kind on events channel"
+            );
             KalicoDispatchResult::Ignored
         }
     }

--- a/rust/kalico-host-rt/src/host_io/reactor.rs
+++ b/rust/kalico-host-rt/src/host_io/reactor.rs
@@ -329,9 +329,11 @@ impl Reactor {
     ) -> Result<(), TransportError> {
         if self.unacked_window.is_full() {
             if self.pending_fire_and_forget.len() >= PENDING_FIRE_AND_FORGET_CEILING {
-                log::error!(
-                    "dispatch_fire_and_forget: pending_fire_and_forget at ceiling ({}); refusing payload",
-                    PENDING_FIRE_AND_FORGET_CEILING,
+                tracing::error!(
+                    subsystem = "mcu-comms",
+                    event = "fire_and_forget_ceiling",
+                    ceiling = PENDING_FIRE_AND_FORGET_CEILING,
+                    "dispatch_fire_and_forget: pending_fire_and_forget at ceiling; refusing payload"
                 );
                 return Err(TransportError::Backpressure);
             }
@@ -379,7 +381,11 @@ impl Reactor {
             match kind {
                 PendingOutboundKind::Submission => {
                     let Some(p) = self.pending_submissions.pop_front() else {
-                        log::error!("pending outbound order referenced missing submission");
+                        tracing::error!(
+                            subsystem = "mcu-comms",
+                            event = "outbound_order_missing_submission",
+                            "pending outbound order referenced missing submission"
+                        );
                         continue;
                     };
                     let completion = p.completion.clone();
@@ -410,7 +416,11 @@ impl Reactor {
                 PendingOutboundKind::FireAndForget => {
                     let Some((payload, is_get_clock)) = self.pending_fire_and_forget.pop_front()
                     else {
-                        log::error!("pending outbound order referenced missing fire-and-forget");
+                        tracing::error!(
+                            subsystem = "mcu-comms",
+                            event = "outbound_order_missing_fire_and_forget",
+                            "pending outbound order referenced missing fire-and-forget"
+                        );
                         continue;
                     };
                     if let Err(e) = self.dispatch_fire_and_forget(payload, is_get_clock) {
@@ -427,8 +437,11 @@ impl Reactor {
                             self.state = ReactorState::Closed;
                             return;
                         }
-                        log::warn!(
-                            "drain_pending_submissions: fire-and-forget redispatch error: {e}"
+                        tracing::warn!(
+                            subsystem = "mcu-comms",
+                            event = "fire_and_forget_redispatch_error",
+                            error = %e,
+                            "drain_pending_submissions: fire-and-forget redispatch error"
                         );
                     }
                 }
@@ -821,7 +834,12 @@ impl Reactor {
                     self.last_recv_time = self.clock.now();
                 }
                 for e in errors {
-                    log::warn!("kalico stream error: {e}");
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "kalico_stream_error",
+                        error = %e,
+                        "kalico stream error"
+                    );
                 }
                 for f in frames {
                     match f {
@@ -847,11 +865,14 @@ impl Reactor {
                 if now.duration_since(first) >= ZERO_BYTE_DEBOUNCE {
                     let silence_ms = now.duration_since(self.last_recv_time).as_millis();
                     let since_write_ms = now.duration_since(self.last_write_time).as_millis();
-                    log::warn!(
-                        "[usb-drop] silence_ms={} since_write_ms={} consec_zero={} err=PhantomZero(Ok(0) for >={ZERO_BYTE_DEBOUNCE:?})",
-                        silence_ms,
-                        since_write_ms,
-                        self.zero_byte_consec,
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "usb_drop_phantom_zero",
+                        silence_ms = %silence_ms,
+                        since_write_ms = %since_write_ms,
+                        consec_zero = self.zero_byte_consec,
+                        debounce = ?ZERO_BYTE_DEBOUNCE,
+                        "[usb-drop] PhantomZero (Ok(0) past debounce window)"
                     );
                     self.pending_host_fault = Some(crate::host_io::runtime_events::FaultEvent {
                         fault_code: FaultCode::HostDisconnect.as_u16(),
@@ -866,12 +887,14 @@ impl Reactor {
                 let now = self.clock.now();
                 let silence_ms = now.duration_since(self.last_recv_time).as_millis();
                 let since_write_ms = now.duration_since(self.last_write_time).as_millis();
-                log::warn!(
-                    "[usb-drop] silence_ms={} since_write_ms={} consec_zero={} err={:?}",
-                    silence_ms,
-                    since_write_ms,
-                    self.zero_byte_consec,
-                    e,
+                tracing::warn!(
+                    subsystem = "mcu-comms",
+                    event = "usb_drop_poll_error",
+                    silence_ms = %silence_ms,
+                    since_write_ms = %since_write_ms,
+                    consec_zero = self.zero_byte_consec,
+                    error = ?e,
+                    "[usb-drop] poll error"
                 );
                 self.pending_host_fault = Some(crate::host_io::runtime_events::FaultEvent {
                     fault_code: FaultCode::HostDisconnect.as_u16(),
@@ -1067,7 +1090,12 @@ impl Reactor {
             ReactorCommand::FireAndForgetTyped { payload } => {
                 if let Err(e) = self.dispatch_fire_and_forget(payload, false) {
                     let is_io = matches!(e, TransportError::Io(_));
-                    log::warn!("FireAndForgetTyped: send error: {e}");
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "fire_and_forget_typed_send_error",
+                        error = %e,
+                        "FireAndForgetTyped: send error"
+                    );
                     if is_io {
                         self.transition_closed_on_io_fault();
                     }
@@ -1314,7 +1342,12 @@ impl Reactor {
                         "retransmit error"
                     );
                     if matches!(e, TransportError::Io(_)) {
-                        log::warn!("retransmit Io error: {e:?}; transitioning Closed");
+                        tracing::warn!(
+                            subsystem = "mcu-comms",
+                            event = "retransmit_io_error",
+                            error = ?e,
+                            "retransmit Io error; transitioning Closed"
+                        );
                         self.transition_closed_on_io_fault();
                     }
                 }

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -338,16 +338,17 @@ impl PassthroughRouter {
         let bridge_now_instant = instant_to_f64(self.clock.now());
         let bridge_now_raw = crate::clock::monotonic_raw_secs();
         let clock_offset = offset_raw - (bridge_now_raw - bridge_now_instant);
-        log::info!(
-            "[clock-seed] set_clock_est_rebased mcu={:?} freq={:.1} offset_raw={:.9} \
-             bridge_now_raw={:.9} bridge_now_instant={:.9} clock_offset={:.9} last_clock={}",
-            mcu,
+        tracing::info!(
+            subsystem = "clocksync",
+            event = "set_clock_est_rebased",
+            mcu = ?mcu,
             freq,
             offset_raw,
             bridge_now_raw,
             bridge_now_instant,
             clock_offset,
-            last_clock
+            last_clock,
+            "[clock-seed] set_clock_est_rebased"
         );
         let rec = self
             .mcus

--- a/rust/kalico-host-rt/src/passthrough_queue/router.rs
+++ b/rust/kalico-host-rt/src/passthrough_queue/router.rs
@@ -296,12 +296,14 @@ impl PassthroughRouter {
         offset: f64,
         last_clock: u64,
     ) -> Result<(), RouterError> {
-        log::info!(
-            "[clock-seed] set_clock_est mcu={:?} freq={:.1} offset={:.9} last_clock={}",
-            mcu,
+        tracing::info!(
+            subsystem = "clocksync",
+            event = "set_clock_est",
+            mcu = ?mcu,
             freq,
             offset,
-            last_clock
+            last_clock,
+            "[clock-seed] set_clock_est"
         );
         let rec = self
             .mcus
@@ -368,13 +370,14 @@ impl PassthroughRouter {
         mcu_at_send: u64,
     ) -> Result<(), RouterError> {
         let clock_offset = instant_to_f64(host_send);
-        log::info!(
-            "[clock-seed] set_clock_est_from_sample mcu={:?} freq={:.1} \
-             clock_offset={:.9} mcu_at_send={}",
-            mcu,
+        tracing::info!(
+            subsystem = "clocksync",
+            event = "set_clock_est_from_sample",
+            mcu = ?mcu,
             freq,
             clock_offset,
-            mcu_at_send
+            mcu_at_send,
+            "[clock-seed] set_clock_est_from_sample"
         );
         let rec = self
             .mcus
@@ -484,15 +487,16 @@ impl PassthroughRouter {
         let delta = (host_time_secs - rec.clock_offset) * rec.clock_freq;
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let projected = rec.last_clock.wrapping_add(delta.max(0.0) as u64);
-        log::trace!(
-            "[project] host_time_to_mcu_clock mcu={:?} host_secs={:.9} clock_offset={:.9} \
-             last_clock={} clock_freq={:.1} result_ns={}",
-            mcu,
+        tracing::trace!(
+            subsystem = "motion",
+            event = "host_time_to_mcu_clock",
+            mcu = ?mcu,
             host_time_secs,
-            rec.clock_offset,
-            rec.last_clock,
-            rec.clock_freq,
-            projected
+            clock_offset = rec.clock_offset,
+            last_clock = rec.last_clock,
+            clock_freq = rec.clock_freq,
+            result_ns = projected,
+            "[project] host_time_to_mcu_clock"
         );
         Ok(projected)
     }
@@ -501,16 +505,23 @@ impl PassthroughRouter {
         let rec = match self.mcus.get(&mcu) {
             Some(r) => r,
             None => {
-                log::warn!("[seg0-deficit] mcu={:?} UNKNOWN", mcu);
+                tracing::warn!(
+                    subsystem = "motion",
+                    event = "seg0_deficit_unknown_mcu",
+                    mcu = ?mcu,
+                    "[seg0-deficit] UNKNOWN mcu"
+                );
                 return;
             }
         };
         if rec.clock_freq == 0.0 {
-            log::warn!(
-                "[seg0-deficit] mcu={:?} clock_freq=0 (not yet synced) t0={:.6} seg0_host={:.6}",
-                mcu,
+            tracing::warn!(
+                subsystem = "motion",
+                event = "seg0_deficit_not_synced",
+                mcu = ?mcu,
                 t0,
-                seg0_host_secs
+                seg0_host_secs,
+                "[seg0-deficit] clock_freq=0 (not yet synced)"
             );
             return;
         }
@@ -520,18 +531,20 @@ impl PassthroughRouter {
         let ack_now = self.compute_ack_clock(mcu).unwrap_or(0);
         let deficit_ticks = start_time as i64 - ack_now as i64;
         let deficit_us = (deficit_ticks as f64 / rec.clock_freq) * 1e6;
-        log::warn!(
-            "[seg0-deficit] mcu={:?} freq={:.1} offset={:.6} last_clock={} t0={:.6} seg0_host={:.6} start_time={} ack_now={} deficit_ticks={} deficit_us={:.1} (negative=>in past)",
-            mcu,
-            rec.clock_freq,
-            rec.clock_offset,
-            rec.last_clock,
+        tracing::warn!(
+            subsystem = "motion",
+            event = "seg0_deficit",
+            mcu = ?mcu,
+            freq = rec.clock_freq,
+            offset = rec.clock_offset,
+            last_clock = rec.last_clock,
             t0,
             seg0_host_secs,
             start_time,
             ack_now,
             deficit_ticks,
-            deficit_us
+            deficit_us,
+            "[seg0-deficit] (negative deficit_us => in past)"
         );
     }
 

--- a/rust/kalico-host-rt/src/unix_native_conn.rs
+++ b/rust/kalico-host-rt/src/unix_native_conn.rs
@@ -285,7 +285,12 @@ fn route_frame(
         pending.waiters.remove(&cid)
     };
     let Some(tx) = tx else {
-        log::warn!("UnixNativeConn: response for unknown correlation_id {cid} dropped");
+        tracing::warn!(
+            subsystem = "mcu-comms",
+            event = "unknown_correlation_id",
+            correlation_id = cid,
+            "UnixNativeConn: response for unknown correlation_id dropped"
+        );
         return;
     };
     let result = match MessageKind::from_u16(hdr.kind_raw) {

--- a/rust/kalico-native-transport/Cargo.toml
+++ b/rust/kalico-native-transport/Cargo.toml
@@ -8,7 +8,7 @@ description = "Kalico-native transport (host side): Layer 1 framer, stream-level
 license.workspace = true
 
 [dependencies]
-log = "0.4"
+tracing = "0.1"
 thiserror = { workspace = true }
 crossbeam-channel = "0.5"
 kalico-protocol = { path = "../kalico-protocol" }

--- a/rust/kalico-native-transport/src/demux.rs
+++ b/rust/kalico-native-transport/src/demux.rs
@@ -189,7 +189,12 @@ impl Demuxer {
                 }
                 KLIPPER_INTERFRAME_SYNC => Ok(None),
                 other => {
-                    log::trace!("demuxer: dropping out-of-frame byte 0x{other:02x}");
+                    tracing::trace!(
+                        subsystem = "mcu-comms",
+                        event = "out_of_frame_byte_dropped",
+                        byte = other,
+                        "demuxer: dropping out-of-frame byte"
+                    );
                     Ok(None)
                 }
             },

--- a/rust/kalico-native-transport/src/transport.rs
+++ b/rust/kalico-native-transport/src/transport.rs
@@ -209,7 +209,12 @@ impl<C: Connection + 'static> KalicoNativeTransport<C> {
     }
 
     fn dispatch_error(&self, e: StreamError) {
-        log::warn!("kalico stream error: {e}");
+        tracing::warn!(
+            subsystem = "mcu-comms",
+            event = "kalico_stream_error",
+            error = %e,
+            "kalico stream error"
+        );
     }
 
     fn dispatch_frame(&self, f: Frame) {
@@ -223,7 +228,11 @@ impl<C: Connection + 'static> KalicoNativeTransport<C> {
 
     fn dispatch_kalico(&self, channel: u8, payload: &[u8]) {
         let Some((header, body)) = decode_message_header(payload) else {
-            log::warn!("kalico frame too short for header");
+            tracing::warn!(
+                subsystem = "mcu-comms",
+                event = "frame_too_short",
+                "kalico frame too short for header"
+            );
             return;
         };
         let kind_raw = header.kind_raw;
@@ -235,11 +244,21 @@ impl<C: Connection + 'static> KalicoNativeTransport<C> {
             *self.inner.state.lock().unwrap(),
             ConnectionState::Identified { .. }
         ) {
-            log::trace!("dropping kalico frame in non-Identified state, kind 0x{kind_raw:04x}");
+            tracing::trace!(
+                subsystem = "mcu-comms",
+                event = "frame_dropped_non_identified",
+                kind_raw = kind_raw,
+                "dropping kalico frame in non-Identified state"
+            );
             return;
         }
         let Some(kind) = MessageKind::from_u16(kind_raw) else {
-            log::warn!("unknown kalico message kind 0x{kind_raw:04x}");
+            tracing::warn!(
+                subsystem = "mcu-comms",
+                event = "unknown_message_kind",
+                kind_raw = kind_raw,
+                "unknown kalico message kind"
+            );
             return;
         };
 
@@ -252,7 +271,12 @@ impl<C: Connection + 'static> KalicoNativeTransport<C> {
         }
 
         if header.correlation_id == 0 {
-            log::warn!("control-channel response with correlation_id=0 (kind 0x{kind_raw:04x})");
+            tracing::warn!(
+                subsystem = "mcu-comms",
+                event = "response_zero_correlation_id",
+                kind_raw = kind_raw,
+                "control-channel response with correlation_id=0"
+            );
             return;
         }
         let mut pending = self.inner.pending.lock().unwrap();
@@ -262,10 +286,12 @@ impl<C: Connection + 'static> KalicoNativeTransport<C> {
                 body: body.to_vec(),
             });
         } else {
-            log::warn!(
-                "no pending call for correlation_id {} (kind 0x{:04x})",
-                header.correlation_id,
-                kind_raw
+            tracing::warn!(
+                subsystem = "mcu-comms",
+                event = "no_pending_call",
+                correlation_id = header.correlation_id,
+                kind_raw = kind_raw,
+                "no pending call for correlation_id"
             );
         }
     }
@@ -320,7 +346,12 @@ impl<C: Connection + 'static> KalicoNativeTransport<C> {
     }
 
     fn fault(&self, msg: String) {
-        log::error!("kalico transport faulted: {msg}");
+        tracing::error!(
+            subsystem = "mcu-comms",
+            event = "transport_faulted",
+            fault = %msg,
+            "kalico transport faulted"
+        );
         *self.inner.state.lock().unwrap() = ConnectionState::Faulted(msg.clone());
         let drained: Vec<PendingCall> = {
             let mut p = self.inner.pending.lock().unwrap();

--- a/rust/motion-bridge/src/bridge.rs
+++ b/rust/motion-bridge/src/bridge.rs
@@ -1199,10 +1199,11 @@ impl PyMotionBridge {
                 if Instant::now() >= reap_deadline {
                     let _ = child.kill();
                     let _ = child.wait();
-                    log::warn!(
-                        "release_mcu: ethercat endpoint (pid {}) did not exit \
-                         within 5 s after SIGTERM — SIGKILL sent",
-                        pid
+                    tracing::warn!(
+                        subsystem = "bridge",
+                        event = "release_mcu_endpoint_sigkill",
+                        pid,
+                        "release_mcu: ethercat endpoint did not exit within 5 s after SIGTERM — SIGKILL sent"
                     );
                     break;
                 }
@@ -1259,7 +1260,11 @@ impl PyMotionBridge {
     ///   sends silently return `Err` and are discarded by the callback — harmless.
     fn shutdown(&self) {
         if self.shut_down.swap(true, Ordering::SeqCst) {
-            log::debug!("bridge.shutdown() called twice (idempotent no-op)");
+            tracing::debug!(
+                subsystem = "bridge",
+                event = "shutdown_called_twice",
+                "bridge.shutdown() called twice (idempotent no-op)"
+            );
             return;
         }
 
@@ -1295,7 +1300,12 @@ impl PyMotionBridge {
         };
         if let Some(h) = pump_join {
             if let Err(e) = h.join() {
-                log::error!("bridge.shutdown(): push-pieces-pump join panicked: {e:?}");
+                tracing::error!(
+                    subsystem = "bridge",
+                    event = "shutdown_pump_join_panicked",
+                    error = ?e,
+                    "bridge.shutdown(): push-pieces-pump join panicked"
+                );
             }
         }
 
@@ -1309,7 +1319,13 @@ impl PyMotionBridge {
         for h in handles {
             if let Err(e) = self.release_mcu(h) {
                 // Fail loud: a release error means an fd / child may be leaked.
-                log::error!("bridge.shutdown(): release_mcu({h}) failed: {e}");
+                tracing::error!(
+                    subsystem = "bridge",
+                    event = "shutdown_release_mcu_failed",
+                    mcu_handle = h,
+                    error = %e,
+                    "bridge.shutdown(): release_mcu failed"
+                );
             }
         }
     }
@@ -1527,9 +1543,11 @@ impl PyMotionBridge {
             };
             if let Some(io) = existing_io {
                 if io.is_alive() {
-                    log::info!(
-                        "attach_serial: reusing existing connection for {serial_path} \
-                         (reactor alive, skipping close/reopen)"
+                    tracing::info!(
+                        subsystem = "mcu-comms",
+                        event = "attach_reuse_connection",
+                        serial_path,
+                        "attach_serial: reusing existing connection (reactor alive, skipping close/reopen)"
                     );
 
                     let runtime_rx = io.take_runtime_event_subscription().map_err(|e| {
@@ -1539,27 +1557,33 @@ impl PyMotionBridge {
                     })?;
 
                     let (kalico_native_supported, identify_caps) = if !expect_native {
-                        log::info!(
-                            "attach_serial: kalico identify skipped on reuse for \
-                             {serial_path} (plugin-attached peripheral, not declared \
-                             via an [mcu] section)"
+                        tracing::info!(
+                            subsystem = "mcu-comms",
+                            event = "attach_identify_skipped_reuse",
+                            serial_path,
+                            "attach_serial: kalico identify skipped on reuse (plugin-attached peripheral, not declared via an [mcu] section)"
                         );
                         (false, 0u64)
                     } else {
                         match io.kalico_identify(std::time::Duration::from_secs(5)) {
                             Ok(out) => {
-                                log::info!(
-                                    "attach_serial: kalico re-identified — \
-                                     reset_epoch=0x{:08x} caps=0x{:016x}",
-                                    out.reset_epoch,
-                                    out.capabilities,
+                                tracing::info!(
+                                    subsystem = "mcu-comms",
+                                    event = "attach_reidentified",
+                                    serial_path,
+                                    reset_epoch = out.reset_epoch,
+                                    capabilities = out.capabilities,
+                                    "attach_serial: kalico re-identified (reset_epoch/caps as hex)"
                                 );
                                 (true, out.capabilities)
                             }
                             Err(e) => {
-                                log::warn!(
-                                    "attach_serial: kalico_identify timed out on reuse \
-                                     for {serial_path} ({e}); treating as Klipper-protocol-only"
+                                tracing::warn!(
+                                    subsystem = "mcu-comms",
+                                    event = "attach_identify_timeout_reuse",
+                                    serial_path,
+                                    error = %e,
+                                    "attach_serial: kalico_identify timed out on reuse; treating as Klipper-protocol-only"
                                 );
                                 (false, 0u64)
                             }
@@ -1569,10 +1593,12 @@ impl PyMotionBridge {
                     let runtime_caps = if kalico_native_supported {
                         match query_runtime_caps(&io, std::time::Duration::from_secs(2)) {
                             Ok(caps) => {
-                                log::debug!(
-                                    "[caps-trace] attach_serial reuse: runtime caps \
-                                     for {serial_path}: total_piece_memory={}",
-                                    caps.total_piece_memory,
+                                tracing::debug!(
+                                    subsystem = "mcu-comms",
+                                    event = "attach_runtime_caps_reuse",
+                                    serial_path,
+                                    total_piece_memory = caps.total_piece_memory,
+                                    "[caps-trace] attach_serial reuse: runtime caps"
                                 );
                                 Some(caps)
                             }
@@ -1591,10 +1617,14 @@ impl PyMotionBridge {
 
                     let critical = kalico_native_supported && !klippy_non_critical;
                     io.set_critical(critical);
-                    log::info!(
-                        "attach_serial: reuse — {serial_path} criticality \
-                         critical={critical} (kalico_native={kalico_native_supported} \
-                         klippy_non_critical={klippy_non_critical})"
+                    tracing::info!(
+                        subsystem = "mcu-comms",
+                        event = "attach_criticality_reuse",
+                        serial_path,
+                        critical,
+                        kalico_native = kalico_native_supported,
+                        klippy_non_critical,
+                        "attach_serial: reuse — criticality set"
                     );
 
                     let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
@@ -1651,7 +1681,13 @@ impl PyMotionBridge {
                             "attach_serial: could not open {serial_path} within {timeout_s}s: {e}"
                         )));
                     }
-                    log::warn!("attach_serial: retrying {serial_path}: {e}");
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "attach_open_retry",
+                        serial_path,
+                        error = %e,
+                        "attach_serial: retrying open"
+                    );
                     std::thread::sleep(Duration::from_millis(500));
                 }
             }
@@ -1662,26 +1698,33 @@ impl PyMotionBridge {
         })?;
 
         let (kalico_native_supported, identify_caps) = if !expect_native {
-            log::info!(
-                "attach_serial: kalico identify skipped for {serial_path} \
-                 (plugin-attached peripheral, not declared via an [mcu] section)"
+            tracing::info!(
+                subsystem = "mcu-comms",
+                event = "attach_identify_skipped",
+                serial_path,
+                "attach_serial: kalico identify skipped (plugin-attached peripheral, not declared via an [mcu] section)"
             );
             (false, 0u64)
         } else {
             match host_io.kalico_identify(std::time::Duration::from_secs(5)) {
                 Ok(out) => {
-                    log::info!(
-                        "attach_serial: kalico identified — reset_epoch=0x{:08x} \
-                         caps=0x{:016x}",
-                        out.reset_epoch,
-                        out.capabilities,
+                    tracing::info!(
+                        subsystem = "mcu-comms",
+                        event = "attach_identified",
+                        serial_path,
+                        reset_epoch = out.reset_epoch,
+                        capabilities = out.capabilities,
+                        "attach_serial: kalico identified (reset_epoch/caps as hex)"
                     );
                     (true, out.capabilities)
                 }
                 Err(e) => {
-                    log::warn!(
-                        "attach_serial: kalico_identify timed out for {serial_path} ({e}); \
-                         continuing attach as a Klipper-protocol-only MCU"
+                    tracing::warn!(
+                        subsystem = "mcu-comms",
+                        event = "attach_identify_timeout",
+                        serial_path,
+                        error = %e,
+                        "attach_serial: kalico_identify timed out; continuing attach as a Klipper-protocol-only MCU"
                     );
                     (false, 0u64)
                 }
@@ -1691,10 +1734,12 @@ impl PyMotionBridge {
         let runtime_caps = if kalico_native_supported {
             match query_runtime_caps(&host_io, std::time::Duration::from_secs(2)) {
                 Ok(caps) => {
-                    log::debug!(
-                        "[caps-trace] attach_serial: runtime caps for {serial_path}: \
-                         total_piece_memory={}",
-                        caps.total_piece_memory,
+                    tracing::debug!(
+                        subsystem = "mcu-comms",
+                        event = "attach_runtime_caps",
+                        serial_path,
+                        total_piece_memory = caps.total_piece_memory,
+                        "[caps-trace] attach_serial: runtime caps"
                     );
                     Some(caps)
                 }
@@ -1713,10 +1758,14 @@ impl PyMotionBridge {
 
         let critical = kalico_native_supported && !klippy_non_critical;
         host_io.set_critical(critical);
-        log::info!(
-            "attach_serial: {serial_path} criticality critical={critical} \
-             (kalico_native={kalico_native_supported} \
-             klippy_non_critical={klippy_non_critical})"
+        tracing::info!(
+            subsystem = "mcu-comms",
+            event = "attach_criticality",
+            serial_path,
+            critical,
+            kalico_native = kalico_native_supported,
+            klippy_non_critical,
+            "attach_serial: criticality set"
         );
 
         let host_io_arc = Arc::new(host_io);
@@ -1760,9 +1809,12 @@ impl PyMotionBridge {
                         host_io_arc.set_mcu_log_hook(Box::new(hook));
                     }
                     Err(e) => {
-                        log::warn!(
-                            "attach_serial: mcu-log: failed to open {}: {e}",
-                            jsonl_path.display()
+                        tracing::warn!(
+                            subsystem = "mcu-comms",
+                            event = "attach_mcu_log_open_failed",
+                            jsonl_path = %jsonl_path.display(),
+                            error = %e,
+                            "attach_serial: mcu-log: failed to open jsonl writer"
                         );
                     }
                 }
@@ -2228,13 +2280,15 @@ impl PyMotionBridge {
         static SET_CLOCK_EST_CALLS: AtomicUsize = AtomicUsize::new(0);
         let call_n = SET_CLOCK_EST_CALLS.fetch_add(1, AOrd::Relaxed);
         if call_n < 5 || call_n % 100 == 0 {
-            log::debug!(
-                "[bridge-trace] set_clock_est call#{} mcu={} freq={} offset={:.6} last_clock={}",
+            tracing::debug!(
+                subsystem = "bridge",
+                event = "set_clock_est",
                 call_n,
                 mcu,
-                freq as u64,
+                freq = freq as u64,
                 offset,
                 last_clock,
+                "[bridge-trace] set_clock_est"
             );
         }
         let mut router = self.router.lock().unwrap_or_else(|p| p.into_inner());
@@ -2412,10 +2466,12 @@ impl PyMotionBridge {
                                  RuntimeCapsResponse; is kalico-ethercat-rt running?"
                         ))
                     })?;
-                log::debug!(
-                    "[caps-trace] init_planner: ethercat mcu {mcu_id} caps \
-                     total_piece_memory={}",
-                    caps.total_piece_memory,
+                tracing::debug!(
+                    subsystem = "bridge",
+                    event = "init_planner_ethercat_caps",
+                    mcu_id,
+                    total_piece_memory = caps.total_piece_memory,
+                    "[caps-trace] init_planner: ethercat mcu caps"
                 );
                 {
                     let mut mcus_lock = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
@@ -2563,10 +2619,11 @@ impl PyMotionBridge {
                             .get(&k)
                             .copied()
                             .unwrap_or_else(|| {
-                                log::error!(
-                                    "pump: no ring_depth for {k:?} — axis absent from \
-                                 init_planner config; using sentinel depth 1 \
-                                 (expect PieceStartInPast fault)"
+                                tracing::error!(
+                                    subsystem = "bridge",
+                                    event = "pump_missing_ring_depth",
+                                    axis_key = ?k,
+                                    "pump: no ring_depth for axis — absent from init_planner config; using sentinel depth 1 (expect PieceStartInPast fault)"
                                 );
                                 1
                             })
@@ -2807,10 +2864,12 @@ impl PyMotionBridge {
             dyn Fn(&trajectory::ShapedSegment) -> Result<(), DispatchError> + Send + Sync,
         > = Arc::new(
             move |seg: &trajectory::ShapedSegment| -> Result<(), DispatchError> {
-                log::debug!(
-                    "[bridge-trace] dispatch entered: seg.t_start={:.6} seg.t_end={:.6}",
-                    seg.t_start,
-                    seg.t_end,
+                tracing::debug!(
+                    subsystem = "bridge",
+                    event = "dispatch_entered",
+                    seg_t_start = seg.t_start,
+                    seg_t_end = seg.t_end,
+                    "[bridge-trace] dispatch entered"
                 );
 
                 let host_now = {

--- a/rust/motion-bridge/src/planner.rs
+++ b/rust/motion-bridge/src/planner.rs
@@ -349,12 +349,12 @@ fn rectify_last_move_time(last_move_time_bits: &AtomicU64, delta: f64) -> bool {
             return true;
         }
     }
-    log::debug!(
-        "planner: rectification CAS contended for >{} attempts (delta {} s) — \
-         giving up on this delta; the atomic will reflect the next \
-         caller-side advance only",
-        RECTIFICATION_CAS_MAX_ATTEMPTS,
+    tracing::debug!(
+        subsystem = "motion",
+        event = "rectify_cas_contended",
+        max_attempts = RECTIFICATION_CAS_MAX_ATTEMPTS,
         delta,
+        "planner: rectification CAS contended — giving up on this delta"
     );
     false
 }
@@ -412,14 +412,16 @@ fn run_commit_and_dispatch(
         }
     }
     commit_fire_count.fetch_add(1, Ordering::AcqRel);
-    log::debug!(
-        "[planner-trace] commit drained={} dur_s={:.6} commit_us={} t_app={:.6} t_disp_before={:.6} t_disp_after={:.6}",
-        drained.len(),
-        batch_dur,
-        commit_us,
-        t_app_before,
+    tracing::debug!(
+        subsystem = "motion",
+        event = "commit_trace",
+        drained = drained.len(),
+        dur_s = batch_dur,
+        commit_us = %commit_us,
+        t_app = t_app_before,
         t_disp_before,
-        state.t_dispatched,
+        t_disp_after = state.t_dispatched,
+        "[planner-trace] commit"
     );
 }
 
@@ -461,7 +463,12 @@ fn run_loop(
         let tl = config
             .to_temporal_limits()
             .expect("limit sections validated in init_planner");
-        log::debug!("[planner-trace] startup limits {:?}", tl.sets());
+        tracing::debug!(
+            subsystem = "motion",
+            event = "startup_limits",
+            limits = ?tl.sets(),
+            "[planner-trace] startup limits"
+        );
     }
 
     let mut last_recv_time: Option<Instant> = None;

--- a/rust/motion-bridge/src/pump.rs
+++ b/rust/motion-bridge/src/pump.rs
@@ -323,9 +323,16 @@ fn check_junction_position_continuity(
         );
     }
     if jump >= JUNCTION_POSITION_LOG_MM {
-        log::error!(
-            "[junction-pos] key={key:?} prev_end={prev_end_pos} next_start={next_start_pos} \
-             jump_mm={jump} prev_end_host={prev_end_host:.6} next_start_host={next_start_host:.6}"
+        tracing::error!(
+            subsystem = "motion",
+            event = "junction_position_discontinuity",
+            key = ?key,
+            prev_end = prev_end_pos,
+            next_start = next_start_pos,
+            jump_mm = jump,
+            prev_end_host = prev_end_host,
+            next_start_host = next_start_host,
+            "[junction-pos] position discontinuity"
         );
     }
 }
@@ -454,12 +461,14 @@ pub fn run_pump<S, F, C, A, O, D>(
                             let anomalous =
                                 tick_jump_us < -50.0 || (tick_jump_us - host_jump_us).abs() > 50.0;
                             if fresh_stream || !anomalous {
-                                log::debug!(
-                                    "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={}",
-                                    key,
+                                tracing::debug!(
+                                    subsystem = "motion",
+                                    event = "junction_jump",
+                                    key = ?key,
                                     tick_jump_us,
                                     host_jump_us,
-                                    fresh_stream,
+                                    fresh = fresh_stream,
+                                    "[junction] jump"
                                 );
                             } else {
                                 let reason = if tick_jump_us < -50.0 {
@@ -467,13 +476,15 @@ pub fn run_pump<S, F, C, A, O, D>(
                                 } else {
                                     "projection_divergence"
                                 };
-                                log::warn!(
-                                    "[junction] key={:?} tick_jump_us={:.1} host_jump_us={:.1} fresh={} reason={}",
-                                    key,
+                                tracing::warn!(
+                                    subsystem = "motion",
+                                    event = "junction_jump_anomalous",
+                                    key = ?key,
                                     tick_jump_us,
                                     host_jump_us,
-                                    fresh_stream,
+                                    fresh = fresh_stream,
                                     reason,
+                                    "[junction] anomalous jump"
                                 );
                             }
                         }
@@ -680,16 +691,24 @@ pub fn run_pump<S, F, C, A, O, D>(
                                 q.advance_write_cursor(n);
                             }
                             Err(SendError::Fatal(ref e)) => {
-                                log::error!(
-                                    "pump send_frame FATAL transport error for {:?}: {e} \
-                                     — invoking fatal-transport action",
-                                    f.key
+                                tracing::error!(
+                                    subsystem = "motion",
+                                    event = "send_frame_fatal",
+                                    key = ?f.key,
+                                    error = %e,
+                                    "pump send_frame FATAL transport error — invoking fatal-transport action"
                                 );
                                 on_fatal_transport(f.key);
                                 return;
                             }
                             Err(SendError::Transient(ref e)) => {
-                                log::error!("pump send_frame failed for {:?}: {e}", f.key);
+                                tracing::error!(
+                                    subsystem = "motion",
+                                    event = "send_frame_transient",
+                                    key = ?f.key,
+                                    error = %e,
+                                    "pump send_frame failed"
+                                );
                                 break 'send;
                             }
                         }
@@ -863,44 +882,40 @@ impl PieceSink for WireSink {
                 .map(|f| format!("{:.1}", (arrival_lead_ticks as f64 / f) * 1e6))
                 .unwrap_or_else(|| "N/A".to_owned());
             if zero_st || past_arrival {
-                log::warn!(
-                    "[transit-diag] mcu={} axis={} \
-                     host_front_start_time={} mcu_front_start_time={} \
-                     arrival_clock={} \
-                     arrival_lead_ticks={} arrival_lead_us={} \
-                     host_send_unix_secs={:.6} \
-                     ALERT: {}",
-                    key.mcu_id,
-                    key.axis,
+                let alert = if zero_st && past_arrival {
+                    "host_start_time=0 (clock-sync gap) AND piece in MCU past"
+                } else if zero_st {
+                    "host_start_time=0 (router clock_freq=0 at dispatch — clock-sync gap)"
+                } else {
+                    "piece arrived in MCU past (arrival_lead<0) — PieceStartInPast risk"
+                };
+                tracing::warn!(
+                    subsystem = "motion",
+                    event = "transit_diag_alert",
+                    mcu = key.mcu_id,
+                    axis = key.axis,
                     host_front_start_time,
-                    r.front_start_time,
-                    r.arrival_clock,
+                    mcu_front_start_time = r.front_start_time,
+                    arrival_clock = r.arrival_clock,
                     arrival_lead_ticks,
-                    arrival_lead_us,
-                    host_send_secs,
-                    if zero_st && past_arrival {
-                        "host_start_time=0 (clock-sync gap) AND piece in MCU past"
-                    } else if zero_st {
-                        "host_start_time=0 (router clock_freq=0 at dispatch — clock-sync gap)"
-                    } else {
-                        "piece arrived in MCU past (arrival_lead<0) — PieceStartInPast risk"
-                    },
+                    arrival_lead_us = %arrival_lead_us,
+                    host_send_unix_secs = host_send_secs,
+                    alert,
+                    "[transit-diag] alert"
                 );
             } else {
-                log::info!(
-                    "[transit-diag] mcu={} axis={} \
-                     host_front_start_time={} mcu_front_start_time={} \
-                     arrival_clock={} \
-                     arrival_lead_ticks={} arrival_lead_us={} \
-                     host_send_unix_secs={:.6}",
-                    key.mcu_id,
-                    key.axis,
+                tracing::info!(
+                    subsystem = "motion",
+                    event = "transit_diag",
+                    mcu = key.mcu_id,
+                    axis = key.axis,
                     host_front_start_time,
-                    r.front_start_time,
-                    r.arrival_clock,
+                    mcu_front_start_time = r.front_start_time,
+                    arrival_clock = r.arrival_clock,
                     arrival_lead_ticks,
-                    arrival_lead_us,
-                    host_send_secs,
+                    arrival_lead_us = %arrival_lead_us,
+                    host_send_unix_secs = host_send_secs,
+                    "[transit-diag]"
                 );
             }
         }


### PR DESCRIPTION
## Summary

Host-rust log lines were emitted as flat `log::*!` message strings, so in
VictoriaLogs they arrived as a single opaque `_msg` with no per-field
structure — you could only full-text search them, never filter or
range-query. This PR routes them all through the structured `tracing`
pipeline so each line carries an indexed `subsystem` and `event` field plus
typed payload fields.

- **`set_clock_est_rebased`** (the line that prompted this): now
  `subsystem=clocksync`, `event=set_clock_est_rebased`, with `freq`,
  `offset_raw`, `clock_offset`, `last_clock`, … as their own numeric fields.
- **Sweep of the remaining 74 `log::*!` sites** across `kalico-host-rt`,
  `motion-bridge`, `kalico-native-transport`, and `kalico-ethercat-rt`.
  Every site gets a `subsystem` and a stable snake_case `event` (e.g.
  `kalico_stream_error`, `unknown_message_kind`, `retransmit_io_error`,
  `seg0_deficit`, `proto_version_mismatch`), with interpolated data lifted
  into typed fields.
- `kalico-native-transport` and `kalico-ethercat-rt` only used the `log`
  facade; their `log` dep is swapped for `tracing` (now their only logging dep).

This is logging-only — no control flow, types, or behavior changed. After
this, a log can be filtered (`event:!="set_clock_est_rebased"`), grouped
(`stats by (subsystem, event)`), or range-queried (`freq:>500000000`)
instead of grepped.

## Test Plan

- [x] `./scripts/ci.sh quick` fully green (ruff, rust-test, rust-clippy `-D warnings`, rust-fmt, watchdog-canary)
- [x] `cargo nextest run` — 1852 passed, 3 skipped
- [x] 0 non-test `log::*!` sites remain in the swept crates
- [x] Deployed to Trident (host + both MCUs); confirmed live in VL that every host-rust log in the running session carries `subsystem`/`event` with typed fields, and zero un-swept (`event=""`) records remain