### PR TITLE
fix: energize an axis's motors together, not sequentially

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -17,13 +17,11 @@ def _endstop_section(config, axis_name):
     return None
 
 
-def _enable_homing_motors(stepper_enable, rail):
+def _homing_motor_names(rail):
     steppers = rail.get_steppers()
     if not steppers:
-        stepper_enable.motor_debug_enable(rail.get_name(), True)
-        return
-    for s in steppers:
-        stepper_enable.motor_debug_enable(s.get_name(), True)
+        return [rail.get_name()]
+    return [s.get_name() for s in steppers]
 
 
 @contextlib.contextmanager
@@ -264,8 +262,10 @@ class Homing:
         stepper_enable = self.printer.lookup_object("stepper_enable")
         homing_deltas = [0.0, 0.0, 0.0]
         homing_deltas[axis] = 1.0
+        homing_names = []
         for active_rail in kin.active_rails(*homing_deltas):
-            _enable_homing_motors(stepper_enable, active_rail)
+            homing_names.extend(_homing_motor_names(active_rail))
+        stepper_enable.motor_enable_group(homing_names)
 
         servo_handle = None
         servo_limits = None

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -129,6 +129,19 @@ class PrinterStepperEnable:
             logging.info("%s has been manually disabled", stepper)
         toolhead.dwell(DISABLE_STALL_TIME)
 
