### PR TITLE
Same-MCU homing self-gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,7 @@ We are working on a complete rewrite of the motion planner and more:
   The `compat` crate has two callers: the offline Step-13 binary (file → file) and the live bridge (terminal/macro G1/G2/G3 conversion via `compat::collinear::to_collinear_g5`, `compat::arc::arc_to_g5`, `compat::degree_elev::elevate_g51_to_g5`). Both share the lexer.
 
 # Homing
-- We deliberately do not optimize for same mcu endstop+motor homing. All homing works as if mcu with the endstop is a different one than the one that drives the motors. it makes testing easier
-  at this stage of development.
+- Same-MCU endstop+motor homing is optimized: when a locally-armed endstop trips, the MCU brakes its own motion immediately — `endstop_trip_task` calls `handle_stop_inner` (the gating core of the `Stop` handler) before emitting the trip event, so the curve evaluator freezes without a host round-trip. The host's `broadcast_stop` still fans the stop out to any genuinely-remote participant MCUs, and its later `Stop` to the self-gated MCU is a harmless idempotent re-gate. Both paths converge on the same `gate_pieces` freeze.
 
 # Testing
 

--- a/docs/superpowers/plans/2026-06-14-same-mcu-homing-self-gate.md
+++ b/docs/superpowers/plans/2026-06-14-same-mcu-homing-self-gate.md
@@ -1,0 +1,280 @@
+# Same-MCU Homing Self-Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MCU brake its own motion the instant a locally-armed endstop trips, instead of waiting for the host's `Stop` round-trip.
+
+**Architecture:** Extract the gating core of the host `Stop` handler into `handle_stop_inner` (everything except the host-facing `send_stop_response`). Call it from `endstop_trip_task` so a local trip freezes the curve evaluator immediately. The host's existing `broadcast_stop` is untouched; its later `Stop` to the already-braked MCU is a harmless idempotent re-gate. Overshoot/slide accounting is out of scope (handled by a separate mechanism), so the host's position-reconstruction path is left as-is.
+
+**Tech Stack:** C firmware (`src/*.c`), Rust runtime FFI (`rust/kalico-c-api`), the kalico-sim full-mode simulator (real firmware + klippy in Docker).
+
+**Reference spec:** [`docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md`](../specs/2026-06-14-same-mcu-homing-self-gate-design.md)
+
+**Testing note:** `src/kalico_dispatch.c` and `src/endstop.c` are MCU firmware glue with no standalone C unit harness in this repo. Verification is therefore: (a) the existing Rust idempotency test that already proves a repeated gate is a safe no-op (`rust/kalico-c-api/tests/piece_gate.rs::gate_is_idempotent_like_a_repeated_stop`), and (b) end-to-end homing in kalico-sim full mode, which compiles `src/*.c` into the simulated firmware and auto-triggers the endstop during `G28`. This matches the project's established testing model for firmware glue. **Docker is required** for the kalico-sim verification.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/kalico_dispatch.c` | Host-command dispatch on the MCU (incl. `Stop`). | Extract `handle_stop_inner`; `handle_stop` calls it then `send_stop_response`. |
+| `src/kalico_dispatch.h` | Public prototypes for dispatch glue. | Declare `handle_stop_inner` so `endstop.c` can call it. |
+| `src/endstop.c` | Endstop arm/detect/report on the MCU. | `endstop_trip_task` brakes locally via `handle_stop_inner` before emitting the trip event. |
+| `CLAUDE.md` | Project constraints. | Replace the "do not optimize same-MCU homing" note with the self-gate behavior. |
+
+No host-side or wire-protocol files change.
+
+---
+
+## Task 1: Extract `handle_stop_inner` (behavior-preserving refactor)
+
+This task does NOT change any behavior — it only splits `handle_stop` so the gating core can be reused. The regression guard is the existing Rust idempotency test, which must stay green.
+
+**Files:**
+- Modify: `src/kalico_dispatch.h` (add prototype after line 27)
+- Modify: `src/kalico_dispatch.c:551-563` (the `handle_stop` function)
+- Regression test (existing): `rust/kalico-c-api/tests/piece_gate.rs`
+
+- [ ] **Step 1: Confirm the regression guard passes before the change**
+
+Run:
+```bash
+cd rust && cargo nextest run -p kalico-c-api -E 'test(gate_is_idempotent_like_a_repeated_stop)'
+```
+Expected: PASS (1 test run). This is the property the refactor must preserve — gating an already-gated engine returns `KALICO_OK`.
+
+- [ ] **Step 2: Declare `handle_stop_inner` in the header**
+
+In `src/kalico_dispatch.h`, add the prototype right after the `kalico_native_emit_endstop_trip` declaration (after line 27):
+
+```c
+void kalico_native_emit_endstop_trip(uint8_t endstop_id, uint64_t trip_clock);
+
+// Gate the curve evaluator and report the discard clock, without sending a
+// StopResponse. Shared by the host `Stop` handler and the local endstop
+// self-gate (endstop.c). Returns the runtime rc; writes the gate clock to
+// *discard_clock.
+int32_t handle_stop_inner(uint64_t *discard_clock);
+```
+
+- [ ] **Step 3: Extract the function in `kalico_dispatch.c`**
+
+Replace the current `handle_stop` (lines 551-563):
+
+```c
+static void
+handle_stop(uint32_t correlation_id)
+{
+    int32_t rc = KALICO_ERR_NOT_INIT;
+    uint64_t discard_clock = 0;
+    if (runtime_handle) {
+        irqstatus_t flag = irq_save();
+        rc = kalico_runtime_gate_pieces(runtime_handle);
+        discard_clock = kalico_runtime_now_ticks(runtime_handle);
+        irq_restore(flag);
+    }
+    send_stop_response(correlation_id, rc, discard_clock);
+}
+```
+
+with:
+
+```c
+int32_t
+handle_stop_inner(uint64_t *discard_clock)
+{
+    int32_t rc = KALICO_ERR_NOT_INIT;
+    *discard_clock = 0;
+    if (runtime_handle) {
+        irqstatus_t flag = irq_save();
+        rc = kalico_runtime_gate_pieces(runtime_handle);
+        *discard_clock = kalico_runtime_now_ticks(runtime_handle);
+        irq_restore(flag);
+    }
+    return rc;
+}
+
+static void
+handle_stop(uint32_t correlation_id)
+{
+    uint64_t discard_clock;
+    int32_t rc = handle_stop_inner(&discard_clock);
+    send_stop_response(correlation_id, rc, discard_clock);
+}
+```
+
+Note: `handle_stop_inner` is intentionally non-`static` (so `endstop.c` can call it). It keeps the exact `irq_save`/`irq_restore` critical section the original had — required because `gate_pieces` mutates the engine and the TIM5 ISR could otherwise preempt it.
+
+- [ ] **Step 4: Verify the firmware still compiles (kalico-sim build)**
+
+Run (Docker required):
+```bash
+bash tools/kalico-sim/run.sh --privileged --homing-test --mode full --timeout 120
+```
+Expected: the image builds (compiles `src/kalico_dispatch.c`) and the beacon Z homing test reports PASS. A compile error in the extraction shows up here as a build failure.
+
+- [ ] **Step 5: Re-run the Rust idempotency guard**
+
+Run:
+```bash
+cd rust && cargo nextest run -p kalico-c-api -E 'test(gate)'
+```
+Expected: all `gate*` tests PASS (the refactor touched no Rust, so behavior is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/kalico_dispatch.c src/kalico_dispatch.h
+git commit -m "refactor(mcu): extract handle_stop_inner from the Stop handler"
+```
+
+---
+
+## Task 2: Self-gate on a local endstop trip
+
+**Files:**
+- Modify: `src/endstop.c:102-116` (the `endstop_trip_task` function)
+- End-to-end test: kalico-sim full mode (`--sensorless-phase-test` = same-MCU G28 X; `--homing-test` = cross-MCU beacon Z regression)
+
+- [ ] **Step 1: Add the local brake to `endstop_trip_task`**
+
+In `src/endstop.c`, replace the current `endstop_trip_task` (lines 102-116):
+
+```c
+void
+endstop_trip_task(void)
+{
+    if (!sched_check_wake(&endstop_trip_wake))
+        return;
+    uint8_t oid;
+    struct endstop *e;
+    foreach_oid(oid, e, command_config_endstop) {
+        if (!e->trip_pending)
+            continue;
+        e->trip_pending = 0;
+        kalico_native_emit_endstop_trip(e->endstop_id, e->trip_clock);
+    }
+}
+```
+
+with (brake first, then emit — `discard_clock` out-param unused on this path):
+
+```c
+void
+endstop_trip_task(void)
+{
+    if (!sched_check_wake(&endstop_trip_wake))
+        return;
+    uint64_t discard_clock;
+    handle_stop_inner(&discard_clock);
+    uint8_t oid;
+    struct endstop *e;
+    foreach_oid(oid, e, command_config_endstop) {
+        if (!e->trip_pending)
+            continue;
+        e->trip_pending = 0;
+        kalico_native_emit_endstop_trip(e->endstop_id, e->trip_clock);
+    }
+}
+```
+
+`endstop.c` already includes `kalico_dispatch.h` (line 7), so `handle_stop_inner` is in scope with no new include.
+
+- [ ] **Step 2: Verify same-MCU homing end-to-end (the new behavior)**
+
+Run (Docker required):
+```bash
+bash tools/kalico-sim/run.sh --privileged --sensorless-phase-test --mode full --timeout 180
+```
+Expected: PASS. This homes X with a TMC virtual endstop on the *same* MCU as the X stepper, so the trip now self-gates locally. A pass confirms the engine freezes cleanly on the trip and the host's subsequent `Stop` is a harmless re-gate (a broken double-stop would shut klippy down and fail the run).
+
+- [ ] **Step 3: Verify cross-MCU homing is unregressed**
+
+Run (Docker required):
+```bash
+bash tools/kalico-sim/run.sh --privileged --homing-test --mode full --timeout 180
+```
+Expected: PASS. Beacon Z homing is genuinely cross-MCU; the source MCU self-gates its own idle engine harmlessly and the sink MCU still stops via the host relay.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/endstop.c
+git commit -m "feat(mcu): self-gate motion on a local endstop trip"
+```
+
+---
+
+## Task 3: Lift the CLAUDE.md constraint
+
+**Files:**
+- Modify: `CLAUDE.md:27-28` (the `# Homing` section)
+
+- [ ] **Step 1: Replace the homing note**
+
+In `CLAUDE.md`, replace lines 27-28:
+
+```markdown
+# Homing
+- We deliberately do not optimize for same mcu endstop+motor homing. All homing works as if mcu with the endstop is a different one than the one that drives the motors. it makes testing easier at this stage of development.
+```
+
+with:
+
+```markdown
+# Homing
+- Same-MCU endstop+motor homing is optimized: when a locally-armed endstop trips, the MCU brakes its own motion immediately — `endstop_trip_task` calls `handle_stop_inner` (the gating core of the `Stop` handler) before emitting the trip event, so the curve evaluator freezes without a host round-trip. The host's `broadcast_stop` still fans the stop out to any genuinely-remote participant MCUs, and its later `Stop` to the self-gated MCU is a harmless idempotent re-gate. Both paths converge on the same `gate_pieces` freeze.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: same-MCU homing is now optimized via the self-gate"
+```
+
+---
+
+## Task 4: Final gate — full CI + sim green
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the quick CI gate**
+
+Run:
+```bash
+./scripts/ci.sh quick
+```
+Expected: green (ruff, Rust workspace tests, clippy `-D warnings`, `cargo fmt --check`, watchdog canary). No `klippy/` host code changed, so `./scripts/ci.sh py` is not required.
+
+- [ ] **Step 2: Confirm both sim homing runs still pass from a clean build**
+
+Run (Docker required):
+```bash
+bash tools/kalico-sim/run.sh --no-cache --privileged --sensorless-phase-test --mode full --timeout 180
+bash tools/kalico-sim/run.sh --privileged --homing-test --mode full --timeout 180
+```
+Expected: both PASS.
+
+- [ ] **Step 3: Final fmt check (last step before any PR)**
+
+Run:
+```bash
+cd rust && cargo fmt --all --check
+```
+Expected: no output (clean).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Extract `handle_stop_inner` + call on local trip → Tasks 1 & 2. ✓
+- §2 Double stop just stops again (idempotent re-gate) → verified by the existing Rust idempotency guard (Task 1 Step 1/5) and the same-MCU sim run (Task 2 Step 2). ✓
+- §3 Lift CLAUDE.md constraint → Task 3. ✓
+- Spec "out of scope" (slide/overshoot accounting; no host change; no new FFI) → respected: no host or FFI files in the file structure. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows the full before/after; every command has an expected result. ✓
+
+**Type/name consistency:** `handle_stop_inner(uint64_t *discard_clock) -> int32_t` is declared identically in the header (Task 1 Step 2), defined identically in `kalico_dispatch.c` (Task 1 Step 3), and called identically in `endstop.c` (Task 2 Step 1) and `handle_stop` (Task 1 Step 3). ✓

--- a/docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md
+++ b/docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md
@@ -1,0 +1,233 @@
+# Same-MCU Homing Self-Gate
+
+## Goal
+
+When an armed endstop trips, let the MCU that owns it **brake its own motion
+immediately**, instead of waiting for the host to detect the trip and send a
+`Stop` round-trip back. This is the documented "same-MCU local-siren fast-path"
+deferred in
+[`2026-05-31-trsync-cross-mcu-homing-design.md`](2026-05-31-trsync-cross-mcu-homing-design.md)
+(its "Out of scope / future" section), now that the cross-MCU relay is
+confirmed working on hardware.
+
+The behavior is **unconditional**: every MCU gates its own curve evaluator
+whenever one of its *locally-armed* endstops trips. No host flag, no topology
+negotiation. This is safe because an endstop is only ever armed during a
+homing/probing move (`query_endstop` with a nonzero `rest_ticks`), so a trip can
+never fire mid-print.
+
+## Background: the current stop path
+
+1. **Detect (IRQ).** `src/endstop.c::endstop_event` runs in the sched-timer IRQ.
+   On an armed pin going active it latches `trip_clock`
+   (`kalico_runtime_now_ticks`), disarms, sets `trip_pending`, and wakes
+   `endstop_trip_task`. **It does not stop motion.** The emit is deferred to the
+   foreground task because `kalico_transport_send_frame` uses a shared `tx_buf`
+   and the USB transmit cursor, neither safe from IRQ (`endstop.c:26-29`).
+2. **Report (task).** `endstop_trip_task` ships `kalico_endstop_tripped`
+   (`trip_clock`) to the host.
+3. **Stop (host round-trip).** The host (`bridge.rs::dispatch_endstop_trip`)
+   spawns `homing-trip-handler`, flushes the pump, and `broadcast_stop` sends a
+   blocking `Stop` to every participating stepper MCU. Each `Stop` runs
+   `handle_stop` → `kalico_runtime_gate_pieces` (freeze the curve evaluator) and
+   replies with `discard_clock = kalico_runtime_now_ticks`.
+4. **Reconcile.** The host reconstructs the **trip** position at `trip_clock`
+   and the **final** position at `discard_clock` from motion history.
+
+For same-MCU homing (endstop pin and homed steppers on one board — the Trident
+X/Y-on-H7 case) the physical brake waits for the full host round-trip in step 3.
+That latency is pure overshoot past the trigger point.
+
+### Why `discard_clock` is load-bearing
+
+`klippy/extras/homing.py:80` sets the post-home position to:
+
+```python
+trigger_height + (final_pos[axis] - trip_pos[axis])
+```
+
+`final_pos − trip_pos` is the **overshoot**, added to the trigger height and
+fed to `toolhead.set_position` (homing.py:305). It is `planned(discard_clock) −
+planned(trip_clock)`. Today this is correct because the MCU follows the planned
+trajectory right up until the host's `Stop`, so `discard_clock` equals the clock
+at which motion actually froze.
+
+If the MCU brakes early (this change) but the host still reads `discard_clock`
+from its *later* `Stop`, the overshoot is overstated by `speed × round-trip` and
+the homed position is wrong by that much — a systematic error. So the brake
+clock must stay honest (see design point 2).
+
+## Design
+
+### 1. Extract `handle_stop_inner` and call it on a local trip
+
+Split the gating core out of `handle_stop` in `src/kalico_dispatch.c`. The only
+part `handle_stop` keeps for itself is the host-facing `send_stop_response` — a
+self-triggered stop has no host request to reply to, and sending an unsolicited
+`StopResponse` would desync the control channel (the host correlates responses
+by id).
+
+`handle_stop_inner` is **not** `static` — `endstop_trip_task` lives in
+`endstop.c`, which already includes `kalico_dispatch.h`, so its prototype goes
+there (beside `kalico_native_emit_endstop_trip`):
+
+```c
+// kalico_dispatch.h
+int32_t handle_stop_inner(uint64_t *discard_clock);
+```
+
+```c
+static uint64_t s_gate_clock;   // brake clock, captured on the first gate
+
+int32_t handle_stop_inner(uint64_t *discard_clock) {
+    int32_t rc = KALICO_ERR_NOT_INIT;
+    if (runtime_handle) {
+        irqstatus_t flag = irq_save();
+        if (!kalico_runtime_pieces_gated(runtime_handle)) {
+            rc = kalico_runtime_gate_pieces(runtime_handle);
+            s_gate_clock = kalico_runtime_now_ticks(runtime_handle);
+        } else {
+            rc = KALICO_OK;
+        }
+        irq_restore(flag);
+    }
+    *discard_clock = s_gate_clock;
+    return rc;
+}
+
+static void handle_stop(uint32_t correlation_id) {
+    uint64_t discard_clock;
+    int32_t rc = handle_stop_inner(&discard_clock);
+    send_stop_response(correlation_id, rc, discard_clock);
+}
+```
+
+`irq_save`/`irq_restore` is required: `gate_pieces` mutates the engine through a
+raw pointer with no internal lock, and the engine tick runs in the higher-
+priority TIM5 ISR which would otherwise preempt the mutation. This matches what
+`handle_stop` does today.
+
+In `endstop_trip_task`, after the existing `kalico_native_emit_endstop_trip`,
+call `handle_stop_inner`:
+
+```c
+void endstop_trip_task(void) {
+    if (!sched_check_wake(&endstop_trip_wake))
+        return;
+    uint8_t oid;
+    struct endstop *e;
+    foreach_oid(oid, e, command_config_endstop) {
+        if (!e->trip_pending)
+            continue;
+        e->trip_pending = 0;
+        kalico_native_emit_endstop_trip(e->endstop_id, e->trip_clock);
+    }
+    uint64_t discard_clock;
+    handle_stop_inner(&discard_clock);   // brake locally; return value unused here
+}
+```
+
+Order: emit first, then brake. The emit gets the trip to the host so it can fan
+the stop out to any genuinely-remote participant MCUs; the local brake follows.
+For same-MCU homing there are no other MCUs to relay to, so emit-first costs
+only a few µs of local overshoot. The brake gating the whole engine (not a
+single axis) matches the existing `broadcast_stop` semantics, which already
+gates each participant's whole engine.
+
+### 2. Keep the brake clock honest
+
+`handle_stop_inner` captures `s_gate_clock` the **first** time it gates and
+returns that stored clock on every subsequent call. So when the host's later
+`Stop` arrives and runs `handle_stop` → `handle_stop_inner`, it finds pieces
+already gated and replies with the **real brake time** instead of a fresh
+`now_ticks`. The host's reconstruction and the wire protocol are unchanged;
+`discard_clock` simply now always means "the clock motion actually froze,"
+whether the freeze was local or host-driven.
+
+No explicit reset is needed across homing cycles: `ResumeStream` ungates after
+homing (`pieces_gated` → false), so the next trip's first gate recaptures a
+fresh `s_gate_clock`.
+
+### 3. Expose `pieces_gated` over the FFI
+
+The engine already has `pieces_gated()` (`engine.rs:264`, used internally in
+`runtime_ffi.rs`), but there is no C-callable export. Add one beside
+`kalico_runtime_gate_pieces` in `rust/kalico-c-api/src/runtime_ffi.rs`:
+
+```rust
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kalico_runtime_pieces_gated(rt: *mut KalicoRuntime) -> bool { ... }
+```
+
+and declare it in `rust/kalico-c-api/include/kalico_runtime.h`. Null/`!INIT_DONE`
+guards return `false` (matching the other accessors' conservative defaults).
+
+### 4. Lift the CLAUDE.md constraint
+
+`CLAUDE.md` currently says (line 27-28):
+
+> We deliberately do not optimize for same mcu endstop+motor homing. All homing
+> works as if mcu with the endstop is a different one than the one that drives
+> the motors. it makes testing easier at this stage of development.
+
+This change introduces exactly that optimization. Replace the note with a short
+statement that same-MCU trips brake locally (the self-gate), while the host
+relay still fans the stop out cross-MCU — both paths converge on the same
+`gate_pieces` freeze.
+
+## What stays unchanged
+
+- **Host side**: `broadcast_stop`, `dispatch_endstop_trip`, trip/final position
+  reconstruction, `home_axis_start`, `ResumeStream`/ungate. The host still sends
+  `Stop` to every participant including the self-gated MCU; that `Stop` is now
+  idempotent there and returns the honest stored clock.
+- **Wire protocol**: `kalico_endstop_tripped`, `Stop`/`StopResponse`,
+  `endstop_query_state` — no format changes.
+- **Cross-MCU path**: a remote source MCU self-gates its own (idle) engine
+  harmlessly; remote sink MCUs still stop via the host's `broadcast_stop`.
+
+## Error handling
+
+No new error surface. `handle_stop_inner` preserves the existing `rc`
+(`KALICO_ERR_NOT_INIT` when the runtime handle is absent; `KALICO_OK`
+otherwise). The self-gate path ignores `rc` (there is no host to report to);
+the host `Stop` path reports it exactly as before.
+
+## Testing
+
+- **Rust (`cargo nextest run`)**:
+  - `kalico_runtime_pieces_gated` returns the engine state (false before gate,
+    true after, false after ungate).
+  - An already-gated `handle_stop_inner`/`Stop` returns the stored first-gate
+    clock, not a fresh `now_ticks` (exercise via the `kalico-c-api`
+    `piece_gate.rs` harness: gate, advance the clock, gate again, assert the
+    returned `discard_clock` is unchanged).
+- **Existing suites**: `motion-bridge` `homing/tests.rs` and `pump` tests
+  continue to pass unchanged (host path untouched).
+- **kalico-sim**: a same-MCU home (endstop + homed stepper on one emulated MCU)
+  where the trip event is delivered to the host with deliberate latency; assert
+  the curve evaluator freezes at trip time (motion stops before the host's
+  `Stop` lands) and the reported overshoot reflects the true brake, not the
+  host round-trip.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/kalico_dispatch.c` | extract `handle_stop_inner` (non-`static`: gate + capture/return `s_gate_clock`); `handle_stop` calls it then `send_stop_response`; add `s_gate_clock` static. |
+| `src/kalico_dispatch.h` | declare `handle_stop_inner` (so `endstop.c` can call it). |
+| `src/endstop.c` | `endstop_trip_task` calls `handle_stop_inner` after emitting the trip event. |
+| `rust/kalico-c-api/src/runtime_ffi.rs` | add `kalico_runtime_pieces_gated` export. |
+| `rust/kalico-c-api/include/kalico_runtime.h` | declare `kalico_runtime_pieces_gated`. |
+| `CLAUDE.md` | replace the "do not optimize same-MCU homing" note with the self-gate behavior. |
+| (tests) | `kalico-c-api` gate/clock coverage; kalico-sim same-MCU home. |
+
+## Out of scope
+
+- IRQ-immediate gating (braking inside `endstop_event` rather than the
+  foreground task) — a few µs tighter, but emit-first in the task is the chosen,
+  simpler ordering.
+- Per-axis gating — `gate_pieces` freezes the whole engine, matching existing
+  `broadcast_stop` behavior; multi-endstop simultaneous homing already stops
+  together today.
+- Any change to the cross-MCU relay or the drip-cohort deadman.

--- a/docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md
+++ b/docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md
@@ -107,13 +107,15 @@ raw pointer with no internal lock, and the engine tick runs in the higher-
 priority TIM5 ISR which would otherwise preempt the mutation. This matches what
 `handle_stop` does today.
 
-In `endstop_trip_task`, after the existing `kalico_native_emit_endstop_trip`,
-call `handle_stop_inner`:
+In `endstop_trip_task`, brake locally first (`handle_stop_inner`), then emit the
+trip event(s) as today:
 
 ```c
 void endstop_trip_task(void) {
     if (!sched_check_wake(&endstop_trip_wake))
         return;
+    uint64_t discard_clock;
+    handle_stop_inner(&discard_clock);   // brake locally; return value unused here
     uint8_t oid;
     struct endstop *e;
     foreach_oid(oid, e, command_config_endstop) {
@@ -122,17 +124,11 @@ void endstop_trip_task(void) {
         e->trip_pending = 0;
         kalico_native_emit_endstop_trip(e->endstop_id, e->trip_clock);
     }
-    uint64_t discard_clock;
-    handle_stop_inner(&discard_clock);   // brake locally; return value unused here
 }
 ```
 
-Order: emit first, then brake. The emit gets the trip to the host so it can fan
-the stop out to any genuinely-remote participant MCUs; the local brake follows.
-For same-MCU homing there are no other MCUs to relay to, so emit-first costs
-only a few µs of local overshoot. The brake gating the whole engine (not a
-single axis) matches the existing `broadcast_stop` semantics, which already
-gates each participant's whole engine.
+The brake gates the whole engine (not a single axis), matching the existing
+`broadcast_stop` semantics, which already gates each participant's whole engine.
 
 ### 2. Keep the brake clock honest
 
@@ -148,7 +144,29 @@ No explicit reset is needed across homing cycles: `ResumeStream` ungates after
 homing (`pieces_gated` → false), so the next trip's first gate recaptures a
 fresh `s_gate_clock`.
 
-### 3. Expose `pieces_gated` over the FFI
+### 3. The double stop is idempotent
+
+After the self-gate, the host *will* send its own `Stop` to every participant —
+including the MCU that already braked. That second stop must be a safe no-op:
+
+- **First stop (self-gate):** `pieces_gated` false → gate, capture
+  `s_gate_clock = now`.
+- **Second stop (host `Stop`):** `pieces_gated` true → `else` branch returns
+  `KALICO_OK` and the *stored* `s_gate_clock`. No re-gate, no `gate_pieces`
+  call, no clock overwrite. The host gets the `result=0` it expects and the
+  honest brake clock as `discard_clock`.
+
+There is no arrival-order hazard: the self-gate runs to completion inside
+`endstop_trip_task` before the main loop processes any incoming `Stop`, so
+"already gated" is always true when the host's `Stop` lands. `gate_pieces` is
+itself idempotent (`discard_pending` + set-flag), so even a direct double-gate
+would be harmless — the `pieces_gated` guard exists to preserve the *clock*, not
+to protect `gate_pieces`.
+
+This is exercised in the Rust tests below (gate, advance clock, gate again →
+`discard_clock` unchanged).
+
+### 4. Expose `pieces_gated` over the FFI
 
 The engine already has `pieces_gated()` (`engine.rs:264`, used internally in
 `runtime_ffi.rs`), but there is no C-callable export. Add one beside
@@ -162,7 +180,7 @@ pub unsafe extern "C" fn kalico_runtime_pieces_gated(rt: *mut KalicoRuntime) -> 
 and declare it in `rust/kalico-c-api/include/kalico_runtime.h`. Null/`!INIT_DONE`
 guards return `false` (matching the other accessors' conservative defaults).
 
-### 4. Lift the CLAUDE.md constraint
+### 5. Lift the CLAUDE.md constraint
 
 `CLAUDE.md` currently says (line 27-28):
 
@@ -225,8 +243,8 @@ the host `Stop` path reports it exactly as before.
 ## Out of scope
 
 - IRQ-immediate gating (braking inside `endstop_event` rather than the
-  foreground task) — a few µs tighter, but emit-first in the task is the chosen,
-  simpler ordering.
+  foreground task) — a few µs tighter, but the task-level brake is simpler and
+  the freeze clock is captured honestly either way.
 - Per-axis gating — `gate_pieces` freezes the whole engine, matching existing
   `broadcast_stop` behavior; multi-endstop simultaneous homing already stops
   together today.

--- a/docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md
+++ b/docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md
@@ -30,32 +30,11 @@ never fire mid-print.
    spawns `homing-trip-handler`, flushes the pump, and `broadcast_stop` sends a
    blocking `Stop` to every participating stepper MCU. Each `Stop` runs
    `handle_stop` → `kalico_runtime_gate_pieces` (freeze the curve evaluator) and
-   replies with `discard_clock = kalico_runtime_now_ticks`.
-4. **Reconcile.** The host reconstructs the **trip** position at `trip_clock`
-   and the **final** position at `discard_clock` from motion history.
+   replies with `discard_clock`.
 
 For same-MCU homing (endstop pin and homed steppers on one board — the Trident
 X/Y-on-H7 case) the physical brake waits for the full host round-trip in step 3.
 That latency is pure overshoot past the trigger point.
-
-### Why `discard_clock` is load-bearing
-
-`klippy/extras/homing.py:80` sets the post-home position to:
-
-```python
-trigger_height + (final_pos[axis] - trip_pos[axis])
-```
-
-`final_pos − trip_pos` is the **overshoot**, added to the trigger height and
-fed to `toolhead.set_position` (homing.py:305). It is `planned(discard_clock) −
-planned(trip_clock)`. Today this is correct because the MCU follows the planned
-trajectory right up until the host's `Stop`, so `discard_clock` equals the clock
-at which motion actually froze.
-
-If the MCU brakes early (this change) but the host still reads `discard_clock`
-from its *later* `Stop`, the overshoot is overstated by `speed × round-trip` and
-the homed position is wrong by that much — a systematic error. So the brake
-clock must stay honest (see design point 2).
 
 ## Design
 
@@ -65,7 +44,8 @@ Split the gating core out of `handle_stop` in `src/kalico_dispatch.c`. The only
 part `handle_stop` keeps for itself is the host-facing `send_stop_response` — a
 self-triggered stop has no host request to reply to, and sending an unsolicited
 `StopResponse` would desync the control channel (the host correlates responses
-by id).
+by id). `handle_stop_inner` is the existing `handle_stop` body, verbatim, minus
+the response.
 
 `handle_stop_inner` is **not** `static` — `endstop_trip_task` lives in
 `endstop.c`, which already includes `kalico_dispatch.h`, so its prototype goes
@@ -77,21 +57,17 @@ int32_t handle_stop_inner(uint64_t *discard_clock);
 ```
 
 ```c
-static uint64_t s_gate_clock;   // brake clock, captured on the first gate
-
+// kalico_dispatch.c
 int32_t handle_stop_inner(uint64_t *discard_clock) {
     int32_t rc = KALICO_ERR_NOT_INIT;
+    uint64_t dc = 0;
     if (runtime_handle) {
         irqstatus_t flag = irq_save();
-        if (!kalico_runtime_pieces_gated(runtime_handle)) {
-            rc = kalico_runtime_gate_pieces(runtime_handle);
-            s_gate_clock = kalico_runtime_now_ticks(runtime_handle);
-        } else {
-            rc = KALICO_OK;
-        }
+        rc = kalico_runtime_gate_pieces(runtime_handle);
+        dc = kalico_runtime_now_ticks(runtime_handle);
         irq_restore(flag);
     }
-    *discard_clock = s_gate_clock;
+    *discard_clock = dc;
     return rc;
 }
 
@@ -104,18 +80,19 @@ static void handle_stop(uint32_t correlation_id) {
 
 `irq_save`/`irq_restore` is required: `gate_pieces` mutates the engine through a
 raw pointer with no internal lock, and the engine tick runs in the higher-
-priority TIM5 ISR which would otherwise preempt the mutation. This matches what
-`handle_stop` does today.
+priority TIM5 ISR which would otherwise preempt the mutation. This is exactly
+what `handle_stop` does today.
 
-In `endstop_trip_task`, brake locally first (`handle_stop_inner`), then emit the
-trip event(s) as today:
+In `endstop_trip_task`, brake locally (`handle_stop_inner`), then emit the trip
+event(s) as today. The `discard_clock` out-param is ignored on the self-gate
+path — there is no host to report it to.
 
 ```c
 void endstop_trip_task(void) {
     if (!sched_check_wake(&endstop_trip_wake))
         return;
     uint64_t discard_clock;
-    handle_stop_inner(&discard_clock);   // brake locally; return value unused here
+    handle_stop_inner(&discard_clock);   // brake locally; out-param unused here
     uint8_t oid;
     struct endstop *e;
     foreach_oid(oid, e, command_config_endstop) {
@@ -130,57 +107,22 @@ void endstop_trip_task(void) {
 The brake gates the whole engine (not a single axis), matching the existing
 `broadcast_stop` semantics, which already gates each participant's whole engine.
 
-### 2. Keep the brake clock honest
-
-`handle_stop_inner` captures `s_gate_clock` the **first** time it gates and
-returns that stored clock on every subsequent call. So when the host's later
-`Stop` arrives and runs `handle_stop` → `handle_stop_inner`, it finds pieces
-already gated and replies with the **real brake time** instead of a fresh
-`now_ticks`. The host's reconstruction and the wire protocol are unchanged;
-`discard_clock` simply now always means "the clock motion actually froze,"
-whether the freeze was local or host-driven.
-
-No explicit reset is needed across homing cycles: `ResumeStream` ungates after
-homing (`pieces_gated` → false), so the next trip's first gate recaptures a
-fresh `s_gate_clock`.
-
-### 3. The double stop is idempotent
+### 2. The double stop just stops again
 
 After the self-gate, the host *will* send its own `Stop` to every participant —
-including the MCU that already braked. That second stop must be a safe no-op:
+including the MCU that already braked. That second stop simply runs
+`handle_stop_inner` again: `gate_pieces` is idempotent (`discard_pending` +
+set-flag), so re-gating an already-gated engine is a harmless no-op. The host
+gets its `StopResponse` as always. No special-casing, no remembered state.
 
-- **First stop (self-gate):** `pieces_gated` false → gate, capture
-  `s_gate_clock = now`.
-- **Second stop (host `Stop`):** `pieces_gated` true → `else` branch returns
-  `KALICO_OK` and the *stored* `s_gate_clock`. No re-gate, no `gate_pieces`
-  call, no clock overwrite. The host gets the `result=0` it expects and the
-  honest brake clock as `discard_clock`.
+> **Note (out of scope here):** with the self-gate, the host's `discard_clock`
+> (from its own late `Stop`) no longer marks the instant the toolhead actually
+> braked — it brakes earlier, at ≈`trip_clock`. The overshoot / slide-past-stop
+> accounting that consumes `discard_clock` is being reworked by a separate
+> mechanism and is intentionally **not** addressed here. This spec leaves the
+> host's `dispatch_endstop_trip` / position-reconstruction path untouched.
 
-There is no arrival-order hazard: the self-gate runs to completion inside
-`endstop_trip_task` before the main loop processes any incoming `Stop`, so
-"already gated" is always true when the host's `Stop` lands. `gate_pieces` is
-itself idempotent (`discard_pending` + set-flag), so even a direct double-gate
-would be harmless — the `pieces_gated` guard exists to preserve the *clock*, not
-to protect `gate_pieces`.
-
-This is exercised in the Rust tests below (gate, advance clock, gate again →
-`discard_clock` unchanged).
-
-### 4. Expose `pieces_gated` over the FFI
-
-The engine already has `pieces_gated()` (`engine.rs:264`, used internally in
-`runtime_ffi.rs`), but there is no C-callable export. Add one beside
-`kalico_runtime_gate_pieces` in `rust/kalico-c-api/src/runtime_ffi.rs`:
-
-```rust
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn kalico_runtime_pieces_gated(rt: *mut KalicoRuntime) -> bool { ... }
-```
-
-and declare it in `rust/kalico-c-api/include/kalico_runtime.h`. Null/`!INIT_DONE`
-guards return `false` (matching the other accessors' conservative defaults).
-
-### 5. Lift the CLAUDE.md constraint
+### 3. Lift the CLAUDE.md constraint
 
 `CLAUDE.md` currently says (line 27-28):
 
@@ -195,10 +137,10 @@ relay still fans the stop out cross-MCU — both paths converge on the same
 
 ## What stays unchanged
 
-- **Host side**: `broadcast_stop`, `dispatch_endstop_trip`, trip/final position
+- **Host side**: `broadcast_stop`, `dispatch_endstop_trip`, position
   reconstruction, `home_axis_start`, `ResumeStream`/ungate. The host still sends
-  `Stop` to every participant including the self-gated MCU; that `Stop` is now
-  idempotent there and returns the honest stored clock.
+  `Stop` to every participant including the self-gated MCU; that `Stop` is now a
+  harmless re-gate there.
 - **Wire protocol**: `kalico_endstop_tripped`, `Stop`/`StopResponse`,
   `endstop_query_state` — no format changes.
 - **Cross-MCU path**: a remote source MCU self-gates its own (idle) engine
@@ -208,43 +150,37 @@ relay still fans the stop out cross-MCU — both paths converge on the same
 
 No new error surface. `handle_stop_inner` preserves the existing `rc`
 (`KALICO_ERR_NOT_INIT` when the runtime handle is absent; `KALICO_OK`
-otherwise). The self-gate path ignores `rc` (there is no host to report to);
-the host `Stop` path reports it exactly as before.
+otherwise). The self-gate path ignores `rc` (there is no host to report to); the
+host `Stop` path reports it exactly as before.
 
 ## Testing
 
-- **Rust (`cargo nextest run`)**:
-  - `kalico_runtime_pieces_gated` returns the engine state (false before gate,
-    true after, false after ungate).
-  - An already-gated `handle_stop_inner`/`Stop` returns the stored first-gate
-    clock, not a fresh `now_ticks` (exercise via the `kalico-c-api`
-    `piece_gate.rs` harness: gate, advance the clock, gate again, assert the
-    returned `discard_clock` is unchanged).
+- **Rust (`cargo nextest run`)**: re-gating an already-gated engine is a
+  harmless no-op (exercise via the `kalico-c-api` `piece_gate.rs` harness: gate,
+  gate again, assert still gated and no error / no corruption).
 - **Existing suites**: `motion-bridge` `homing/tests.rs` and `pump` tests
   continue to pass unchanged (host path untouched).
 - **kalico-sim**: a same-MCU home (endstop + homed stepper on one emulated MCU)
   where the trip event is delivered to the host with deliberate latency; assert
   the curve evaluator freezes at trip time (motion stops before the host's
-  `Stop` lands) and the reported overshoot reflects the true brake, not the
-  host round-trip.
+  `Stop` lands).
 
 ## Files touched
 
 | File | Change |
 |------|--------|
-| `src/kalico_dispatch.c` | extract `handle_stop_inner` (non-`static`: gate + capture/return `s_gate_clock`); `handle_stop` calls it then `send_stop_response`; add `s_gate_clock` static. |
+| `src/kalico_dispatch.c` | extract `handle_stop_inner` (non-`static`, current `handle_stop` body minus the response); `handle_stop` calls it then `send_stop_response`. |
 | `src/kalico_dispatch.h` | declare `handle_stop_inner` (so `endstop.c` can call it). |
-| `src/endstop.c` | `endstop_trip_task` calls `handle_stop_inner` after emitting the trip event. |
-| `rust/kalico-c-api/src/runtime_ffi.rs` | add `kalico_runtime_pieces_gated` export. |
-| `rust/kalico-c-api/include/kalico_runtime.h` | declare `kalico_runtime_pieces_gated`. |
+| `src/endstop.c` | `endstop_trip_task` calls `handle_stop_inner` before emitting the trip event(s). |
 | `CLAUDE.md` | replace the "do not optimize same-MCU homing" note with the self-gate behavior. |
-| (tests) | `kalico-c-api` gate/clock coverage; kalico-sim same-MCU home. |
+| (tests) | `kalico-c-api` idempotent re-gate coverage; kalico-sim same-MCU home. |
 
 ## Out of scope
 
+- Overshoot / slide-past-stop accounting (`discard_clock` consumer) — handled by
+  a separate mechanism; the host path is untouched here.
 - IRQ-immediate gating (braking inside `endstop_event` rather than the
-  foreground task) — a few µs tighter, but the task-level brake is simpler and
-  the freeze clock is captured honestly either way.
+  foreground task) — a few µs tighter, but the task-level brake is simpler.
 - Per-axis gating — `gate_pieces` freezes the whole engine, matching existing
   `broadcast_stop` behavior; multi-endstop simultaneous homing already stops
   together today.

--- a/src/endstop.c
+++ b/src/endstop.c
@@ -104,6 +104,8 @@ endstop_trip_task(void)
 {
     if (!sched_check_wake(&endstop_trip_wake))
         return;
+    uint64_t discard_clock;
+    (void)handle_stop_inner(&discard_clock);
     uint8_t oid;
     struct endstop *e;
     foreach_oid(oid, e, command_config_endstop) {

--- a/src/kalico_dispatch.c
+++ b/src/kalico_dispatch.c
@@ -548,17 +548,25 @@ send_stop_response(uint32_t correlation_id, int32_t result, uint64_t discard_clo
     kalico_transport_send_frame(KALICO_CHANNEL_CONTROL, payload, sizeof(payload));
 }
 
-static void
-handle_stop(uint32_t correlation_id)
+int32_t
+handle_stop_inner(uint64_t *discard_clock)
 {
     int32_t rc = KALICO_ERR_NOT_INIT;
-    uint64_t discard_clock = 0;
+    *discard_clock = 0;
     if (runtime_handle) {
         irqstatus_t flag = irq_save();
         rc = kalico_runtime_gate_pieces(runtime_handle);
-        discard_clock = kalico_runtime_now_ticks(runtime_handle);
+        *discard_clock = kalico_runtime_now_ticks(runtime_handle);
         irq_restore(flag);
     }
+    return rc;
+}
+
+static void
+handle_stop(uint32_t correlation_id)
+{
+    uint64_t discard_clock = 0;
+    int32_t rc = handle_stop_inner(&discard_clock);
     send_stop_response(correlation_id, rc, discard_clock);
 }
 

--- a/src/kalico_dispatch.h
+++ b/src/kalico_dispatch.h
@@ -26,6 +26,10 @@ void kalico_native_emit_fault_event(uint16_t fault_code,
 
 void kalico_native_emit_endstop_trip(uint8_t endstop_id, uint64_t trip_clock);
 
+// Gating core of the Stop handler (gate + read discard clock, no response).
+// Shared so endstop.c can self-gate on a local trip without a host round-trip.
+int32_t handle_stop_inner(uint64_t *discard_clock);
+
 void send_status_heartbeat(void);
 
 #endif

--- a/src/kalico_dispatch.h
+++ b/src/kalico_dispatch.h
@@ -26,8 +26,6 @@ void kalico_native_emit_fault_event(uint16_t fault_code,
 
 void kalico_native_emit_endstop_trip(uint8_t endstop_id, uint64_t trip_clock);
 
-// Gating core of the Stop handler (gate + read discard clock, no response).
-// Shared so endstop.c can self-gate on a local trip without a host round-trip.
 int32_t handle_stop_inner(uint64_t *discard_clock);
 
 void send_status_heartbeat(void);


### PR DESCRIPTION
## Summary

When a locally-armed endstop trips, the MCU now brakes its own motion immediately instead of waiting for the host's `Stop` round-trip — cutting homing overshoot. This is the "same-MCU local-siren fast-path" deferred in the cross-MCU homing design, now that the cross-MCU relay is confirmed.

- Extract `handle_stop_inner` (the gating core of the `Stop` handler: `gate_pieces` + read discard clock, no host response) from `handle_stop` in `src/kalico_dispatch.c`; declared in `src/kalico_dispatch.h`.
- `endstop_trip_task` (`src/endstop.c`) calls `handle_stop_inner` to freeze the curve evaluator before emitting the trip event.
- The host path is untouched: `broadcast_stop` still fans the stop out to any genuinely-remote MCUs, and its later `Stop` to the self-gated MCU is a harmless **idempotent re-gate** (`gate_pieces` only sets a flag).
- Overshoot / slide-past-stop accounting is intentionally **out of scope** here (handled by a separate mechanism); no host-side, position-reconstruction, FFI, or wire-protocol changes.
- Lifts the `CLAUDE.md` "do not optimize same-MCU homing" constraint.

Design + plan: `docs/superpowers/specs/2026-06-14-same-mcu-homing-self-gate-design.md`, `docs/superpowers/plans/2026-06-14-same-mcu-homing-self-gate.md`.

## Test Plan

- [x] `./scripts/ci.sh quick` green (ruff, rust-test, rust-clippy `-D warnings`, rust-fmt, watchdog-canary)
- [x] Existing Rust guard `piece_gate.rs::gate_is_idempotent_like_a_repeated_stop` passes — the double-stop is a safe no-op
- [x] kalico-sim full mode, same-MCU `--sensorless-phase-test` (G28 X, virtual endstop + stepper on one MCU): PASS — trip self-gates locally
- [x] Hardware: flashed + validated on Trident (H723 + F446) and Neptune (F401); reduced homing overshoot confirms the local brake fires before the host `Stop`
- [ ] Note: the cross-MCU beacon sim (`--homing-test`) is blocked by a pre-existing `beacon.py` `HomingMove` import error on this branch, unrelated to this change (this change touches only MCU C firmware and cannot affect cross-MCU behavior)