### PR TITLE
fix(homing): insta-trip first approach when endstop already triggered

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -7,7 +7,6 @@ from klippy.bridge_endstop import AXIS_ENDSTOP_IDS, BridgeEndstop
 HOMING_POLL_PERIOD = 0.001
 TRIP_DEADLINE_MARGIN = 5.0
 _DRAIN_PAUSE_TIMEOUT = 60.0
-NO_MOVEMENT_EPSILON = 0.005
 
 
 def _endstop_section(config, axis_name):
@@ -377,12 +376,6 @@ class Homing:
             )
         toolhead.wait_moves()
         self._drain_motion_before_arming_device(gcmd, bridge, axis)
-        if endstop.is_triggered():
-            raise gcmd.error(
-                "%s endstop already triggered — move off the trigger before"
-                " homing or probing" % ("XYZ"[axis],)
-            )
-        start_axis_pos = toolhead.get_position()[axis]
         provider = entry["provider"]
         if provider is not None and hasattr(provider, "trip_move_begin"):
             provider.trip_move_begin(entry)
@@ -429,11 +422,9 @@ class Homing:
                 provider.trip_move_end(entry)
         trip_pos, final_pos, trip_clock = result
         _verify_latched_trip(gcmd, axis, endstop, trip_clock)
-        if abs(trip_pos[axis] - start_axis_pos) < NO_MOVEMENT_EPSILON:
-            raise gcmd.error(
-                "%s endstop triggered prior to movement — trigger is stuck"
-                " or miswired" % ("XYZ"[axis],)
-            )
+        # TODO: guard a still-triggered endstop on the second home after
+        # retract (where zero movement is the real stuck/miswired fault) once
+        # second-approach homing lands; the first approach may insta-trip.
         return trip_pos, final_pos
 
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -7,6 +7,7 @@ from . import manual_probe
 
 Z_AXIS = 2
 ACCURACY_DEFAULT_SAMPLES = 10
+NO_MOVEMENT_EPSILON = 0.005
 
 
 def calc_probe_z_result(values, method):
@@ -152,6 +153,11 @@ class PrinterProbe:
                 "trigger_height": None,
             },
         )
+        if abs(trip_pos[Z_AXIS] - current_z) < NO_MOVEMENT_EPSILON:
+            raise gcmd.error(
+                "Probe triggered prior to movement — probe is already in"
+                " contact or the trigger is stuck"
+            )
         newpos = list(toolhead.get_position())
         newpos[Z_AXIS] = final_pos[Z_AXIS]
         toolhead.set_position(newpos)

--- a/test/test_homing_trip_arm.py
+++ b/test/test_homing_trip_arm.py
@@ -4,7 +4,7 @@ from klippy.extras.homing import Homing
 
 
 class ArmReached(Exception):
-    """Sentinel proving trip_move got past the already-triggered check."""
+    """Sentinel proving trip_move armed the endstop instead of erroring."""
 
 
 class FakeGcmd:
@@ -28,6 +28,7 @@ class FakeEndstop:
         return self.triggered_after_wait
 
     def arm(self, poll_period):
+        self.calls.append("arm")
         raise ArmReached()
 
 
@@ -71,22 +72,20 @@ def run_trip_move(endstop):
     )
 
 
-def test_pin_triggered_only_while_moves_queued_does_not_error():
-    # After Z homes on the probe, the head sits at the trigger point while
-    # the lift move is still queued — the live pin must be sampled only
-    # after wait_moves, when the lift has physically completed.
+def test_trip_move_arms_when_endstop_already_triggered():
+    # Matches mainline: an already-triggered endstop is not a precheck error.
+    # The first approach arms the endstop and lets it insta-trip — the MCU
+    # samples the live pin and brakes immediately (src/endstop.c) and the
+    # bridge buffers the early trip.
+    endstop = FakeEndstop(triggered_after_wait=True)
+    with pytest.raises(ArmReached):
+        run_trip_move(endstop)
+    assert "arm" in endstop.calls
+    assert "is_triggered" not in endstop.calls
+
+
+def test_trip_move_waits_for_queued_motion_before_arming():
     endstop = FakeEndstop(triggered_after_wait=False)
     with pytest.raises(ArmReached):
         run_trip_move(endstop)