+    def motor_enable_group(self, stepper_names):
+        # Energize several motors at one print_time so they latch together —
+        # enabling them one at a time snaps each rotor to its commutation
+        # phase separately, which on a coupled axis (CoreXY gantry) walks the
+        # toolhead diagonally between snaps.
+        toolhead = self.printer.lookup_object("toolhead")
+        toolhead.dwell(DISABLE_STALL_TIME)
+        print_time = toolhead.get_last_move_time()
+        for name in stepper_names:
+            self.enable_lines[name].motor_enable(print_time)
+            logging.info("%s enabled for homing", name)
+        toolhead.dwell(DISABLE_STALL_TIME)
+
     def get_status(self, eventtime):
         steppers = {
             name: et.is_motor_enabled()

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -130,16 +130,12 @@ class PrinterStepperEnable:
         toolhead.dwell(DISABLE_STALL_TIME)
 
     def motor_enable_group(self, stepper_names):
-        # Energize several motors at one print_time so they latch together —
-        # enabling them one at a time snaps each rotor to its commutation
-        # phase separately, which on a coupled axis (CoreXY gantry) walks the
-        # toolhead diagonally between snaps.
         toolhead = self.printer.lookup_object("toolhead")
         toolhead.dwell(DISABLE_STALL_TIME)
-        print_time = toolhead.get_last_move_time()
+        shared_print_time = toolhead.get_last_move_time()
         for name in stepper_names:
-            self.enable_lines[name].motor_enable(print_time)
-            logging.info("%s enabled for homing", name)
+            self.enable_lines[name].motor_enable(shared_print_time)
+            logging.info("%s enabled", name)
         toolhead.dwell(DISABLE_STALL_TIME)
 
     def get_status(self, eventtime):

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -460,15 +460,9 @@ class TMCCommandHelper:
 
     def _handle_stepper_enable(self, print_time, is_enable):
         if is_enable:
-            # submit_move dispatches segments to the MCU as soon as
-            # _fire_active_callbacks returns, and the bridge has no
-            # lookahead to defer behind. So whatever a move needs on the
-            # driver before its first step — toff restored for a
-            # virtual-enable driver, phase mode entered for a
-            # phase-stepped one — must run inline here, not on a later
-            # reactor turn (mainline's wait_moves() flush, which the
-            # bridge lacks). A dedicated-enable driver that did not reset
-            # needs nothing: its registers survived the toggle.
+            # Inline, not deferred like disable below: the bridge ships the
+            # move right after this with no lookahead, so deferring to the
+            # reactor loses the first move on a driver not yet ready.
             self._do_enable_bridge(print_time)
             return
 

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -223,6 +223,9 @@ class TMCErrorCheck:
             return self.printer.get_reactor().NEVER
         return eventtime + 1.0
 
+    def reset_detect_supported(self):
+        return self.gstat_reg_info is not None and self.clear_gstat
+
     def stop_checks(self):
         if self.check_timer is None:
             return
@@ -457,17 +460,15 @@ class TMCCommandHelper:
 
     def _handle_stepper_enable(self, print_time, is_enable):
         if is_enable:
-            # In bridge mode, submit_move dispatches segments to the MCU
-            # immediately after _fire_active_callbacks returns. If we
-            # defer _do_enable to the reactor, the MCU steps into an
-            # uninitialised TMC driver and the first move is lost. Run
-            # the register init + phase calibration inline so the driver
-            # is ready before the segment is dispatched. The gcode mutex
-            # and wait_moves() are unnecessary here — the move hasn't
-            # been submitted yet, so there's nothing to flush or wait
-            # for. Mainline defers because the move sits in the
-            # lookahead and _do_enable's wait_moves() IS what flushes it
-            # to the MCU; bridge mode doesn't have that lookahead.
+            # submit_move dispatches segments to the MCU as soon as
+            # _fire_active_callbacks returns, and the bridge has no
+            # lookahead to defer behind. So whatever a move needs on the
+            # driver before its first step — toff restored for a
+            # virtual-enable driver, phase mode entered for a
+            # phase-stepped one — must run inline here, not on a later
+            # reactor turn (mainline's wait_moves() flush, which the
+            # bridge lacks). A dedicated-enable driver that did not reset
+            # needs nothing: its registers survived the toggle.
             self._do_enable_bridge(print_time)
             return
 
@@ -478,13 +479,25 @@ class TMCCommandHelper:
 
     def _do_enable_bridge(self, print_time):
         try:
-            if self.toff is not None:
-                self.fields.set_field("toff", self.toff)
-            self._init_registers()
             if self._post_enable_cb is not None:
+                if self.toff is not None:
+                    self.fields.set_field("toff", self.toff)
+                self._init_registers()
                 self._post_enable_cb()
-            if self._post_enable_cb is None:
-                self.echeck_helper.start_checks()
+                return
+            did_reset = self.echeck_helper.start_checks()
+            reinit = (
+                did_reset or not self.echeck_helper.reset_detect_supported()
+            )
+            if self.toff is not None:
+                val = self.fields.set_field("toff", self.toff)
+                if reinit:
+                    self._init_registers()
+                else:
+                    reg_name = self.fields.lookup_register("toff")
+                    self.mcu_tmc.set_register(reg_name, val, print_time)
+            elif reinit:
+                self._init_registers()
         except (self.printer.command_error, RuntimeError) as e:
             self.printer.invoke_shutdown(
                 "TMC %s _do_enable_bridge failed: %s" % (self.stepper_name, e)

--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -363,13 +363,16 @@ class Motion:
             if isinstance(rail, servo_axis.ServoRail)
         )
         fired = False
+        move_time = None
         for owner in owners:
             if not owner._active_callbacks:
                 continue
             cbs = owner._active_callbacks
             owner._active_callbacks = []
+            if move_time is None:
+                move_time = self.get_last_move_time()
             for cb in cbs:
-                cb(self.get_last_move_time())
+                cb(move_time)
             fired = True
         return fired
 

--- a/test/test_active_rails.py
+++ b/test/test_active_rails.py
@@ -76,8 +76,10 @@ class FakeToolhead:
         self.kin = kin
         self.follower_steppers = list(follower_steppers)
         self._clock = 100.0
+        self.move_time_calls = 0
 
     def get_last_move_time(self):
+        self.move_time_calls += 1
         self._clock += 0.090
         return self._clock
 
@@ -93,7 +95,7 @@ def all_steppers(kin):
     return [s for rail in kin.rails for s in rail.get_steppers()]
 
 
-def test_each_enable_callback_gets_fresh_print_time():
+def test_all_enable_callbacks_share_one_print_time():
     kin = make_kin("corexy")
     fired = []
     for s in all_steppers(kin):
@@ -101,8 +103,17 @@ def test_each_enable_callback_gets_fresh_print_time():
     th = FakeToolhead(kin)
     th._fire_active_callbacks((5.0, 5.0, 5.0, 0.0))
     assert len(fired) == 6
-    assert len(set(fired)) == 6, "print_time must be recomputed per callback"
-    assert fired == sorted(fired)
+    assert len(set(fired)) == 1, (
+        "every motor of a move energizes at one print_time"
+    )
+    assert th.move_time_calls == 1, "print_time is sampled once, not per motor"
+
+
+def test_no_active_callbacks_does_not_sample_print_time():
+    kin = make_kin("corexy")
+    th = FakeToolhead(kin)
+    assert th._fire_active_callbacks((5.0, 5.0, 5.0, 0.0)) is False
+    assert th.move_time_calls == 0, "no enable to schedule, no clock read"
 
 
 def test_cartesian_move_enables_only_the_moving_axis():

--- a/test/test_homing_enable.py
+++ b/test/test_homing_enable.py
@@ -1,0 +1,97 @@
+from klippy.extras import homing, stepper_enable
+from klippy.extras.stepper_enable import DISABLE_STALL_TIME
+
+
+class FakeEnableLine:
+    def __init__(self):
+        self.enabled_at = []
+
+    def motor_enable(self, print_time):
+        self.enabled_at.append(print_time)
+
+
+class FakeToolhead:
+    def __init__(self):
+        self.dwells = []
+        self._t = 100.0
+        self.move_time_calls = 0
+
+    def dwell(self, delay):
+        self.dwells.append(delay)
+        self._t += delay
+
+    def get_last_move_time(self):
+        self.move_time_calls += 1
+        return self._t
+
+
+class FakePrinter:
+    def __init__(self, toolhead):
+        self._toolhead = toolhead
+
+    def lookup_object(self, name):
+        assert name == "toolhead"
+        return self._toolhead
+
+
+class FakeStepperEnable:
+    motor_enable_group = stepper_enable.PrinterStepperEnable.motor_enable_group
+
+    def __init__(self, toolhead, names):
+        self.printer = FakePrinter(toolhead)
+        self.enable_lines = {n: FakeEnableLine() for n in names}
+
+
+def test_group_enable_energizes_every_motor_at_one_print_time():
+    th = FakeToolhead()
+    se = FakeStepperEnable(th, ["motor_a", "motor_b", "motor_z"])
+    se.motor_enable_group(["motor_a", "motor_b", "motor_z"])
+    times = [el.enabled_at for el in se.enable_lines.values()]
+    assert all(t == times[0] for t in times), "all motors share one print_time"
+    assert all(len(t) == 1 for t in times)
+    assert th.move_time_calls == 1, (
+        "print_time sampled once for the whole group"
+    )
+
+
+def test_group_enable_dwells_once_around_the_batch():
+    th = FakeToolhead()
+    se = FakeStepperEnable(th, ["motor_a", "motor_b"])
+    se.motor_enable_group(["motor_a", "motor_b"])
+    assert th.dwells == [DISABLE_STALL_TIME, DISABLE_STALL_TIME], (
+        "one settle dwell before and after, not per motor"
+    )
+
+
+class FakeStepper:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self, short=False):
+        return self._name
+
+
+class FakeRail:
+    def __init__(self, steppers, name):
+        self._steppers = steppers
+        self._name = name
+
+    def get_steppers(self):
+        return self._steppers
+
+    def get_name(self, short=False):
+        return self._name
+
+
+def test_homing_collects_every_active_rail_motor():
+    x = FakeRail([FakeStepper("motor_a")], "stepper_x")
+    y = FakeRail([FakeStepper("motor_b")], "stepper_y")
+    names = []
+    for rail in (x, y):
+        names.extend(homing._homing_motor_names(rail))
+    assert names == ["motor_a", "motor_b"], "both gantry motors in one batch"
+
+
+def test_homing_falls_back_to_rail_name_when_no_steppers():
+    servo = FakeRail([], "servo_x")
+    assert homing._homing_motor_names(servo) == ["servo_x"]

