### PR TITLE
Executed-trajectory limit-utilization metric: per-family peaks + named limiters

### DIFF
--- a/rust/motion-engine/src/binding_report.rs
+++ b/rust/motion-engine/src/binding_report.rs
@@ -28,8 +28,6 @@ pub fn label_binding(
             return None;
         }
     };
-    // Dynamic limit sets have no config name; show their reserved kind. Config
-    // sets resolve to their declared section name by index.
     let limit = match kind {
         temporal::LimitKind::Feedrate => "feedrate".to_string(),
         temporal::LimitKind::RuntimeCap => "runtime_caps".to_string(),

--- a/rust/motion-engine/src/binding_report.rs
+++ b/rust/motion-engine/src/binding_report.rs
@@ -35,14 +35,14 @@ pub fn label_binding(c: BindingConstraint, names: &[String]) -> Option<BindingLa
     })
 }
 
-/// Fields carried by the per-move `replan_anytime` structured event. The gap is
-/// the deterministic closeness-to-limit measure derived from the verified worst
-/// binding ratio: `gap = (1 - ratio).max(0)` — `0` means the trajectory sits on
-/// the kinematic limit, `0.06` means it runs ~6% below. `ratio` and `constraint`
-/// both come from `check_chain`'s `BindingSummary`, so neither is fabricated.
+/// Fields carried by the per-move `replan_anytime` structured event. `limiter_*`
+/// names which kinematic limit the solver pinned (the family/derivative, and
+/// whether via pressure-advance); `binding_ratio` is the solver's grid-measured
+/// peak ratio for that limit. Both come from `check_chain`'s `BindingSummary`, so
+/// neither is fabricated. Comparing `binding_ratio` against the executed
+/// `peak_utilization` surfaces any grid-vs-executed measurement divergence.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnytimeEventFields {
-    pub gap: f64,
     pub limiter_limit: String,
     pub limiter_derivative: &'static str,
     pub limiter_via_pa: bool,