-    assert endstop.calls.index("wait_moves") < endstop.calls.index(
-        "is_triggered"
-    )
-
-
-def test_pin_still_triggered_after_wait_moves_errors():
-    endstop = FakeEndstop(triggered_after_wait=True)
-    with pytest.raises(RuntimeError, match="already triggered"):
-        run_trip_move(endstop)
-    assert endstop.calls.index("wait_moves") < endstop.calls.index(
-        "is_triggered"
-    )
+    assert endstop.calls.index("wait_moves") < endstop.calls.index("arm")

--- a/test/test_probe_logic.py
+++ b/test/test_probe_logic.py
@@ -88,3 +88,59 @@ def test_multi_probe_lifecycle_is_noop():
     probe = PrinterProbe.__new__(PrinterProbe)
     assert probe.multi_probe_begin() is None
     assert probe.multi_probe_end() is None
+
+
+class _ProbeError(RuntimeError):
+    pass
+
+
+class _ProbeGCmd:
+    def error(self, msg):
+        return _ProbeError(msg)
+
+
+class _FakeRail:
+    def get_range(self):
+        return (-2.0, 200.0)
+
+
+class _FakeKin:
+    def _axis_rails(self):
+        return {2: _FakeRail()}
+
+
+class _FakeToolhead:
+    def __init__(self, z):
+        self._z = z
+
+    def get_kinematics(self):
+        return _FakeKin()
+
+    def get_position(self):
+        return [0.0, 0.0, self._z, 0.0]
+
+    def set_position(self, newpos):
+        self._z = newpos[2]
+
+
+def _probe_with_trip(trip_z, final_z):
+    from klippy.extras.probe import PrinterProbe
+
+    probe = PrinterProbe.__new__(PrinterProbe)
+    probe._endstop = object()
+
+    class _Homing:
+        def trip_move(self, gcmd, toolhead, bridge, axis, *_args):
+            return [0.0, 0.0, trip_z], [0.0, 0.0, final_z]
+
+    toolhead = _FakeToolhead(z=10.0)
+    return probe._probe_once(_ProbeGCmd(), toolhead, _Homing(), object(), 5.0)
+
+
+def test_probe_rejects_trigger_prior_to_movement():
+    with pytest.raises(_ProbeError, match="prior to movement"):
+        _probe_with_trip(trip_z=10.0, final_z=10.0)
+
+
+def test_probe_returns_trip_height_after_real_movement():
+    assert _probe_with_trip(trip_z=3.5, final_z=3.4) == pytest.approx(3.5)


### PR DESCRIPTION
## Summary
- An already-triggered endstop is no longer a hard error on the first homing approach. Previously G28 raised `<axis> endstop already triggered — move off the trigger before homing or probing`, which doesn't match mainline. Now the first approach insta-trips at the trigger point and completes, exactly as if it tripped on the first poll.
- Removed two first-approach guards from `Homing.trip_move`: the pre-move `is_triggered()` check and the post-move zero-movement check. The firmware already supports this — `src/endstop.c` samples the live pin level on the first poll after arming and trips immediately, and the bridge buffers it as an early trip. The still-triggered fault belongs on the second home after retract (not yet implemented); left a TODO there.
- Kept the no-movement rejection for **probing**, moved into `PrinterProbe._probe_once` (`Probe triggered prior to movement…`), matching mainline — a probe already in contact must not yield a bad Z.
- Applies to all axes (X/Y/Z); the axis in the old message was just the formatted name.

## Test Plan
- [x] `./scripts/ci.sh quick` green (ruff, rust-test, rust-clippy, rust-fmt, watchdog-canary)
- [x] `./scripts/ci.sh py` green (335 passed)
- [x] New/updated unit tests: `test/test_homing_trip_arm.py` (trip_move arms instead of erroring when already triggered), `test/test_probe_logic.py` (probe rejects trigger-prior-to-movement, returns trip height after real movement)
- [x] Flashed to the Neptune bench on this branch; host comes up ready
- [x] Bench: home Y with the endstop already pressed → completes via insta-trip instead of erroring