--- a/test/test_servo_homing.py
+++ b/test/test_servo_homing.py
@@ -181,20 +181,16 @@ class FakeRail:
         return self._name
 
 
-def test_enable_homing_motors_enables_each_stepper():
-    se = FakeStepperEnable()
+def test_homing_motor_names_lists_each_stepper():
     rail = FakeRail(
         [FakeStepper("stepper_x"), FakeStepper("stepper_x1")], "stepper_x"
     )
-    homing_mod._enable_homing_motors(se, rail)
-    assert se.calls == [("stepper_x", True), ("stepper_x1", True)]
+    assert homing_mod._homing_motor_names(rail) == ["stepper_x", "stepper_x1"]
 
 
-def test_enable_homing_motors_enables_servo_rail_by_name():
-    se = FakeStepperEnable()
+def test_homing_motor_names_uses_servo_rail_name_when_no_steppers():
     rail = FakeRail([], "servo_x")
-    homing_mod._enable_homing_motors(se, rail)
-    assert se.calls == [("servo_x", True)]
+    assert homing_mod._homing_motor_names(rail) == ["servo_x"]
 
 
 def make_homing_servo_rail():

--- a/test/test_tmc_enable.py
+++ b/test/test_tmc_enable.py
@@ -1,0 +1,118 @@
+from klippy.extras import tmc
+
+
+class FakeFields:
+    TOFF_REG = "CHOPCONF"
+
+    def __init__(self):
+        self.registers = {}
+        self.set_field_calls = []
+
+    def set_field(self, name, value):
+        self.set_field_calls.append((name, value))
+        self.registers[self.TOFF_REG] = value
+        return value
+
+    def lookup_register(self, name):
+        return self.TOFF_REG
+
+
+class FakeMcuTmc:
+    def __init__(self):
+        self.writes = []
+
+    def set_register(self, reg, val, print_time=None):
+        self.writes.append((reg, val, print_time))
+
+
+class FakeEcheck:
+    def __init__(self, did_reset=False, supported=True):
+        self._did_reset = did_reset
+        self._supported = supported
+        self.start_calls = 0
+
+    def start_checks(self):
+        self.start_calls += 1
+        return self._did_reset
+
+    def reset_detect_supported(self):
+        return self._supported
+
+
+class FakePrinter:
+    command_error = RuntimeError
+
+    def __init__(self):
+        self.shutdowns = []
+
+    def invoke_shutdown(self, msg):
+        self.shutdowns.append(msg)
+
+
+class FakeTMC:
+    _do_enable_bridge = tmc.TMCCommandHelper._do_enable_bridge
+
+    def __init__(
+        self, toff=None, did_reset=False, supported=True, post_cb=None
+    ):
+        self.toff = toff
+        self.fields = FakeFields()
+        self.mcu_tmc = FakeMcuTmc()
+        self.echeck_helper = FakeEcheck(did_reset, supported)
+        self.printer = FakePrinter()
+        self.stepper_name = "stepper_x"
+        self._post_enable_cb = post_cb
+        self.init_calls = 0
+
+    def _init_registers(self, print_time=None):
+        self.init_calls += 1
+
+
+def test_dedicated_enable_no_reset_skips_reinit():
+    t = FakeTMC(toff=None, did_reset=False)
+    t._do_enable_bridge(0.0)
+    assert t.init_calls == 0, "registers persist across a dedicated-pin toggle"
+    assert t.mcu_tmc.writes == []
+    assert t.echeck_helper.start_calls == 1, "status/reset check still runs"
+    assert t.printer.shutdowns == []
+
+
+def test_dedicated_enable_reset_reinits():
+    t = FakeTMC(toff=None, did_reset=True)
+    t._do_enable_bridge(0.0)
+    assert t.init_calls == 1, "driver lost its registers — restore them"
+
+
+def test_virtual_enable_no_reset_restores_toff_only():
+    t = FakeTMC(toff=3, did_reset=False)
+    t._do_enable_bridge(1.5)
+    assert t.init_calls == 0, "no full re-init when the driver did not reset"
+    assert t.fields.set_field_calls == [("toff", 3)]
+    assert t.mcu_tmc.writes == [("CHOPCONF", 3, 1.5)], "only toff is rewritten"
+
+
+def test_virtual_enable_reset_reinits_and_restores_toff():
+    t = FakeTMC(toff=3, did_reset=True)
+    t._do_enable_bridge(0.0)
+    assert t.init_calls == 1
+    assert ("toff", 3) in t.fields.set_field_calls
+    assert t.mcu_tmc.writes == [], (
+        "full init carries toff; no extra single write"
+    )
+
+
+def test_unsupported_reset_detection_always_reinits():
+    t = FakeTMC(toff=None, did_reset=False, supported=False)
+    t._do_enable_bridge(0.0)
+    assert t.init_calls == 1, (
+        "tmc2130-style drivers can't prove no-reset; be safe"
+    )
+
+
+def test_phase_stepping_path_inits_and_calls_post_enable():
+    calls = []
+    t = FakeTMC(toff=None, post_cb=lambda: calls.append("cb"))
+    t._do_enable_bridge(0.0)
+    assert t.init_calls == 1, "phase-mode entry needs the full register setup"
+    assert calls == ["cb"]
+    assert t.echeck_helper.start_calls == 0, "post-enable cb owns the checks"