@@ -59,17 +59,12 @@ pub fn anytime_event_fields(
         .and_then(|w| label_binding(w.constraint, names).map(|l| (l, w.ratio)))
     {
         Some((l, ratio)) => AnytimeEventFields {
-            gap: (1.0 - ratio).max(0.0),
             limiter_limit: l.limit,
             limiter_derivative: l.derivative,
             limiter_via_pa: l.via_pa,
             binding_ratio: ratio,
         },
-        // No binding reported ⇒ no measurable shortfall. A gap of 0 honestly
-        // says "no conservativeness measured", never inventing 100% from a
-        // missing ratio.
         None => AnytimeEventFields {
-            gap: 0.0,
             limiter_limit: String::from("none"),
             limiter_derivative: "none",
             limiter_via_pa: false,

--- a/rust/motion-engine/src/binding_report.rs
+++ b/rust/motion-engine/src/binding_report.rs
@@ -10,7 +10,11 @@ pub struct BindingLabel {
     pub via_pa: bool,
 }
 
-pub fn label_binding(c: BindingConstraint, names: &[String]) -> Option<BindingLabel> {
+pub fn label_binding(
+    c: BindingConstraint,
+    kind: temporal::LimitKind,
+    names: &[String],
+) -> Option<BindingLabel> {
     let (set, derivative, via_pa) = match c {
         BindingConstraint::Velocity { set } => (set, "velocity", false),
         BindingConstraint::AccelNorm { set } => (set, "accel", false),
@@ -24,10 +28,16 @@ pub fn label_binding(c: BindingConstraint, names: &[String]) -> Option<BindingLa
             return None;
         }
     };
-    let limit = names
-        .get(set)
-        .cloned()
-        .unwrap_or_else(|| "runtime_caps".to_string());
+    // Dynamic limit sets have no config name; show their reserved kind. Config
+    // sets resolve to their declared section name by index.
+    let limit = match kind {
+        temporal::LimitKind::Feedrate => "feedrate".to_string(),
+        temporal::LimitKind::RuntimeCap => "runtime_caps".to_string(),
+        temporal::LimitKind::Config => names
+            .get(set)
+            .cloned()
+            .unwrap_or_else(|| "runtime_caps".to_string()),
+    };
     Some(BindingLabel {
         limit,
         derivative,
@@ -56,7 +66,7 @@ pub fn anytime_event_fields(
 ) -> AnytimeEventFields {
     match binding
         .worst
-        .and_then(|w| label_binding(w.constraint, names).map(|l| (l, w.ratio)))
+        .and_then(|w| label_binding(w.constraint, w.kind, names).map(|l| (l, w.ratio)))
     {
         Some((l, ratio)) => AnytimeEventFields {
             limiter_limit: l.limit,
@@ -78,7 +88,7 @@ pub const ROLLUP_INTERVAL: Duration = Duration::from_secs(1);
 pub struct BindingAccumulator {
     window: HashMap<BindingConstraint, u64>,
     window_samples: u64,
-    worst: Option<(BindingConstraint, f64, f64)>,
+    worst: Option<(BindingConstraint, temporal::LimitKind, f64, f64)>,
     last_rollup: Instant,
 }
 
@@ -98,8 +108,8 @@ impl BindingAccumulator {
             self.window_samples += u64::from(*n);
         }
         if let Some(w) = &summary.worst {
-            if self.worst.is_none_or(|(_, r, _)| w.ratio > r) {
-                self.worst = Some((w.constraint, w.ratio, t));
+            if self.worst.is_none_or(|(_, _, r, _)| w.ratio > r) {
+                self.worst = Some((w.constraint, w.kind, w.ratio, t));
             }
         }
     }
@@ -126,8 +136,8 @@ impl BindingAccumulator {
     }
 
     fn emit(&self, names: &[String]) {
-        if let Some((c, ratio, t)) = self.worst {
-            if let Some(l) = label_binding(c, names) {
+        if let Some((c, kind, ratio, t)) = self.worst {
+            if let Some(l) = label_binding(c, kind, names) {
                 tracing::info!(
                     subsystem = "motion",
                     event = "binding_rollup",
@@ -142,7 +152,7 @@ impl BindingAccumulator {
             }
         }
         for (c, count) in &self.window {
-            if let Some(l) = label_binding(*c, names) {
+            if let Some(l) = label_binding(*c, temporal::LimitKind::Config, names) {
                 tracing::info!(
                     subsystem = "motion",
                     event = "binding_hist",
@@ -162,7 +172,7 @@ impl BindingAccumulator {
     }
 
     #[cfg(test)]
-    pub fn worst(&self) -> Option<(BindingConstraint, f64, f64)> {
+    pub fn worst(&self) -> Option<(BindingConstraint, temporal::LimitKind, f64, f64)> {
         self.worst
     }
 }

--- a/rust/motion-engine/src/binding_report.rs
+++ b/rust/motion-engine/src/binding_report.rs
@@ -43,12 +43,6 @@ pub fn label_binding(
     })
 }
 
-/// Fields carried by the per-move `replan_anytime` structured event. `limiter_*`
-/// names which kinematic limit the solver pinned (the family/derivative, and
-/// whether via pressure-advance); `binding_ratio` is the solver's grid-measured
-/// peak ratio for that limit. Both come from `check_chain`'s `BindingSummary`, so
-/// neither is fabricated. Comparing `binding_ratio` against the executed
-/// `peak_utilization` surfaces any grid-vs-executed measurement divergence.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AnytimeEventFields {
     pub limiter_limit: String,

--- a/rust/motion-engine/src/binding_report/tests.rs
+++ b/rust/motion-engine/src/binding_report/tests.rs
@@ -14,9 +14,10 @@ fn all_labeled_variants_map_to_correct_derivative_and_pa_flag() {
         (BindingConstraint::PaJerk { set: 0 }, "jerk", true),
     ];
     for &(constraint, expected_derivative, expected_via_pa) in cases {
-        let label = label_binding(constraint, &names).unwrap_or_else(|| {
-            panic!("{constraint:?} must produce a label");
-        });
+        let label =
+            label_binding(constraint, temporal::LimitKind::Config, &names).unwrap_or_else(|| {
+                panic!("{constraint:?} must produce a label");
+            });
         assert_eq!(
             label.derivative, expected_derivative,
             "{constraint:?}: wrong derivative"
@@ -31,18 +32,65 @@ fn all_labeled_variants_map_to_correct_derivative_and_pa_flag() {
 #[test]
 fn labeled_set_index_resolves_to_name_or_runtime_caps_fallback() {
     let names = vec!["gantry".to_string()];
-    let resolved = label_binding(BindingConstraint::Velocity { set: 0 }, &names).unwrap();
+    let resolved = label_binding(
+        BindingConstraint::Velocity { set: 0 },
+        temporal::LimitKind::Config,
+        &names,
+    )
+    .unwrap();
     assert_eq!(resolved.limit, "gantry");
 
-    let fallback = label_binding(BindingConstraint::AccelNorm { set: 1 }, &names).unwrap();
+    let fallback = label_binding(
+        BindingConstraint::AccelNorm { set: 1 },
+        temporal::LimitKind::Config,
+        &names,
+    )
+    .unwrap();
     assert_eq!(fallback.limit, "runtime_caps");
+}
+
+/// Dynamic limit sets show their reserved kind name; config sets resolve to the
+/// declared section name by index.
+#[test]
+fn dynamic_limit_kinds_get_reserved_names() {
+    let names = vec!["gantry".to_string()];
+    let feed = label_binding(
+        BindingConstraint::Velocity { set: 5 },
+        temporal::LimitKind::Feedrate,
+        &names,
+    )
+    .unwrap();
+    assert_eq!(feed.limit, "feedrate");
+
+    let runtime = label_binding(
+        BindingConstraint::AccelNorm { set: 5 },
+        temporal::LimitKind::RuntimeCap,
+        &names,
+    )
+    .unwrap();
+    assert_eq!(runtime.limit, "runtime_caps");
+
+    let config = label_binding(
+        BindingConstraint::Velocity { set: 0 },
+        temporal::LimitKind::Config,
+        &names,
+    )
+    .unwrap();
+    assert_eq!(config.limit, "gantry");
 }
 
 #[test]
 fn none_and_boundary_produce_no_label() {
     let names = vec!["gantry".to_string()];
-    assert!(label_binding(BindingConstraint::None, &names).is_none());
-    assert!(label_binding(BindingConstraint::Boundary, &names).is_none());
+    assert!(label_binding(BindingConstraint::None, temporal::LimitKind::Config, &names).is_none());
+    assert!(
+        label_binding(
+            BindingConstraint::Boundary,
+            temporal::LimitKind::Config,
+            &names
+        )
+        .is_none()
+    );
 }
 
 fn summary(set: usize, count: u32, ratio: f64) -> ReplanBindingSummary {
@@ -51,6 +99,7 @@ fn summary(set: usize, count: u32, ratio: f64) -> ReplanBindingSummary {
         worst: Some(ReplanWorstBinding {
             constraint: BindingConstraint::Velocity { set },
             ratio,
+            kind: temporal::LimitKind::Config,
         }),
         ..Default::default()
     }
@@ -63,7 +112,7 @@ fn record_tallies_window_and_keeps_max_ratio_worst() {
     acc.record(&summary(0, 3, 0.8), 1.0);
     acc.record(&summary(0, 2, 0.95), 2.0);
     assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 5);
-    let (constraint, ratio, t) = acc.worst().unwrap();
+    let (constraint, _kind, ratio, t) = acc.worst().unwrap();
     assert_eq!(constraint, BindingConstraint::Velocity { set: 0 });
     assert!((ratio - 0.95).abs() < 1e-12);
     assert!((t - 2.0).abs() < 1e-12);
@@ -106,6 +155,7 @@ fn g5_anytime_event_matches_binding_and_gap() {
         worst: Some(ReplanWorstBinding {
             constraint: BindingConstraint::Velocity { set: 0 },
             ratio: 0.94,
+            kind: temporal::LimitKind::Config,
         }),
         ..Default::default()
     };
@@ -129,6 +179,7 @@ fn g5_anytime_event_tracks_pa_jerk_family() {
         worst: Some(ReplanWorstBinding {
             constraint: BindingConstraint::PaJerk { set: 1 },
             ratio: 0.88,
+            kind: temporal::LimitKind::Config,
         }),
         ..Default::default()
     };
@@ -152,6 +203,7 @@ fn g5_anytime_event_on_limit_and_no_binding() {
         worst: Some(ReplanWorstBinding {
             constraint: BindingConstraint::AccelNorm { set: 0 },
             ratio: 1.0,
+            kind: temporal::LimitKind::Config,
         }),
         ..Default::default()
     };

--- a/rust/motion-engine/src/binding_report/tests.rs
+++ b/rust/motion-engine/src/binding_report/tests.rs
@@ -116,16 +116,11 @@ fn g5_anytime_event_matches_binding_and_gap() {
     assert_eq!(fields.limiter_derivative, "velocity");
     assert!(!fields.limiter_via_pa);
     assert!((fields.binding_ratio - 0.94).abs() < 1e-12);
-    assert!(
-        (fields.gap - 0.06).abs() < 1e-9,
-        "gap must equal (1 - ratio).max(0); got {}",
-        fields.gap,
-    );
 }
 
 /// G5 — a PA-jerk binding on set 1 (no name → runtime_caps fallback) at ratio
-/// 0.88 produces the matching limiter and gap 0.12. Confirms the event tracks
-/// the actual worst family, not a fixed one.
+/// 0.88 produces the matching limiter and binding_ratio. Confirms the event
+/// tracks the actual worst family, not a fixed one.
 #[test]
 fn g5_anytime_event_tracks_pa_jerk_family() {
     let names = vec!["gantry".to_string()];
@@ -143,11 +138,11 @@ fn g5_anytime_event_tracks_pa_jerk_family() {
     assert_eq!(fields.limiter_limit, "runtime_caps");
     assert_eq!(fields.limiter_derivative, "jerk");
     assert!(fields.limiter_via_pa);
-    assert!((fields.gap - 0.12).abs() < 1e-9);
+    assert!((fields.binding_ratio - 0.88).abs() < 1e-12);
 }
 
-/// G5 — an on-the-limit binding (ratio = 1.0, the converged optimum) reports
-/// gap 0; no binding at all reports the `none` limiter and gap 0.
+/// G5 — an on-the-limit binding (ratio = 1.0, the converged optimum) and the
+/// no-binding case both report their `binding_ratio` and limiter correctly.
 #[test]
 fn g5_anytime_event_on_limit_and_no_binding() {
     let names = vec!["gantry".to_string()];
@@ -161,14 +156,18 @@ fn g5_anytime_event_on_limit_and_no_binding() {
         ..Default::default()
     };
     let f = anytime_event_fields(&on_limit, &names);
-    assert!(f.gap.abs() < 1e-12, "on-limit gap must be 0; got {}", f.gap);
+    assert!(
+        (f.binding_ratio - 1.0).abs() < 1e-12,
+        "on-limit binding_ratio must be 1.0; got {}",
+        f.binding_ratio,
+    );
     assert_eq!(f.limiter_derivative, "accel");
 
     let none = ReplanBindingSummary::default();
     let f = anytime_event_fields(&none, &names);
     assert_eq!(f.limiter_limit, "none");
     assert_eq!(f.limiter_derivative, "none");
-    assert!(f.gap.abs() < 1e-12);
+    assert!(f.binding_ratio.abs() < 1e-12);
 }
 
 #[test]

--- a/rust/motion-engine/src/binding_report/tests.rs
+++ b/rust/motion-engine/src/binding_report/tests.rs
@@ -49,8 +49,6 @@ fn labeled_set_index_resolves_to_name_or_runtime_caps_fallback() {
     assert_eq!(fallback.limit, "runtime_caps");
 }
 
-/// Dynamic limit sets show their reserved kind name; config sets resolve to the
-/// declared section name by index.
 #[test]
 fn dynamic_limit_kinds_get_reserved_names() {
     let names = vec!["gantry".to_string()];
@@ -143,10 +141,6 @@ fn flush_emits_and_clears_a_partial_window() {
     assert_eq!(acc.window_count(BindingConstraint::Velocity { set: 0 }), 0);
 }
 
-/// G5 — the gap + limiter the `replan_anytime` event carries must match the
-/// actual binding constraint and its verified ratio. With a known XY-velocity
-/// binding at ratio 0.94 (a conservative floor), the event reports the matching
-/// limiter and `gap = 1 - 0.94 = 0.06`.
 #[test]
 fn g5_anytime_event_matches_binding_and_gap() {
     let names = vec!["gantry".to_string(), "extruder".to_string()];
@@ -168,9 +162,6 @@ fn g5_anytime_event_matches_binding_and_gap() {
     assert!((fields.binding_ratio - 0.94).abs() < 1e-12);
 }
 
-/// G5 — a PA-jerk binding on set 1 (no name → runtime_caps fallback) at ratio
-/// 0.88 produces the matching limiter and binding_ratio. Confirms the event
-/// tracks the actual worst family, not a fixed one.
 #[test]
 fn g5_anytime_event_tracks_pa_jerk_family() {
     let names = vec!["gantry".to_string()];
@@ -192,8 +183,6 @@ fn g5_anytime_event_tracks_pa_jerk_family() {
     assert!((fields.binding_ratio - 0.88).abs() < 1e-12);
 }
 
-/// G5 — an on-the-limit binding (ratio = 1.0, the converged optimum) and the
-/// no-binding case both report their `binding_ratio` and limiter correctly.
 #[test]
 fn g5_anytime_event_on_limit_and_no_binding() {
     let names = vec!["gantry".to_string()];

--- a/rust/motion-engine/src/config.rs
+++ b/rust/motion-engine/src/config.rs
@@ -493,9 +493,10 @@ impl PlannerConfig {
             }
         }
 
+        let limits = temporal::Limits::try_new(&sets, n_axes.max(temporal::N_SPATIAL))?;
         if self.runtime_caps.velocity.is_some() || self.runtime_caps.accel.is_some() {
             let a = self.runtime_caps.accel.unwrap_or(f64::INFINITY);
-            sets.push(temporal::LimitSet {
+            let runtime_set = temporal::LimitSet {
                 axes: temporal::AxisSet::spatial(),
                 v_max: self.runtime_caps.velocity.unwrap_or(f64::INFINITY),
                 a_max: a,
@@ -504,12 +505,11 @@ impl PlannerConfig {
                 } else {
                     f64::INFINITY
                 },
-            });
+            };
+            Ok(limits.with_extra_sets_of_kind(&[runtime_set], temporal::LimitKind::RuntimeCap))
+        } else {
+            Ok(limits)
         }
-        Ok(temporal::Limits::try_new(
-            &sets,
-            n_axes.max(temporal::N_SPATIAL),
-        )?)
     }
 }
 

--- a/rust/motion-engine/src/planner.rs
+++ b/rust/motion-engine/src/planner.rs
@@ -663,12 +663,23 @@ fn run_loop(
                     // Fixed-decimal so the JSON layer stores e.g. "0.5970" instead of
                     // serde's "2.03e-7" — comparable at a glance in the log UI and still
                     // numerically filterable (VL parses numeric-looking strings).
-                    let gap_str = format!("{:.4}", fields.gap);
                     let binding_ratio_str = format!("{:.4}", fields.binding_ratio);
+                    // Peak utilization of the executed trajectory: how hard the
+                    // committed motion actually rides the tightest limit, measured
+                    // at the MCU step rate. <1 ⇒ headroom left; >1 ⇒ over-limit
+                    // between solver grid points.
+                    let peak_util_str = format!("{:.4}", binding.peak_utilization);
+                    let peak_util_family = match binding.peak_util_family {
+                        Some(trajectory::utilization::UtilFamily::Velocity) => "velocity",
+                        Some(trajectory::utilization::UtilFamily::Accel) => "accel",
+                        Some(trajectory::utilization::UtilFamily::Jerk) => "jerk",
+                        None => "none",
+                    };
                     tracing::info!(
                         subsystem = "motion",
                         event = "replan_anytime",
-                        gap = %gap_str,
+                        peak_utilization = %peak_util_str,
+                        peak_util_family,
                         limiter_limit = %fields.limiter_limit,
                         limiter_derivative = fields.limiter_derivative,
                         limiter_via_pa = fields.limiter_via_pa,

--- a/rust/motion-engine/src/planner.rs
+++ b/rust/motion-engine/src/planner.rs
@@ -675,11 +675,27 @@ fn run_loop(
                         Some(trajectory::utilization::UtilFamily::Jerk) => "jerk",
                         None => "none",
                     };
+                    // Per-family executed peaks: how hard each derivative rides its
+                    // limit (ratio) and its raw path-frame magnitude. Lets a reader
+                    // see e.g. velocity 1.00 / jerk 1.03 at once, not just the max.
+                    let p = binding.peaks.unwrap_or_default();
+                    let vel_util_str = format!("{:.4}", p.vel_ratio);
+                    let accel_util_str = format!("{:.4}", p.accel_ratio);
+                    let jerk_util_str = format!("{:.4}", p.jerk_ratio);
+                    let vel_mag_str = format!("{:.2}", p.vel_mag);
+                    let accel_mag_str = format!("{:.2}", p.accel_mag);
+                    let jerk_mag_str = format!("{:.2}", p.jerk_mag);
                     tracing::info!(
                         subsystem = "motion",
                         event = "replan_anytime",
                         peak_utilization = %peak_util_str,
                         peak_util_family,
+                        vel_util = %vel_util_str,
+                        accel_util = %accel_util_str,
+                        jerk_util = %jerk_util_str,
+                        vel_mm_s = %vel_mag_str,
+                        accel_mm_s2 = %accel_mag_str,
+                        jerk_mm_s3 = %jerk_mag_str,
                         limiter_limit = %fields.limiter_limit,
                         limiter_derivative = fields.limiter_derivative,
                         limiter_via_pa = fields.limiter_via_pa,

--- a/rust/motion-engine/src/planner.rs
+++ b/rust/motion-engine/src/planner.rs
@@ -664,10 +664,6 @@ fn run_loop(
                     // serde's "2.03e-7" — comparable at a glance in the log UI and still
                     // numerically filterable (VL parses numeric-looking strings).
                     let binding_ratio_str = format!("{:.4}", fields.binding_ratio);
-                    // Peak utilization of the executed trajectory: how hard the
-                    // committed motion actually rides the tightest limit, measured
-                    // at the MCU step rate. <1 ⇒ headroom left; >1 ⇒ over-limit
-                    // between solver grid points.
                     let peak_util_str = format!("{:.4}", binding.peak_utilization);
                     let peak_util_family = match binding.peak_util_family {
                         Some(trajectory::utilization::UtilFamily::Velocity) => "velocity",
@@ -675,9 +671,6 @@ fn run_loop(
                         Some(trajectory::utilization::UtilFamily::Jerk) => "jerk",
                         None => "none",
                     };
-                    // Per-family executed peaks: how hard each derivative rides its
-                    // limit (ratio) and its raw path-frame magnitude. Lets a reader
-                    // see e.g. velocity 1.00 / jerk 1.03 at once, not just the max.
                     let p = binding.peaks.unwrap_or_default();
                     let vel_util_str = format!("{:.4}", p.vel_ratio);
                     let accel_util_str = format!("{:.4}", p.accel_ratio);

--- a/rust/motion-engine/tests/binding_report_e2e.rs
+++ b/rust/motion-engine/tests/binding_report_e2e.rs
@@ -26,6 +26,7 @@ fn binding_events_land_in_host_rust_jsonl_tagged_with_print_id() {
         worst: Some(ReplanWorstBinding {
             constraint: BindingConstraint::PaAccel { set: 1 },
             ratio: 0.98,
+            kind: temporal::LimitKind::Config,
         }),
         ..Default::default()
     };

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -63,8 +63,6 @@ pub struct WorstBinding {
     pub ratio: f64,
     pub grid_index: usize,
     pub s: f64,
-    /// Provenance of the binding limit set — lets diagnostics name a config limit
-    /// (by its section name) apart from the dynamic feedrate or runtime-cap sets.
     pub kind: LimitKind,
 }
 

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -2,8 +2,8 @@ pub mod deadline;
 
 pub mod limits;
 pub use limits::{
-    AxisSet, LimitSet, Limits, LimitsError, MAX_AXES, MAX_LIMIT_SETS, N_SPATIAL, kappa_set,
-    restricted_norm,
+    AxisSet, LimitKind, LimitSet, Limits, LimitsError, MAX_AXES, MAX_LIMIT_SETS, N_SPATIAL,
+    kappa_set, restricted_norm,
 };
 
 pub mod topp;
@@ -63,6 +63,9 @@ pub struct WorstBinding {
     pub ratio: f64,
     pub grid_index: usize,
     pub s: f64,
+    /// Provenance of the binding limit set — lets diagnostics name a config limit
+    /// (by its section name) apart from the dynamic feedrate or runtime-cap sets.
+    pub kind: LimitKind,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/rust/temporal/src/limits.rs
+++ b/rust/temporal/src/limits.rs
@@ -49,9 +49,25 @@ pub struct LimitSet {
     pub j_max: f64,
 }
 
+/// Provenance of a limit set, used purely to label which limit a move is riding
+/// in diagnostics. `Config` sets carry a user-defined name (resolved externally
+/// by set index); the dynamic kinds are injected by the planner at runtime and
+/// have no config name, so the report shows their reserved kind instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LimitKind {
+    /// A config-declared `[limit]` section.
+    #[default]
+    Config,
+    /// The per-move feedrate path-speed cap, set dynamically from the G-code feed.
+    Feedrate,
+    /// A `SET_VELOCITY_LIMIT` runtime cap override.
+    RuntimeCap,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Limits {
     sets: [LimitSet; MAX_LIMIT_SETS],
+    kinds: [LimitKind; MAX_LIMIT_SETS],
     n_sets: u8,
     n_axes: u8,
 }
@@ -115,9 +131,16 @@ impl Limits {
         arr[..sets.len()].copy_from_slice(sets);
         Ok(Self {
             sets: arr,
+            kinds: [LimitKind::Config; MAX_LIMIT_SETS],
             n_sets: sets.len() as u8,
             n_axes: n_axes as u8,
         })
+    }
+
+    /// Provenance of set `set` (defaults to `Config` for any out-of-range index).
+    #[must_use]
+    pub fn kind(&self, set: usize) -> LimitKind {
+        self.kinds.get(set).copied().unwrap_or(LimitKind::Config)
     }
 
     #[must_use]
@@ -254,14 +277,30 @@ impl Limits {
     #[must_use]
     pub fn with_sets_mapped(&self, f: impl Fn(&LimitSet) -> LimitSet) -> Self {
         let sets: Vec<LimitSet> = self.sets().iter().map(f).collect();
-        Self::try_new(&sets, self.n_axes()).expect("set mapping preserves validity")
+        let mut out = Self::try_new(&sets, self.n_axes()).expect("set mapping preserves validity");
+        out.kinds = self.kinds;
+        out
     }
 
     #[must_use]
     pub fn with_extra_sets(&self, extra: &[LimitSet]) -> Self {
+        self.with_extra_sets_of_kind(extra, LimitKind::Config)
+    }
+
+    /// Append `extra` limit sets tagged with `kind`, preserving the kinds of the
+    /// existing sets. Used to inject dynamic limits (feedrate, runtime caps) so
+    /// diagnostics can name them apart from config sets.
+    #[must_use]
+    pub fn with_extra_sets_of_kind(&self, extra: &[LimitSet], kind: LimitKind) -> Self {
         let mut sets: Vec<LimitSet> = self.sets().to_vec();
         sets.extend_from_slice(extra);
-        Self::try_new(&sets, self.n_axes()).expect("appending sets preserves validity")
+        let mut out =
+            Self::try_new(&sets, self.n_axes()).expect("appending sets preserves validity");
+        out.kinds = self.kinds;
+        for slot in out.kinds[self.n_sets as usize..sets.len()].iter_mut() {
+            *slot = kind;
+        }
+        out
     }
 
     #[must_use]

--- a/rust/temporal/src/limits.rs
+++ b/rust/temporal/src/limits.rs
@@ -49,18 +49,11 @@ pub struct LimitSet {
     pub j_max: f64,
 }
 
-/// Provenance of a limit set, used purely to label which limit a move is riding
-/// in diagnostics. `Config` sets carry a user-defined name (resolved externally
-/// by set index); the dynamic kinds are injected by the planner at runtime and
-/// have no config name, so the report shows their reserved kind instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LimitKind {
-    /// A config-declared `[limit]` section.
     #[default]
     Config,
-    /// The per-move feedrate path-speed cap, set dynamically from the G-code feed.
     Feedrate,
-    /// A `SET_VELOCITY_LIMIT` runtime cap override.
     RuntimeCap,
 }
 
@@ -137,7 +130,6 @@ impl Limits {
         })
     }
 
-    /// Provenance of set `set` (defaults to `Config` for any out-of-range index).
     #[must_use]
     pub fn kind(&self, set: usize) -> LimitKind {
         self.kinds.get(set).copied().unwrap_or(LimitKind::Config)
@@ -287,9 +279,6 @@ impl Limits {
         self.with_extra_sets_of_kind(extra, LimitKind::Config)
     }
 
-    /// Append `extra` limit sets tagged with `kind`, preserving the kinds of the
-    /// existing sets. Used to inject dynamic limits (feedrate, runtime caps) so
-    /// diagnostics can name them apart from config sets.
     #[must_use]
     pub fn with_extra_sets_of_kind(&self, extra: &[LimitSet], kind: LimitKind) -> Self {
         let mut sets: Vec<LimitSet> = self.sets().to_vec();

--- a/rust/temporal/src/multi/chain/tests.rs
+++ b/rust/temporal/src/multi/chain/tests.rs
@@ -84,6 +84,7 @@ fn binding_summary_assigned_to_first_slice_only() {
             ratio: 1.0,
             grid_index: 2,
             s: 2.0,
+            kind: crate::LimitKind::Config,
         }),
     };
     let chain_profile = TopProfile {

--- a/rust/temporal/src/multi/parallel.rs
+++ b/rust/temporal/src/multi/parallel.rs
@@ -348,18 +348,12 @@ fn scale_chain_v_max(chain: &ChainGrid, factor: f64) -> ChainGrid {
     let factor = factor.max(V_SCALE_FACTOR_FLOOR);
     let mut scaled = chain.clone();
     for l in &mut scaled.limits {
-        let sets: Vec<crate::LimitSet> = l
-            .sets()
-            .iter()
-            .map(|s| crate::LimitSet {
-                axes: s.axes,
-                v_max: s.v_max * factor,
-                a_max: s.a_max,
-                j_max: s.j_max,
-            })
-            .collect();
-        *l =
-            crate::Limits::try_new(&sets, l.n_axes()).expect("velocity rescale preserves validity");
+        *l = l.with_sets_mapped(|s| crate::LimitSet {
+            axes: s.axes,
+            v_max: s.v_max * factor,
+            a_max: s.a_max,
+            j_max: s.j_max,
+        });
     }
     scaled
 }

--- a/rust/temporal/src/topp/chain.rs
+++ b/rust/temporal/src/topp/chain.rs
@@ -239,12 +239,15 @@ impl ChainGrid {
         );
         let limits = if feedrate_mm_s.is_finite() && feedrate_mm_s > 0.0 {
             let axes: Vec<usize> = followers.iter().map(|f| f.axis).collect();
-            limits.with_extra_sets(&[crate::LimitSet {
-                axes: crate::AxisSet::from_indices(&axes),
-                v_max: feedrate_mm_s,
-                a_max: f64::INFINITY,
-                j_max: f64::INFINITY,
-            }])
+            limits.with_extra_sets_of_kind(
+                &[crate::LimitSet {
+                    axes: crate::AxisSet::from_indices(&axes),
+                    v_max: feedrate_mm_s,
+                    a_max: f64::INFINITY,
+                    j_max: f64::INFINITY,
+                }],
+                crate::LimitKind::Feedrate,
+            )
         } else {
             limits
         };

--- a/rust/temporal/src/topp/scaling.rs
+++ b/rust/temporal/src/topp/scaling.rs
@@ -33,17 +33,12 @@ impl SolverScale {
 
     pub(crate) fn scale_limits(&self, limits: &Limits) -> Limits {
         let s = self.sigma();
-        let sets: Vec<crate::LimitSet> = limits
-            .sets()
-            .iter()
-            .map(|l| crate::LimitSet {
-                axes: l.axes,
-                v_max: l.v_max / s,
-                a_max: l.a_max / s,
-                j_max: l.j_max / s,
-            })
-            .collect();
-        Limits::try_new(&sets, limits.n_axes()).expect("scaling preserves validity")
+        limits.with_sets_mapped(|l| crate::LimitSet {
+            axes: l.axes,
+            v_max: l.v_max / s,
+            a_max: l.a_max / s,
+            j_max: l.j_max / s,
+        })
     }
 
     pub(crate) fn scale_grid(&self, grid: &ArclengthGrid) -> ArclengthGrid {

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -361,11 +361,24 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
             global_worst_tag,
             BindingConstraint::None | BindingConstraint::Boundary
         ) {
+        let set = match global_worst_tag {
+            BindingConstraint::Velocity { set }
+            | BindingConstraint::AccelNorm { set }
+            | BindingConstraint::JerkNorm { set }
+            | BindingConstraint::PaVelocity { set }
+            | BindingConstraint::PaAccel { set }
+            | BindingConstraint::PaJerk { set } => Some(set),
+            BindingConstraint::None | BindingConstraint::Boundary => None,
+        };
+        let kind = set.map_or(crate::LimitKind::Config, |s| {
+            chain.limits_at(global_worst_idx).kind(s)
+        });
         Some(WorstBinding {
             constraint: global_worst_tag,
             ratio: global_worst_ratio,
             grid_index: global_worst_idx,
             s: chain.s[global_worst_idx],
+            kind,
         })
     } else {
         None

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -137,6 +137,9 @@ pub struct ReplanBindingSummary {
     pub peak_utilization: f64,
     /// Which kinematic family the peak utilization landed on.
     pub peak_util_family: Option<crate::utilization::UtilFamily>,
+    /// Per-family executed peaks (velocity/accel/jerk ratios and raw magnitudes)
+    /// over the window. `peak_utilization` is the max of the three ratios.
+    pub peaks: Option<crate::utilization::UtilizationPeaks>,
 }
 
 fn aggregate_binding(profiles: &[temporal::TopProfile]) -> ReplanBindingSummary {
@@ -167,6 +170,7 @@ fn aggregate_binding(profiles: &[temporal::TopProfile]) -> ReplanBindingSummary 
         deadline_truncated,
         peak_utilization: 0.0,
         peak_util_family: None,
+        peaks: None,
     }
 }
 
@@ -575,14 +579,17 @@ fn run_one_iteration(
         .collect();
 
     let mut binding = aggregate_binding(&batch_output.profiles);
-    if let Some(u) = crate::utilization::window_peak_utilization(
+    if let Some(peaks) = crate::utilization::window_peak_utilization(
         emitted
             .iter()
             .zip(input.segments.iter())
             .map(|(seg, src)| (seg.axes.as_slice(), &src.temporal.limits)),
     ) {
-        binding.peak_utilization = u.ratio;
-        binding.peak_util_family = Some(u.family);
+        if let Some(w) = peaks.worst() {
+            binding.peak_utilization = w.ratio;
+            binding.peak_util_family = Some(w.family);
+        }
+        binding.peaks = Some(peaks);
     }
 
     Ok(BetaIterResult {

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -115,7 +115,6 @@ pub struct PlanStats {
 pub struct ReplanWorstBinding {
     pub constraint: temporal::BindingConstraint,
     pub ratio: f64,
-    /// Provenance of the binding limit set (config / dynamic feedrate / runtime cap).
     pub kind: temporal::LimitKind,
 }
 
@@ -128,17 +127,8 @@ pub struct ReplanBindingSummary {
     /// the authoritative `deadline_limited` signal, replacing the wall-clock
     /// heuristic that misfired on slow-but-converged solves under host load.
     pub deadline_truncated: bool,
-    /// Peak limit utilization of the committed (executed) trajectory across the
-    /// window: the largest `|executed| / cap` ratio reached on any axis-set and
-    /// family, measured the way the MCU steps it. Below 1 means headroom was left
-    /// on the table (the solver could ride a limit harder); above 1 means the
-    /// executed motion exceeds a limit between solver grid points. 0 when no
-    /// segment yields a sample. See [`crate::utilization`].
     pub peak_utilization: f64,
-    /// Which kinematic family the peak utilization landed on.
     pub peak_util_family: Option<crate::utilization::UtilFamily>,
-    /// Per-family executed peaks (velocity/accel/jerk ratios and raw magnitudes)
-    /// over the window. `peak_utilization` is the max of the three ratios.
     pub peaks: Option<crate::utilization::UtilizationPeaks>,
 }
 

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -126,6 +126,15 @@ pub struct ReplanBindingSummary {
     /// the authoritative `deadline_limited` signal, replacing the wall-clock
     /// heuristic that misfired on slow-but-converged solves under host load.
     pub deadline_truncated: bool,
+    /// Peak limit utilization of the committed (executed) trajectory across the
+    /// window: the largest `|executed| / cap` ratio reached on any axis-set and
+    /// family, measured the way the MCU steps it. Below 1 means headroom was left
+    /// on the table (the solver could ride a limit harder); above 1 means the
+    /// executed motion exceeds a limit between solver grid points. 0 when no
+    /// segment yields a sample. See [`crate::utilization`].
+    pub peak_utilization: f64,
+    /// Which kinematic family the peak utilization landed on.
+    pub peak_util_family: Option<crate::utilization::UtilFamily>,
 }
 
 fn aggregate_binding(profiles: &[temporal::TopProfile]) -> ReplanBindingSummary {
@@ -153,6 +162,8 @@ fn aggregate_binding(profiles: &[temporal::TopProfile]) -> ReplanBindingSummary 
         histogram,
         worst,
         deadline_truncated,
+        peak_utilization: 0.0,
+        peak_util_family: None,
     }
 }
 
@@ -560,7 +571,16 @@ fn run_one_iteration(
         })
         .collect();
 
-    let binding = aggregate_binding(&batch_output.profiles);
+    let mut binding = aggregate_binding(&batch_output.profiles);
+    if let Some(u) = crate::utilization::window_peak_utilization(
+        emitted
+            .iter()
+            .zip(input.segments.iter())
+            .map(|(seg, src)| (seg.axes.as_slice(), &src.temporal.limits)),
+    ) {
+        binding.peak_utilization = u.ratio;
+        binding.peak_util_family = Some(u.family);
+    }
 
     Ok(BetaIterResult {
         fitted,

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -115,6 +115,8 @@ pub struct PlanStats {
 pub struct ReplanWorstBinding {
     pub constraint: temporal::BindingConstraint,
     pub ratio: f64,
+    /// Provenance of the binding limit set (config / dynamic feedrate / runtime cap).
+    pub kind: temporal::LimitKind,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -152,6 +154,7 @@ fn aggregate_binding(profiles: &[temporal::TopProfile]) -> ReplanBindingSummary 
                 worst = Some(ReplanWorstBinding {
                     constraint: w.constraint,
                     ratio: w.ratio,
+                    kind: w.kind,
                 });
             }
         }

--- a/rust/trajectory/src/beta/tests.rs
+++ b/rust/trajectory/src/beta/tests.rs
@@ -232,3 +232,76 @@ fn jerk_limited_z_move_converges_under_worst_case_derate() {
         output.stats.beta_iterations
     );
 }
+
+/// A move cruising at its requested feed (below the per-axis box cap) reports
+/// peak utilization ≈ 1.0 on velocity — the feed path-speed set added by
+/// `per_segment_limits` is honored end-to-end through the real plan path, so
+/// riding the feed reads as "at the limit", not as `feed / box_cap`. This locks
+/// that the utilization metric measures against the effective (feed-inclusive)
+/// velocity limit, not just the machine box.
+#[test]
+fn feed_cruise_reads_full_velocity_utilization() {
+    // Accel/jerk caps are set far above anything this cruise can reach, so the
+    // feed path-speed set is the unambiguous binding limit (the worst), letting us
+    // assert its kind. (With tight jerk, a boundary jerk transient would outrank
+    // the feed velocity — correctly tagged Config — which is a different test.)
+    let base = temporal::Limits::axis_boxes([1000.0; 3], [1.0e9; 3], [1.0e12; 3]);
+    let curve = nurbs::VectorNurbs::try_new(
+        1,
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![[0.0, 0.0, 0.0], [200.0, 0.0, 0.0]],
+    )
+    .unwrap();
+    let feed = 494.0;
+    let limits = crate::streaming::state::per_segment_limits(&curve, &base, feed);
+
+    let segments = [ShapeSegmentInput {
+        temporal: temporal::multi::SegmentInput {
+            curve: &curve,
+            limits,
+            followers: &[],
+            virtual_path: None,
+        },
+        followers: &[],
+        feedrate_mm_s: feed,
+    }];
+    let chains = AxisChainSet::passthrough_spatial();
+    let input = ShapeBatchInput {
+        follower_history: None,
+        segments: &segments,
+        grid_strategy: temporal::multi::GridStrategy::Adaptive {
+            min_n: 20,
+            max_n: 400,
+            target_grid_spacing_mm: 0.5,
+        },
+        worker_threads: 1,
+        chains: &chains,
+        follower_start: &[],
+        fit_tolerance_mm: 0.005,
+        beta_max_iters: 10,
+        beta_convergence_ratio: 1.02,
+        initial_v: feed,
+        initial_a: 0.0,
+        terminal_v: feed,
+        start_d2_override: None,
+    };
+
+    let output = plan_velocity_inner(&input, SafetyMode::WorstCaseFuture).expect("plan");
+    assert_eq!(
+        output.binding.peak_util_family,
+        Some(crate::utilization::UtilFamily::Velocity),
+        "a feed cruise must be velocity-bound, not jerk/accel"
+    );
+    assert!(
+        (output.binding.peak_utilization - 1.0).abs() < 0.05,
+        "cruising at feed must read ~1.0 (feed credited), not feed/box; got {}",
+        output.binding.peak_utilization,
+    );
+    assert_eq!(
+        output.binding.worst.map(|w| w.kind),
+        Some(temporal::LimitKind::Feedrate),
+        "a feed-bound move (accel/jerk slack) must name the dynamic feedrate set as \
+         its limiter; got {:?}",
+        output.binding.worst,
+    );
+}

--- a/rust/trajectory/src/beta/tests.rs
+++ b/rust/trajectory/src/beta/tests.rs
@@ -233,18 +233,8 @@ fn jerk_limited_z_move_converges_under_worst_case_derate() {
     );
 }
 
-/// A move cruising at its requested feed (below the per-axis box cap) reports
-/// peak utilization ≈ 1.0 on velocity — the feed path-speed set added by
-/// `per_segment_limits` is honored end-to-end through the real plan path, so
-/// riding the feed reads as "at the limit", not as `feed / box_cap`. This locks
-/// that the utilization metric measures against the effective (feed-inclusive)
-/// velocity limit, not just the machine box.
 #[test]
 fn feed_cruise_reads_full_velocity_utilization() {
-    // Accel/jerk caps are set far above anything this cruise can reach, so the
-    // feed path-speed set is the unambiguous binding limit (the worst), letting us
-    // assert its kind. (With tight jerk, a boundary jerk transient would outrank
-    // the feed velocity — correctly tagged Config — which is a different test.)
     let base = temporal::Limits::axis_boxes([1000.0; 3], [1.0e9; 3], [1.0e12; 3]);
     let curve = nurbs::VectorNurbs::try_new(
         1,

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -12,6 +12,7 @@ mod reparam;
 mod shaper;
 mod smooth_fit;
 pub mod streaming;
+pub mod utilization;
 
 pub use beta::{ReplanBindingSummary, ReplanWorstBinding};
 pub use emit_shaped::{emit_shaped, EmitSegmentMeta, PerAxisHistory, ShapeEmission};

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -1054,12 +1054,15 @@ fn plan_segment_for<'a>(m: &'a UncommittedMove, base: &temporal::Limits) -> Plan
         && m.segment.feedrate_mm_s > 0.0
     {
         let follower_axes: Vec<usize> = m.segment.followers.iter().map(|f| f.axis_index).collect();
-        limits = limits.with_extra_sets(&[temporal::LimitSet {
-            axes: temporal::AxisSet::from_indices(&follower_axes),
-            v_max: m.segment.feedrate_mm_s,
-            a_max: f64::INFINITY,
-            j_max: f64::INFINITY,
-        }]);
+        limits = limits.with_extra_sets_of_kind(
+            &[temporal::LimitSet {
+                axes: temporal::AxisSet::from_indices(&follower_axes),
+                v_max: m.segment.feedrate_mm_s,
+                a_max: f64::INFINITY,
+                j_max: f64::INFINITY,
+            }],
+            temporal::LimitKind::Feedrate,
+        );
     }
     PlanSegment {
         temporal: temporal::multi::SegmentInput {
@@ -1124,12 +1127,15 @@ pub(crate) fn per_segment_limits(
     }
 
     if feedrate_mm_s > 0.0 && chord_len > AXIS_INACTIVE_SPAN_EPS_MM {
-        limits = limits.with_extra_sets(&[temporal::LimitSet {
-            axes: temporal::AxisSet::spatial(),
-            v_max: feedrate_mm_s,
-            a_max: f64::INFINITY,
-            j_max: f64::INFINITY,
-        }]);
+        limits = limits.with_extra_sets_of_kind(
+            &[temporal::LimitSet {
+                axes: temporal::AxisSet::spatial(),
+                v_max: feedrate_mm_s,
+                a_max: f64::INFINITY,
+                j_max: f64::INFINITY,
+            }],
+            temporal::LimitKind::Feedrate,
+        );
     }
 
     limits

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -1829,3 +1829,19 @@ fn follower_only_retract_then_idle_then_move_holds_ledger() {
         "two -1mm retracts must leave the ledger at -2, got {end}"
     );
 }
+
+#[test]
+fn per_segment_limits_adds_feedrate_path_speed_set() {
+    let base = temporal::Limits::axis_boxes([1000.0; 3], [500_000.0; 3], [1.0e7; 3]);
+    let curve = nurbs::VectorNurbs::try_new(
+        1,
+        vec![0.0, 0.0, 1.0, 1.0],
+        vec![[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]],
+    )
+    .unwrap();
+    let feed = 494.0;
+    let limits = super::state::per_segment_limits(&curve, &base, feed);
+    let caps: Vec<f64> = limits.spatial_sets().map(|(_, s)| s.v_max).collect();
+    let has_feed = caps.iter().any(|v| (v - feed).abs() < 1e-6);
+    assert!(has_feed, "feed set missing; spatial v_max caps = {caps:?}");
+}

--- a/rust/trajectory/src/utilization.rs
+++ b/rust/trajectory/src/utilization.rs
@@ -1,0 +1,123 @@
+//! Executed-trajectory limit utilization: how close to the kinematic limits the
+//! committed per-axis time-polynomials actually ride, measured the way the MCU
+//! steps them (finite differences at the 40 kHz sample rate).
+//!
+//! Unlike a grid-sampled solver diagnostic, this evaluates the exact committed
+//! trajectory — the `FittedSegment`/emitted axes are polynomials in time, so
+//! their velocity/accel/jerk are exact for any geometry and include the behavior
+//! between solver grid points. By the maximum principle a time-optimal trajectory
+//! rides some limit at (almost) every instant, so the peak utilization is both an
+//! optimality signal (well below 1 ⇒ headroom left on the table) and a feasibility
+//! check (above 1 ⇒ the executed motion exceeds a limit the grid never sampled).
+
+use nurbs::bezier::extract_bezier_pieces;
+use nurbs::ScalarNurbs;
+use temporal::{restricted_norm, Limits};
+
+/// The kinematic family a peak utilization was reached on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UtilFamily {
+    Velocity,
+    Accel,
+    Jerk,
+}
+
+/// Peak limit utilization over a trajectory: the largest `|executed| / cap` ratio
+/// reached on any axis-set and family, and which family it was.
+#[derive(Debug, Clone, Copy)]
+pub struct PeakUtilization {
+    pub ratio: f64,
+    pub family: UtilFamily,
+}
+
+/// MCU stepping period (40 kHz), matching `peak::peak_accel`.
+const MCU_DT: f64 = 25e-6;
+
+/// Peak utilization of one committed segment, sampling the per-axis time
+/// polynomials at the MCU rate and forming `restricted_norm / cap` for each
+/// spatial limit set and family. Returns `None` for a segment too short to carry
+/// a jerk stencil or one whose caps are all non-finite.
+#[must_use]
+pub fn segment_peak_utilization(
+    axes: &[ScalarNurbs<f64>],
+    limits: &Limits,
+) -> Option<PeakUtilization> {
+    if axes.len() < 3 {
+        return None;
+    }
+    let pieces = extract_bezier_pieces(&axes[0]);
+    let t0 = pieces.first()?.u_start;
+    let t1 = pieces.last()?.u_end;
+    let dur = t1 - t0;
+    if dur <= 4.0 * MCU_DT {
+        return None;
+    }
+
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let n = (dur / MCU_DT).ceil() as usize;
+    let dt = dur / n as f64;
+
+    let sample = |t: f64| -> [f64; 3] {
+        [
+            nurbs::eval::eval(&axes[0], t),
+            nurbs::eval::eval(&axes[1], t),
+            nurbs::eval::eval(&axes[2], t),
+        ]
+    };
+    let x: Vec<[f64; 3]> = (0..=n).map(|i| sample(t0 + dt * i as f64)).collect();
+
+    let mut best: Option<PeakUtilization> = None;
+    let mut consider = |ratio: f64, family: UtilFamily| {
+        if ratio.is_finite() && best.is_none_or(|b| ratio > b.ratio) {
+            best = Some(PeakUtilization { ratio, family });
+        }
+    };
+
+    for i in 2..=n - 2 {
+        let mut v = [0.0_f64; 3];
+        let mut a = [0.0_f64; 3];
+        let mut j = [0.0_f64; 3];
+        for k in 0..3 {
+            v[k] = (x[i + 1][k] - x[i - 1][k]) / (2.0 * dt);
+            a[k] = (x[i + 1][k] - 2.0 * x[i][k] + x[i - 1][k]) / (dt * dt);
+            j[k] = (x[i + 2][k] - 2.0 * x[i + 1][k] + 2.0 * x[i - 1][k] - x[i - 2][k])
+                / (2.0 * dt * dt * dt);
+        }
+        for (_, set) in limits.spatial_sets() {
+            if set.v_max.is_finite() {
+                consider(
+                    restricted_norm(&v, set.axes) / set.v_max,
+                    UtilFamily::Velocity,
+                );
+            }
+            if set.a_max.is_finite() {
+                consider(restricted_norm(&a, set.axes) / set.a_max, UtilFamily::Accel);
+            }
+            if set.j_max.is_finite() {
+                consider(restricted_norm(&j, set.axes) / set.j_max, UtilFamily::Jerk);
+            }
+        }
+    }
+
+    best
+}
+
+/// Peak utilization across a window of committed segments, each checked against
+/// its own true (un-derated) limits. `None` when no segment yields a sample.
+#[must_use]
+pub fn window_peak_utilization<'a>(
+    segments: impl IntoIterator<Item = (&'a [ScalarNurbs<f64>], &'a Limits)>,
+) -> Option<PeakUtilization> {
+    let mut best: Option<PeakUtilization> = None;
+    for (axes, limits) in segments {
+        if let Some(u) = segment_peak_utilization(axes, limits) {
+            if best.is_none_or(|b| u.ratio > b.ratio) {
+                best = Some(u);
+            }
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/trajectory/src/utilization.rs
+++ b/rust/trajectory/src/utilization.rs
@@ -22,26 +22,69 @@ pub enum UtilFamily {
     Jerk,
 }
 
-/// Peak limit utilization over a trajectory: the largest `|executed| / cap` ratio
-/// reached on any axis-set and family, and which family it was.
+/// The overall worst utilization over a trajectory: the largest `|executed|/cap`
+/// ratio reached on any axis-set and family, and which family it was.
 #[derive(Debug, Clone, Copy)]
 pub struct PeakUtilization {
     pub ratio: f64,
     pub family: UtilFamily,
 }
 
+/// Per-family executed peaks over a trajectory: the worst `|executed|/cap` ratio
+/// per family, and the raw peak path-frame magnitudes (mm/s, mm/s², mm/s³). All
+/// measured on the committed time polynomials at the MCU sample rate.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UtilizationPeaks {
+    pub vel_ratio: f64,
+    pub accel_ratio: f64,
+    pub jerk_ratio: f64,
+    pub vel_mag: f64,
+    pub accel_mag: f64,
+    pub jerk_mag: f64,
+}
+
+impl UtilizationPeaks {
+    fn merge_max(&mut self, o: &UtilizationPeaks) {
+        self.vel_ratio = self.vel_ratio.max(o.vel_ratio);
+        self.accel_ratio = self.accel_ratio.max(o.accel_ratio);
+        self.jerk_ratio = self.jerk_ratio.max(o.jerk_ratio);
+        self.vel_mag = self.vel_mag.max(o.vel_mag);
+        self.accel_mag = self.accel_mag.max(o.accel_mag);
+        self.jerk_mag = self.jerk_mag.max(o.jerk_mag);
+    }
+
+    /// The overall worst family and its ratio — the headline utilization.
+    #[must_use]
+    pub fn worst(&self) -> Option<PeakUtilization> {
+        let mut best = (self.vel_ratio, UtilFamily::Velocity);
+        if self.accel_ratio > best.0 {
+            best = (self.accel_ratio, UtilFamily::Accel);
+        }
+        if self.jerk_ratio > best.0 {
+            best = (self.jerk_ratio, UtilFamily::Jerk);
+        }
+        (best.0 > 0.0).then_some(PeakUtilization {
+            ratio: best.0,
+            family: best.1,
+        })
+    }
+}
+
 /// MCU stepping period (40 kHz), matching `peak::peak_accel`.
 const MCU_DT: f64 = 25e-6;
 
-/// Peak utilization of one committed segment, sampling the per-axis time
-/// polynomials at the MCU rate and forming `restricted_norm / cap` for each
-/// spatial limit set and family. Returns `None` for a segment too short to carry
-/// a jerk stencil or one whose caps are all non-finite.
+fn norm3(x: &[f64; 3]) -> f64 {
+    (x[0] * x[0] + x[1] * x[1] + x[2] * x[2]).sqrt()
+}
+
+/// Per-family executed peaks of one committed segment, sampling the per-axis time
+/// polynomials at the MCU rate. Returns `None` for a segment too short to carry a
+/// jerk stencil.
 #[must_use]
 pub fn segment_peak_utilization(
     axes: &[ScalarNurbs<f64>],
     limits: &Limits,
-) -> Option<PeakUtilization> {
+) -> Option<UtilizationPeaks> {
     if axes.len() < 3 {
         return None;
     }
@@ -66,13 +109,7 @@ pub fn segment_peak_utilization(
     };
     let x: Vec<[f64; 3]> = (0..=n).map(|i| sample(t0 + dt * i as f64)).collect();
 
-    let mut best: Option<PeakUtilization> = None;
-    let mut consider = |ratio: f64, family: UtilFamily| {
-        if ratio.is_finite() && best.is_none_or(|b| ratio > b.ratio) {
-            best = Some(PeakUtilization { ratio, family });
-        }
-    };
-
+    let mut p = UtilizationPeaks::default();
     for i in 2..=n - 2 {
         let mut v = [0.0_f64; 3];
         let mut a = [0.0_f64; 3];
@@ -83,40 +120,42 @@ pub fn segment_peak_utilization(
             j[k] = (x[i + 2][k] - 2.0 * x[i + 1][k] + 2.0 * x[i - 1][k] - x[i - 2][k])
                 / (2.0 * dt * dt * dt);
         }
+        p.vel_mag = p.vel_mag.max(norm3(&v));
+        p.accel_mag = p.accel_mag.max(norm3(&a));
+        p.jerk_mag = p.jerk_mag.max(norm3(&j));
         for (_, set) in limits.spatial_sets() {
             if set.v_max.is_finite() {
-                consider(
-                    restricted_norm(&v, set.axes) / set.v_max,
-                    UtilFamily::Velocity,
-                );
+                p.vel_ratio = p.vel_ratio.max(restricted_norm(&v, set.axes) / set.v_max);
             }
             if set.a_max.is_finite() {
-                consider(restricted_norm(&a, set.axes) / set.a_max, UtilFamily::Accel);
+                p.accel_ratio = p.accel_ratio.max(restricted_norm(&a, set.axes) / set.a_max);
             }
             if set.j_max.is_finite() {
-                consider(restricted_norm(&j, set.axes) / set.j_max, UtilFamily::Jerk);
+                p.jerk_ratio = p.jerk_ratio.max(restricted_norm(&j, set.axes) / set.j_max);
             }
         }
     }
 
-    best
+    Some(p)
 }
 
-/// Peak utilization across a window of committed segments, each checked against
-/// its own true (un-derated) limits. `None` when no segment yields a sample.
+/// Per-family executed peaks across a window of committed segments, each checked
+/// against its own true (un-derated) limits — the max of each field over the
+/// window. `None` when no segment yields a sample.
 #[must_use]
 pub fn window_peak_utilization<'a>(
     segments: impl IntoIterator<Item = (&'a [ScalarNurbs<f64>], &'a Limits)>,
-) -> Option<PeakUtilization> {
-    let mut best: Option<PeakUtilization> = None;
+) -> Option<UtilizationPeaks> {
+    let mut acc: Option<UtilizationPeaks> = None;
     for (axes, limits) in segments {
-        if let Some(u) = segment_peak_utilization(axes, limits) {
-            if best.is_none_or(|b| u.ratio > b.ratio) {
-                best = Some(u);
+        if let Some(p) = segment_peak_utilization(axes, limits) {
+            match &mut acc {
+                Some(a) => a.merge_max(&p),
+                None => acc = Some(p),
             }
         }
     }
-    best
+    acc
 }
 
 #[cfg(test)]

--- a/rust/trajectory/src/utilization.rs
+++ b/rust/trajectory/src/utilization.rs
@@ -1,20 +1,7 @@
-//! Executed-trajectory limit utilization: how close to the kinematic limits the
-//! committed per-axis time-polynomials actually ride, measured the way the MCU
-//! steps them (finite differences at the 40 kHz sample rate).
-//!
-//! Unlike a grid-sampled solver diagnostic, this evaluates the exact committed
-//! trajectory — the `FittedSegment`/emitted axes are polynomials in time, so
-//! their velocity/accel/jerk are exact for any geometry and include the behavior
-//! between solver grid points. By the maximum principle a time-optimal trajectory
-//! rides some limit at (almost) every instant, so the peak utilization is both an
-//! optimality signal (well below 1 ⇒ headroom left on the table) and a feasibility
-//! check (above 1 ⇒ the executed motion exceeds a limit the grid never sampled).
-
 use nurbs::bezier::extract_bezier_pieces;
 use nurbs::ScalarNurbs;
 use temporal::{restricted_norm, Limits};
 
-/// The kinematic family a peak utilization was reached on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UtilFamily {
     Velocity,
@@ -22,17 +9,12 @@ pub enum UtilFamily {
     Jerk,
 }
 
-/// The overall worst utilization over a trajectory: the largest `|executed|/cap`
-/// ratio reached on any axis-set and family, and which family it was.
 #[derive(Debug, Clone, Copy)]
 pub struct PeakUtilization {
     pub ratio: f64,
     pub family: UtilFamily,
 }
 
-/// Per-family executed peaks over a trajectory: the worst `|executed|/cap` ratio
-/// per family, and the raw peak path-frame magnitudes (mm/s, mm/s², mm/s³). All
-/// measured on the committed time polynomials at the MCU sample rate.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UtilizationPeaks {
     pub vel_ratio: f64,
@@ -53,7 +35,6 @@ impl UtilizationPeaks {
         self.jerk_mag = self.jerk_mag.max(o.jerk_mag);
     }
 
-    /// The overall worst family and its ratio — the headline utilization.
     #[must_use]
     pub fn worst(&self) -> Option<PeakUtilization> {
         let mut best = (self.vel_ratio, UtilFamily::Velocity);
@@ -70,16 +51,12 @@ impl UtilizationPeaks {
     }
 }
 
-/// MCU stepping period (40 kHz), matching `peak::peak_accel`.
 const MCU_DT: f64 = 25e-6;
 
 fn norm3(x: &[f64; 3]) -> f64 {
     (x[0] * x[0] + x[1] * x[1] + x[2] * x[2]).sqrt()
 }
 
-/// Per-family executed peaks of one committed segment, sampling the per-axis time
-/// polynomials at the MCU rate. Returns `None` for a segment too short to carry a
-/// jerk stencil.
 #[must_use]
 pub fn segment_peak_utilization(
     axes: &[ScalarNurbs<f64>],
@@ -139,9 +116,6 @@ pub fn segment_peak_utilization(
     Some(p)
 }
 
-/// Per-family executed peaks across a window of committed segments, each checked
-/// against its own true (un-derated) limits — the max of each field over the
-/// window. `None` when no segment yields a sample.
 #[must_use]
 pub fn window_peak_utilization<'a>(
     segments: impl IntoIterator<Item = (&'a [ScalarNurbs<f64>], &'a Limits)>,

--- a/rust/trajectory/src/utilization/tests.rs
+++ b/rust/trajectory/src/utilization/tests.rs
@@ -9,8 +9,6 @@ fn constant(value: f64, t_end: f64) -> ScalarNurbs<f64> {
     ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![value, value]).unwrap()
 }
 
-/// Axis 0 moves at constant velocity `v`; axes 1,2 are still. The executed
-/// trajectory rides velocity at `v / v_max` and nothing else.
 #[test]
 fn constant_velocity_reports_velocity_family() {
     let t_end = 0.1;
@@ -33,15 +31,9 @@ fn constant_velocity_reports_velocity_family() {
         u.vel_mag
     );
     assert!((u.vel_ratio - v / 300.0).abs() < 1e-6);
-    // accel/jerk are zero up to finite-difference floating-point noise (the jerk
-    // stencil divides by dt³ ≈ 1.5e-14, so a true-zero rounds to ~6e-5 of cap) —
-    // negligible against the 0.33 velocity ratio.
     assert!(u.accel_ratio < 1e-3 && u.jerk_ratio < 1e-3);
 }
 
-/// Axis 0 under constant acceleration `a` (x = ½ a t²). With caps chosen so the
-/// accel ratio dominates the velocity ratio, the peak family is Accel and the
-/// ratio is exact (the second difference of a quadratic is exact).
 #[test]
 fn constant_accel_reports_accel_family_exactly() {
     let t_end = 0.1;
@@ -54,8 +46,6 @@ fn constant_accel_reports_accel_family_exactly() {
     .unwrap();
     let axes = [ax0, constant(0.0, t_end), constant(0.0, t_end)];
 
-    // peak velocity is a*t_end = 500; v_max = 600 keeps velocity ratio below the
-    // accel ratio of a / a_max = 1.0.
     let u = segment_peak_utilization(&axes, &limits(600.0, a, 50_000.0))
         .expect("a moving segment must report utilization");
     let w = u.worst().expect("a moving segment has a worst family");
@@ -65,7 +55,6 @@ fn constant_accel_reports_accel_family_exactly() {
         "accel utilization must be a / a_max = 1.0; got {}",
         w.ratio,
     );
-    // raw peak accel is exactly a (second difference of a quadratic is exact).
     assert!(
         (u.accel_mag - a).abs() < 1e-3,
         "raw peak accel ≈ a; got {}",
@@ -73,8 +62,6 @@ fn constant_accel_reports_accel_family_exactly() {
     );
 }
 
-/// A segment exceeding its accel cap reports utilization above 1 — the executed
-/// trajectory is over the limit, which a feasibility check must surface.
 #[test]
 fn over_limit_segment_reports_ratio_above_one() {
     let t_end = 0.1;
@@ -97,16 +84,10 @@ fn over_limit_segment_reports_ratio_above_one() {
     );
 }
 
-/// The requested feedrate is wired as a separate full-spatial path-speed set
-/// (v_max = feed) by `per_segment_limits`. A move cruising at the feed must read
-/// utilization 1.0 against that set — NOT feed/machine against the per-axis box.
-/// This locks that utilization is measured against the effective limit, so a move
-/// running exactly at its requested feed reports as riding its limit, not as
-/// leaving (machine - feed) headroom.
 #[test]
 fn utilization_credits_the_feedrate_path_speed_set() {
     let t_end = 0.1;
-    let feed = 150.0; // half the machine cap of 300
+    let feed = 150.0;
     let ax0 =
         ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, feed * t_end]).unwrap();
     let axes = [ax0, constant(0.0, t_end), constant(0.0, t_end)];
@@ -128,10 +109,9 @@ fn utilization_credits_the_feedrate_path_speed_set() {
     );
 }
 
-/// A segment too short to carry a jerk stencil yields no utilization sample.
 #[test]
 fn segment_too_short_is_none() {
-    let t_end = 1e-5; // < 4 * MCU_DT
+    let t_end = 1e-5;
     let axes = [
         ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, 1.0]).unwrap(),
         constant(0.0, t_end),
@@ -140,7 +120,6 @@ fn segment_too_short_is_none() {
     assert!(segment_peak_utilization(&axes, &limits(300.0, 10_000.0, 50_000.0)).is_none());
 }
 
-/// The window peak is the max over its segments.
 #[test]
 fn window_peak_takes_the_max_segment() {
     let t_end = 0.1;

--- a/rust/trajectory/src/utilization/tests.rs
+++ b/rust/trajectory/src/utilization/tests.rs
@@ -78,6 +78,36 @@ fn over_limit_segment_reports_ratio_above_one() {
     );
 }
 
+/// The requested feedrate is wired as a separate full-spatial path-speed set
+/// (v_max = feed) by `per_segment_limits`. A move cruising at the feed must read
+/// utilization 1.0 against that set — NOT feed/machine against the per-axis box.
+/// This locks that utilization is measured against the effective limit, so a move
+/// running exactly at its requested feed reports as riding its limit, not as
+/// leaving (machine - feed) headroom.
+#[test]
+fn utilization_credits_the_feedrate_path_speed_set() {
+    let t_end = 0.1;
+    let feed = 150.0; // half the machine cap of 300
+    let ax0 =
+        ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, feed * t_end]).unwrap();
+    let axes = [ax0, constant(0.0, t_end), constant(0.0, t_end)];
+
+    let lim = limits(300.0, 10_000.0, 50_000.0).with_extra_sets(&[temporal::LimitSet {
+        axes: temporal::AxisSet::spatial(),
+        v_max: feed,
+        a_max: f64::INFINITY,
+        j_max: f64::INFINITY,
+    }]);
+
+    let u = segment_peak_utilization(&axes, &lim).expect("util");
+    assert_eq!(u.family, UtilFamily::Velocity);
+    assert!(
+        (u.ratio - 1.0).abs() < 1e-6,
+        "must credit the feed set (1.0), not feed/machine (0.5); got {}",
+        u.ratio,
+    );
+}
+
 /// A segment too short to carry a jerk stencil yields no utilization sample.
 #[test]
 fn segment_too_short_is_none() {

--- a/rust/trajectory/src/utilization/tests.rs
+++ b/rust/trajectory/src/utilization/tests.rs
@@ -1,0 +1,112 @@
+use super::*;
+use temporal::Limits;
+
+fn limits(v: f64, a: f64, j: f64) -> Limits {
+    Limits::axis_boxes([v, v, v], [a, a, a], [j, j, j])
+}
+
+fn constant(value: f64, t_end: f64) -> ScalarNurbs<f64> {
+    ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![value, value]).unwrap()
+}
+
+/// Axis 0 moves at constant velocity `v`; axes 1,2 are still. The executed
+/// trajectory rides velocity at `v / v_max` and nothing else.
+#[test]
+fn constant_velocity_reports_velocity_family() {
+    let t_end = 0.1;
+    let v = 100.0;
+    let ax0 = ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, v * t_end]).unwrap();
+    let axes = [ax0, constant(0.0, t_end), constant(0.0, t_end)];
+
+    let u = segment_peak_utilization(&axes, &limits(300.0, 10_000.0, 50_000.0))
+        .expect("a moving segment must report utilization");
+    assert_eq!(u.family, UtilFamily::Velocity);
+    assert!(
+        (u.ratio - v / 300.0).abs() < 1e-6,
+        "velocity utilization must be v / v_max; got {}",
+        u.ratio,
+    );
+}
+
+/// Axis 0 under constant acceleration `a` (x = ½ a t²). With caps chosen so the
+/// accel ratio dominates the velocity ratio, the peak family is Accel and the
+/// ratio is exact (the second difference of a quadratic is exact).
+#[test]
+fn constant_accel_reports_accel_family_exactly() {
+    let t_end = 0.1;
+    let a = 5_000.0;
+    let ax0 = ScalarNurbs::try_new(
+        2,
+        vec![0.0, 0.0, 0.0, t_end, t_end, t_end],
+        vec![0.0, 0.0, 0.5 * a * t_end * t_end],
+    )
+    .unwrap();
+    let axes = [ax0, constant(0.0, t_end), constant(0.0, t_end)];
+
+    // peak velocity is a*t_end = 500; v_max = 600 keeps velocity ratio below the
+    // accel ratio of a / a_max = 1.0.
+    let u = segment_peak_utilization(&axes, &limits(600.0, a, 50_000.0))
+        .expect("a moving segment must report utilization");
+    assert_eq!(u.family, UtilFamily::Accel);
+    assert!(
+        (u.ratio - 1.0).abs() < 1e-6,
+        "accel utilization must be a / a_max = 1.0; got {}",
+        u.ratio,
+    );
+}
+
+/// A segment exceeding its accel cap reports utilization above 1 — the executed
+/// trajectory is over the limit, which a feasibility check must surface.
+#[test]
+fn over_limit_segment_reports_ratio_above_one() {
+    let t_end = 0.1;
+    let a = 5_000.0;
+    let ax0 = ScalarNurbs::try_new(
+        2,
+        vec![0.0, 0.0, 0.0, t_end, t_end, t_end],
+        vec![0.0, 0.0, 0.5 * a * t_end * t_end],
+    )
+    .unwrap();
+    let axes = [ax0, constant(0.0, t_end), constant(0.0, t_end)];
+
+    let u = segment_peak_utilization(&axes, &limits(600.0, 2_500.0, 50_000.0))
+        .expect("a moving segment must report utilization");
+    assert!(
+        u.ratio > 1.0,
+        "an over-limit segment must report utilization > 1; got {}",
+        u.ratio,
+    );
+}
+
+/// A segment too short to carry a jerk stencil yields no utilization sample.
+#[test]
+fn segment_too_short_is_none() {
+    let t_end = 1e-5; // < 4 * MCU_DT
+    let axes = [
+        ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, 1.0]).unwrap(),
+        constant(0.0, t_end),
+        constant(0.0, t_end),
+    ];
+    assert!(segment_peak_utilization(&axes, &limits(300.0, 10_000.0, 50_000.0)).is_none());
+}
+
+/// The window peak is the max over its segments.
+#[test]
+fn window_peak_takes_the_max_segment() {
+    let t_end = 0.1;
+    let slow =
+        ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, 50.0 * t_end]).unwrap();
+    let fast =
+        ScalarNurbs::try_new(1, vec![0.0, 0.0, t_end, t_end], vec![0.0, 200.0 * t_end]).unwrap();
+    let lim = limits(300.0, 10_000.0, 50_000.0);
+    let seg_slow = [slow, constant(0.0, t_end), constant(0.0, t_end)];
+    let seg_fast = [fast, constant(0.0, t_end), constant(0.0, t_end)];
+
+    let u = window_peak_utilization([(seg_slow.as_slice(), &lim), (seg_fast.as_slice(), &lim)])
+        .expect("window must report utilization");
+    assert!(
+        (u.ratio - 200.0 / 300.0).abs() < 1e-6,
+        "window peak must be the faster segment; got {}",
+        u.ratio,
+    );
+}

--- a/rust/trajectory/src/utilization/tests.rs
+++ b/rust/trajectory/src/utilization/tests.rs
@@ -27,7 +27,6 @@ fn constant_velocity_reports_velocity_family() {
         "velocity utilization must be v / v_max; got {}",
         w.ratio,
     );
-    // per-family detail: the raw peak velocity is v, accel/jerk are ~0.
     assert!(
         (u.vel_mag - v).abs() < 1e-3,
         "raw peak velocity ≈ v; got {}",

--- a/rust/trajectory/src/utilization/tests.rs
+++ b/rust/trajectory/src/utilization/tests.rs
@@ -20,12 +20,24 @@ fn constant_velocity_reports_velocity_family() {
 
     let u = segment_peak_utilization(&axes, &limits(300.0, 10_000.0, 50_000.0))
         .expect("a moving segment must report utilization");
-    assert_eq!(u.family, UtilFamily::Velocity);
+    let w = u.worst().expect("a moving segment has a worst family");
+    assert_eq!(w.family, UtilFamily::Velocity);
     assert!(
-        (u.ratio - v / 300.0).abs() < 1e-6,
+        (w.ratio - v / 300.0).abs() < 1e-6,
         "velocity utilization must be v / v_max; got {}",
-        u.ratio,
+        w.ratio,
     );
+    // per-family detail: the raw peak velocity is v, accel/jerk are ~0.
+    assert!(
+        (u.vel_mag - v).abs() < 1e-3,
+        "raw peak velocity ≈ v; got {}",
+        u.vel_mag
+    );
+    assert!((u.vel_ratio - v / 300.0).abs() < 1e-6);
+    // accel/jerk are zero up to finite-difference floating-point noise (the jerk
+    // stencil divides by dt³ ≈ 1.5e-14, so a true-zero rounds to ~6e-5 of cap) —
+    // negligible against the 0.33 velocity ratio.
+    assert!(u.accel_ratio < 1e-3 && u.jerk_ratio < 1e-3);
 }
 
 /// Axis 0 under constant acceleration `a` (x = ½ a t²). With caps chosen so the
@@ -47,11 +59,18 @@ fn constant_accel_reports_accel_family_exactly() {
     // accel ratio of a / a_max = 1.0.
     let u = segment_peak_utilization(&axes, &limits(600.0, a, 50_000.0))
         .expect("a moving segment must report utilization");
-    assert_eq!(u.family, UtilFamily::Accel);
+    let w = u.worst().expect("a moving segment has a worst family");
+    assert_eq!(w.family, UtilFamily::Accel);
     assert!(
-        (u.ratio - 1.0).abs() < 1e-6,
+        (w.ratio - 1.0).abs() < 1e-6,
         "accel utilization must be a / a_max = 1.0; got {}",
-        u.ratio,
+        w.ratio,
+    );
+    // raw peak accel is exactly a (second difference of a quadratic is exact).
+    assert!(
+        (u.accel_mag - a).abs() < 1e-3,
+        "raw peak accel ≈ a; got {}",
+        u.accel_mag
     );
 }
 
@@ -71,10 +90,11 @@ fn over_limit_segment_reports_ratio_above_one() {
 
     let u = segment_peak_utilization(&axes, &limits(600.0, 2_500.0, 50_000.0))
         .expect("a moving segment must report utilization");
+    let w = u.worst().expect("a moving segment has a worst family");
     assert!(
-        u.ratio > 1.0,
+        w.ratio > 1.0,
         "an over-limit segment must report utilization > 1; got {}",
-        u.ratio,
+        w.ratio,
     );
 }
 
@@ -100,11 +120,12 @@ fn utilization_credits_the_feedrate_path_speed_set() {
     }]);
 
     let u = segment_peak_utilization(&axes, &lim).expect("util");
-    assert_eq!(u.family, UtilFamily::Velocity);
+    let w = u.worst().expect("a moving segment has a worst family");
+    assert_eq!(w.family, UtilFamily::Velocity);
     assert!(
-        (u.ratio - 1.0).abs() < 1e-6,
+        (w.ratio - 1.0).abs() < 1e-6,
         "must credit the feed set (1.0), not feed/machine (0.5); got {}",
-        u.ratio,
+        w.ratio,
     );
 }
 
@@ -134,9 +155,14 @@ fn window_peak_takes_the_max_segment() {
 
     let u = window_peak_utilization([(seg_slow.as_slice(), &lim), (seg_fast.as_slice(), &lim)])
         .expect("window must report utilization");
+    let w = u.worst().expect("window has a worst family");
     assert!(
-        (u.ratio - 200.0 / 300.0).abs() < 1e-6,
+        (w.ratio - 200.0 / 300.0).abs() < 1e-6,
         "window peak must be the faster segment; got {}",
-        u.ratio,
+        w.ratio,
+    );
+    assert!(
+        (u.vel_mag - 200.0).abs() < 1e-3,
+        "window raw peak velocity is the faster segment"
     );
 }


### PR DESCRIPTION
## Summary

Replaces the misleading binding-margin `gap` (1 − worst grid ratio) with a metric that measures **what the committed trajectory actually does**, so the numbers can drive prioritization.

- **Executed peak utilization.** Samples the committed per-axis time polynomials (what the MCU steps) at the 40 kHz rate and forms `|executed| / cap` per limit set. Exact for any geometry, and it catches between-grid-point excursions the solver grid never samples: below 1 = headroom left, around 1 = riding the limit, above 1 = the executed path exceeds a limit (a feasibility blind spot the old grid metric missed). Lives in `trajectory::utilization`.
- **Respects the requested feedrate.** The per-move feed path-speed set is honored end-to-end, so a move cruising at feed reads ~1.0, not feed/machine — verified by a regression test through the real plan path.
- **Named limiters.** A `Copy` `LimitKind` (Config / Feedrate / RuntimeCap) rides a parallel array on `Limits` (no `LimitSet` literal churn) and is carried through `verify` → `WorstBinding` → the report. `limiter_limit` now reads the config section name, `feedrate`, or `runtime_caps` — so feed-limited vs machine-limited is obvious at a glance. Also fixes two `scale_*` paths that silently reset the kind by rebuilding `Limits` via `try_new`.
- **Per-family peaks on `replan_anytime`.** The sweep already computes per-axis v/a/j; it now keeps all three peaks, so the event carries `vel_util`/`accel_util`/`jerk_util` (ratios) and `vel_mm_s`/`accel_mm_s2`/`jerk_mm_s3` (raw magnitudes) alongside the headline `peak_utilization` + `peak_util_family`.

The old `gap` field is dropped; `binding_ratio` (solver grid view) and `limiter_*` are kept, so a divergence between `binding_ratio` and `peak_utilization` surfaces grid-vs-executed measurement error.

## Test Plan

- [x] `./scripts/ci.sh quick` green (ruff, rust-test, rust-clippy, rust-fmt, watchdog).
- [x] New regression tests: feed credited in utilization (cruise at feed → ~1.0), feedrate set emitted by `per_segment_limits`, per-family peak ratios/magnitudes, limit-kind → reserved name mapping, over-limit segment reports above 1.
- [x] Flashed to the EtherCAT bench; klippy `ready`, `mcu_ready`, VL healthy, named limiters live on `replan_anytime`.