### PR TITLE
temporal: collapse junction handling to a single collinearity predicate

### DIFF
--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -15,8 +15,7 @@ pub use topp::{
 
 pub mod multi;
 pub use multi::{
-    BatchError, BatchInput, BatchOutput, GridStrategy, JoiningStatus, JunctionInfo, SegmentInput,
-    plan_batch,
+    BatchError, BatchInput, BatchOutput, GridStrategy, JoiningStatus, SegmentInput, plan_batch,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/rust/temporal/src/multi/chain.rs
+++ b/rust/temporal/src/multi/chain.rs
@@ -1,17 +1,16 @@
-use crate::multi::junction::JunctionKind;
 use crate::{BindingSummary, GridSample, TopProfile};
 use std::ops::RangeInclusive;
 
 #[allow(clippy::range_minus_one)]
 pub(crate) fn partition_chains(
     n_segments: usize,
-    kinds: &[JunctionKind],
+    collinear: &[bool],
 ) -> Vec<RangeInclusive<usize>> {
-    debug_assert_eq!(kinds.len() + 1, n_segments);
+    debug_assert_eq!(collinear.len() + 1, n_segments);
     let mut chains = Vec::new();
     let mut start = 0;
-    for (k, kind) in kinds.iter().enumerate() {
-        if *kind == JunctionKind::Corner {
+    for (k, &is_collinear) in collinear.iter().enumerate() {
+        if !is_collinear {
             chains.push(start..=k);
             start = k + 1;
         }

--- a/rust/temporal/src/multi/chain/tests.rs
+++ b/rust/temporal/src/multi/chain/tests.rs
@@ -1,31 +1,26 @@
 use super::*;
-use crate::multi::junction::JunctionKind;
 use crate::{
     BindingConstraint, BindingSummary, GridSample, GridScheme, SolveStatus, TopProfile,
     WorstBinding,
 };
 
 #[test]
-fn partition_splits_only_at_corners() {
-    let kinds = [
-        JunctionKind::Smooth,
-        JunctionKind::Corner,
-        JunctionKind::Smooth,
-    ];
-    let chains = partition_chains(4, &kinds);
+fn partition_splits_only_at_non_collinear() {
+    let collinear = [true, false, true];
+    let chains = partition_chains(4, &collinear);
     assert_eq!(chains, vec![0..=1, 2..=3]);
 }
 
 #[test]
-fn partition_all_smooth_is_one_chain() {
-    let kinds = [JunctionKind::Smooth, JunctionKind::Smooth];
-    assert_eq!(partition_chains(3, &kinds), vec![0..=2]);
+fn partition_all_collinear_is_one_chain() {
+    let collinear = [true, true];
+    assert_eq!(partition_chains(3, &collinear), vec![0..=2]);
 }
 
 #[test]
-fn partition_all_corners_is_all_singletons() {
-    let kinds = [JunctionKind::Corner, JunctionKind::Corner];
-    assert_eq!(partition_chains(3, &kinds), vec![0..=0, 1..=1, 2..=2]);
+fn partition_none_collinear_is_all_singletons() {
+    let collinear = [false, false];
+    assert_eq!(partition_chains(3, &collinear), vec![0..=0, 1..=1, 2..=2]);
 }
 
 #[test]

--- a/rust/temporal/src/multi/joining.rs
+++ b/rust/temporal/src/multi/joining.rs
@@ -210,37 +210,4 @@ pub(crate) fn exchange_follower_tails(
 }
 
 #[cfg(test)]
-pub(crate) fn forward_sweep(states: &mut [ChainState], corner_caps: &[f64]) -> usize {
-    const EPS_VEL: f64 = 1e-3;
-    let mut dirty_count = 0;
-    for k in 1..states.len() {
-        let proposed_v_start = corner_caps[k - 1].min(states[k - 1].v_end);
-        if (proposed_v_start - states[k].v_start).abs() > EPS_VEL {
-            states[k].v_start = proposed_v_start;
-            states[k].dirty = true;
-            dirty_count += 1;
-        }
-    }
-    dirty_count
-}
-
-#[cfg(test)]
-pub(crate) fn reverse_sweep(states: &mut [ChainState], corner_caps: &[f64]) -> usize {
-    const EPS_VEL: f64 = 1e-3;
-    if states.len() < 2 {
-        return 0;
-    }
-    let mut dirty_count = 0;
-    for k in (0..states.len() - 1).rev() {
-        let proposed_v_end = corner_caps[k].min(states[k + 1].v_start);
-        if (proposed_v_end - states[k].v_end).abs() > EPS_VEL {
-            states[k].v_end = proposed_v_end;
-            states[k].dirty = true;
-            dirty_count += 1;
-        }
-    }
-    dirty_count
-}
-
-#[cfg(test)]
 mod tests;

--- a/rust/temporal/src/multi/joining/tests.rs
+++ b/rust/temporal/src/multi/joining/tests.rs
@@ -11,34 +11,6 @@ fn make_state(v_start: f64, v_end: f64) -> ChainState {
 }
 
 #[test]
-fn forward_propagates_v_end_to_next_v_start() {
-    let mut states = vec![make_state(0.0, 100.0), make_state(0.0, 200.0)];
-    let corner_caps = vec![150.0];
-    let dirty = forward_sweep(&mut states, &corner_caps);
-    assert_eq!(dirty, 1);
-    assert!((states[1].v_start - 100.0).abs() < 1e-6);
-    assert!(states[1].dirty);
-}
-
-#[test]
-fn forward_no_change_no_dirty() {
-    let mut states = vec![make_state(0.0, 150.0), make_state(150.0, 200.0)];
-    let corner_caps = vec![150.0];
-    let dirty = forward_sweep(&mut states, &corner_caps);
-    assert_eq!(dirty, 0);
-    assert!(!states[1].dirty);
-}
-
-#[test]
-fn reverse_propagates_v_start_to_prev_v_end() {
-    let mut states = vec![make_state(0.0, 200.0), make_state(100.0, 200.0)];
-    let corner_caps = vec![150.0];
-    let dirty = reverse_sweep(&mut states, &corner_caps);
-    assert_eq!(dirty, 1);
-    assert!((states[0].v_end - 100.0).abs() < 1e-6);
-}
-
-#[test]
 fn bidirectional_sweep_uses_lower_achieved_side() {
     let mut states = vec![make_state(0.0, 120.0), make_state(80.0, 0.0)];
     let corner_caps = vec![150.0];
@@ -50,14 +22,4 @@ fn bidirectional_sweep_uses_lower_achieved_side() {
     assert!((states[1].v_start - 80.0).abs() < 1e-6);
     assert!(states[0].dirty);
     assert!(!states[1].dirty);
-}
-
-#[test]
-fn converges_in_one_sweep_on_already_consistent() {
-    let mut states = vec![make_state(0.0, 150.0), make_state(150.0, 200.0)];
-    let corner_caps = vec![150.0];
-    let f_dirty = forward_sweep(&mut states, &corner_caps);
-    let r_dirty = reverse_sweep(&mut states, &corner_caps);
-    assert_eq!(f_dirty, 0);
-    assert_eq!(r_dirty, 0);
 }

--- a/rust/temporal/src/multi/junction.rs
+++ b/rust/temporal/src/multi/junction.rs
@@ -1,46 +1,35 @@
 use nurbs::VectorNurbs;
 use nurbs::eval::{vector_derivative, vector_eval};
 
-/// Fuse threshold: junctions with tangent disagreement at or below this are
-/// chain-fused (treated G1-continuous). Purely a numerical collinearity
-/// epsilon — anything sharper is a corner and comes to a full stop.
-const THETA_FUSE_RAD: f64 = 1e-3;
+/// Two adjacent curves count as collinear when the forward unit tangent at the
+/// left curve's end and at the right curve's start disagree by at most this
+/// angle. Purely a numerical collinearity epsilon — anything sharper is a
+/// full-stop junction the blender did not round away.
+const THETA_COLLINEAR_RAD: f64 = 1e-3;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum JunctionKind {
-    Smooth,
-    Corner,
-}
-
-pub(crate) fn classify_junction_curves(
-    left: &VectorNurbs<f64, 3>,
-    right: &VectorNurbs<f64, 3>,
-) -> JunctionKind {
+/// `true` when the path is tangent-continuous (G1) across the junction between
+/// two adjacent curves, within `THETA_COLLINEAR_RAD`. A degenerate (zero)
+/// tangent on either side is never collinear — an undefined direction cannot be
+/// parallel to anything — which is also what isolates zero-displacement
+/// (virtual-path) segments into their own chains.
+///
+/// This is the sole junction predicate: a non-collinear junction is exactly a
+/// chain boundary / full stop. The batch solver partitions chains on it and the
+/// streaming planner snaps its re-solve window to it.
+#[must_use]
+pub fn are_collinear(left: &VectorNurbs<f64, 3>, right: &VectorNurbs<f64, 3>) -> bool {
     let t_left = forward_unit_tangent_at_end(left);
     let t_right = forward_unit_tangent_at_start(right);
-    classify_junction(&t_left, &t_right)
+    tangents_collinear(&t_left, &t_right)
 }
 
-/// `true` when the junction between two adjacent curves is a corner (full-stop
-/// boundary) under the exact same classification the batch solver uses to
-/// partition chains. The streaming planner uses this to snap its bounded
-/// re-solve sub-window to a chain boundary.
-#[must_use]
-pub fn is_corner_between(left: &VectorNurbs<f64, 3>, right: &VectorNurbs<f64, 3>) -> bool {
-    classify_junction_curves(left, right) == JunctionKind::Corner
-}
-
-fn classify_junction(t_left: &[f64; 3], t_right: &[f64; 3]) -> JunctionKind {
+fn tangents_collinear(t_left: &[f64; 3], t_right: &[f64; 3]) -> bool {
     let left_degenerate = t_left[0].abs() + t_left[1].abs() + t_left[2].abs() < 1e-12;
     let right_degenerate = t_right[0].abs() + t_right[1].abs() + t_right[2].abs() < 1e-12;
     if left_degenerate || right_degenerate {
-        return JunctionKind::Corner;
+        return false;
     }
-    if turn_angle(t_left, t_right) <= THETA_FUSE_RAD {
-        JunctionKind::Smooth
-    } else {
-        JunctionKind::Corner
-    }
+    turn_angle(t_left, t_right) <= THETA_COLLINEAR_RAD
 }
 
 fn turn_angle(t_left: &[f64; 3], t_right: &[f64; 3]) -> f64 {

--- a/rust/temporal/src/multi/junction/tests.rs
+++ b/rust/temporal/src/multi/junction/tests.rs
@@ -5,41 +5,29 @@ fn line(from: [f64; 3], to: [f64; 3]) -> VectorNurbs<f64, 3> {
 }
 
 #[test]
-fn collinear_junction_is_smooth() {
+fn collinear_junction_is_collinear() {
     let a = line([0.0; 3], [40.0, 0.0, 0.0]);
     let b = line([40.0, 0.0, 0.0], [100.0, 0.0, 0.0]);
-    assert!(matches!(
-        classify_junction_curves(&a, &b),
-        JunctionKind::Smooth
-    ));
+    assert!(are_collinear(&a, &b));
 }
 
 #[test]
-fn right_angle_junction_is_corner() {
+fn right_angle_junction_is_not_collinear() {
     let a = line([0.0; 3], [40.0, 0.0, 0.0]);
     let b = line([40.0, 0.0, 0.0], [40.0, 60.0, 0.0]);
-    assert!(matches!(
-        classify_junction_curves(&a, &b),
-        JunctionKind::Corner
-    ));
+    assert!(!are_collinear(&a, &b));
 }
 
 #[test]
-fn reversal_junction_is_corner() {
+fn reversal_junction_is_not_collinear() {
     let a = line([0.0; 3], [40.0, 0.0, 0.0]);
     let b = line([40.0, 0.0, 0.0], [0.0, 0.0, 0.0]);
-    assert!(matches!(
-        classify_junction_curves(&a, &b),
-        JunctionKind::Corner
-    ));
+    assert!(!are_collinear(&a, &b));
 }
 
 #[test]
-fn kink_just_above_fuse_threshold_is_corner() {
+fn kink_just_above_threshold_is_not_collinear() {
     let a = line([0.0; 3], [40.0, 0.0, 0.0]);
     let b = line([40.0, 0.0, 0.0], [80.0, 40.0 * (2e-3_f64).tan(), 0.0]);
-    assert!(matches!(
-        classify_junction_curves(&a, &b),
-        JunctionKind::Corner
-    ));
+    assert!(!are_collinear(&a, &b));
 }

--- a/rust/temporal/src/multi/mod.rs
+++ b/rust/temporal/src/multi/mod.rs
@@ -48,7 +48,6 @@ pub struct BatchShaping {
 #[derive(Debug)]
 pub struct BatchOutput {
     pub profiles: Vec<TopProfile>,
-    pub junctions: Vec<JunctionInfo>,
     pub joining_sweeps: u32,
     pub joining_status: JoiningStatus,
 }
@@ -59,12 +58,6 @@ pub enum JoiningStatus {
     Converged,
     StalledOnInfeasibleSegment { last_dirty_count: usize },
     CappedAtMaxSweeps { last_dirty_count: usize },
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct JunctionInfo {
-    pub between_segments: (usize, usize),
-    pub v_junction: f64,
 }
 
 #[derive(Debug, Error)]
@@ -122,12 +115,10 @@ pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
 
     let k = input.segments.len();
 
-    let kinds: Vec<junction::JunctionKind> = (0..k - 1)
-        .map(|i| {
-            junction::classify_junction_curves(input.segments[i].curve, input.segments[i + 1].curve)
-        })
+    let collinear: Vec<bool> = (0..k - 1)
+        .map(|i| junction::are_collinear(input.segments[i].curve, input.segments[i + 1].curve))
         .collect();
-    let chain_ranges = chain::partition_chains(k, &kinds);
+    let chain_ranges = chain::partition_chains(k, &collinear);
     let n_chains = chain_ranges.len();
 
     let grid_max_n = match input.grid_strategy {
@@ -257,16 +248,8 @@ pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
         })
         .collect();
 
-    let junction_infos: Vec<JunctionInfo> = (0..k - 1)
-        .map(|j| JunctionInfo {
-            between_segments: (j, j + 1),
-            v_junction: profiles[j].samples.last().map_or(0.0, |s| s.v),
-        })
-        .collect();
-
     Ok(BatchOutput {
         profiles,
-        junctions: junction_infos,
         joining_sweeps: sweeps,
         joining_status,
     })

--- a/rust/temporal/src/multi/tests.rs
+++ b/rust/temporal/src/multi/tests.rs
@@ -169,7 +169,6 @@ fn plan_batch_threads_nonzero_initial_velocity() {
         v_last < 1.0,
         "terminal velocity {v_last} must be ≈ 0 mm/s under terminal_velocity = 0.0",
     );
-    assert!(output.junctions.is_empty());
 }
 
 fn zero_curve_at(p: [f64; 3]) -> VectorNurbs<f64, 3> {

--- a/rust/temporal/tests/multi_segment.rs
+++ b/rust/temporal/tests/multi_segment.rs
@@ -1,6 +1,10 @@
 use nurbs::VectorNurbs;
 use temporal::{BatchInput, GridStrategy, JoiningStatus, Limits, SegmentInput, plan_batch};
 
+fn v_junction_at(output: &temporal::BatchOutput, k: usize) -> f64 {
+    output.profiles[k].samples.last().unwrap().v
+}
+
 fn textbook_limits() -> Limits {
     Limits::axis_boxes([500.0; 3], [5_000.0; 3], [100_000.0; 3])
 }
@@ -14,8 +18,8 @@ fn adaptive() -> GridStrategy {
 }
 
 fn assert_junction_continuity_for_all(output: &temporal::BatchOutput, eps_mm_s: f64) {
-    for (k, junction) in output.junctions.iter().enumerate() {
-        let v_jct = junction.v_junction;
+    for k in 0..output.profiles.len().saturating_sub(1) {
+        let v_jct = v_junction_at(output, k);
         let v_end_left = output.profiles[k].samples.last().unwrap().v;
         let v_start_right = output.profiles[k + 1].samples[0].v;
         assert!(
@@ -75,7 +79,7 @@ mod fixture_1_two_g1_sharp_corner {
         assert_eq!(output.profiles.len(), 2);
 
         assert_junction_continuity_for_all(&output, 1.0);
-        let v_jct = output.junctions[0].v_junction;
+        let v_jct = v_junction_at(&output, 0);
         assert!(
             v_jct.abs() < 0.1,
             "tangent-discontinuous junction must come to a full stop, got {v_jct}"
@@ -134,7 +138,7 @@ mod fixture_2_g1_to_g5_smooth {
         };
         let output = plan_batch(input).expect("should succeed");
 
-        let v_jct = output.junctions[0].v_junction;
+        let v_jct = v_junction_at(&output, 0);
         assert!(
             v_jct > 1.0,
             "smooth G1→G5 junction must carry speed through the fuse, got {v_jct}"

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -493,7 +493,7 @@ impl ShaperState {
         while idx > 0 {
             let prev = &self.uncommitted_moves[idx - 1].segment.xyz;
             let cur = &self.uncommitted_moves[idx].segment.xyz;
-            if temporal::multi::junction::is_corner_between(prev, cur) {
+            if !temporal::multi::junction::are_collinear(prev, cur) {
                 return idx;
             }
             idx -= 1;


### PR DESCRIPTION
## Summary

Groundwork for geometry-level junction blending. No behavior change — this only removes dead/vestigial junction machinery and collapses the junction taxonomy to a single predicate.

- **Remove `JunctionInfo` / `BatchOutput.junctions`.** It was computed on every solve and exposed publicly, but consumed only by tests. Tests now read junction velocity off the profile tail (`v_junction_at`), identical to how it was computed.
- **Remove the test-only `forward_sweep` / `reverse_sweep` helpers** and their orphaned tests; the real `bidirectional_junction_sweep` test stays.
- **Collapse `JunctionKind { Smooth, Corner }` + `classify_junction*` + `is_corner_between` into one predicate, `are_collinear()`.** A non-collinear junction is exactly a chain boundary / full stop. `partition_chains` now splits on collinearity flags; the streaming planner snaps its re-solve window with `!are_collinear()`. `is_corner_between` was just `is_non_collinear` under another name.
- The degenerate-tangent → not-collinear branch is kept and documented, because it's what isolates zero-displacement (virtual-path) segments into their own chains.

## Test Plan

- [x] `cargo nextest run -p temporal -p trajectory` — 335 passed
- [x] `./scripts/ci.sh quick` — ruff, rust-test, rust-clippy, rust-fmt, watchdog-canary all pass
- [x] Flashed to Neptune (F401 + host motion-bridge cdylib rebuilt); klippy reaches `ready` running this branch, no startup crash