### PR DESCRIPTION
## Summary

Steppers of one axis energized one-by-one during homing — an audible
click-click-click, and on the CoreXY gantry a visible diagonal lurch as each
rotor snapped to its commutation phase separately before the next motor
latched. Root cause was two independent enable paths each sampling a fresh
`get_last_move_time()` per motor and doing blocking per-motor work between
them. Fixes:

- **`fix(motion)`** — `_fire_active_callbacks` sampled the move time per motor,
  staggering each EN pin by the previous motor's inline driver init. Sample it
  once per move so all of an axis's EN pins latch at one MCU clock. (regular-move path)
- **`fix(tmc)`** — `_do_enable_bridge` re-sent every register over blocking SPI
  on every enable. Read the reset state first (already detected via GSTAT) and
  only re-init when the driver actually reset, or when reset detection is
  unreliable (TMC2130/2660, kept always-reinit). Virtual-enable drivers still
  restore `toff` each enable. Phase-stepping path unchanged.
- **`fix(homing)`** — the actual homing symptom. Homing's trip move is
  bridge-driven and bypasses `move()`, so it energized motors via
  `_enable_homing_motors` → `motor_debug_enable` once per motor (dwell, fresh
  print_time, enable, dwell). Added `motor_enable_group`, which energizes a set
  of motors at one shared print_time with a single settle dwell, and collect
  every active rail's motors across the axis into one group call.

## Test Plan

- [x] `pytest test/` — 302 passed, 77 skipped, 1 xfailed
- [x] New unit tests: `test_homing_enable.py`, `test_tmc_enable.py`; inverted timestamp test in `test_active_rails.py`; updated `test_servo_homing.py`
- [x] ruff check + format clean
- [x] Flashed Trident (H723 + F446), both MCUs `runtime.mcu_ready`, live session error-free
- [x] Bench-confirmed: single simultaneous energize, no CoreXY diagonal