### PR TITLE
Fix servo calibration macros against the rewritten motion objects

### DIFF
--- a/config/servo_calibration.cfg
+++ b/config/servo_calibration.cfg
@@ -53,8 +53,7 @@ gcode:
 [gcode_macro _SERVO_CAL_RESTORE]
 description: Internal - restore configured velocity limits
 gcode:
-  {% set cfg_accel = printer.configfile.settings.printer.max_accel %}
-  SET_VELOCITY_LIMIT ACCEL={cfg_accel}
+  RESET_VELOCITY_LIMIT
 
 [gcode_shell_command servo_tracking_report]
 command: ~/klippy-env/bin/python ~/kalico/scripts/servo_capture.py
@@ -139,7 +138,7 @@ gcode:
 [gcode_macro SERVO_SHOW_TUNING]
 description: Read back tuning mode, inertia ratio, gain set 1 and feedforward params from the drive. Param SERVO
 gcode:
-  {% set servo = params.SERVO|default('servo_x') %}
+  {% set servo = params.SERVO|default('motor_x') %}
   RESPOND MSG="C00.04 auto-tuning mode (0=manual 1=stiffness table 2=positioning):"
   SERVO_PARAM SERVO={servo} GET=0x2000.0x05
   RESPOND MSG="C00.05 stiffness level (1..31, used in mode 1):"
@@ -164,7 +163,7 @@ gcode:
 [gcode_macro SERVO_SET_INERTIA_RATIO]
 description: Write C00.06 load inertia ratio in percent (fit recommends 37; drive default 100). Params RATIO SERVO
 gcode:
-  {% set servo = params.SERVO|default('servo_x') %}
+  {% set servo = params.SERVO|default('motor_x') %}
   {% set ratio = params.RATIO|int %}
   {% if not 0 <= ratio <= 12000 %}
     {action_raise_error("RATIO=%d outside C00.06 range 0..12000 (%%)" % ratio)}
@@ -174,7 +173,7 @@ gcode:
 [gcode_macro SERVO_APPLY_GAINS]
 description: Switch the drive to manual tuning (C00.04=0) and write gain set 1. POS_GAIN in 0.1 rad/s (400 = 40 rad/s), SPEED_GAIN in 0.1 Hz (250 = 25 Hz), INTEGRAL in 0.01 ms (3184 = 31.8 ms). Defaults are the factory Low preset. Param SERVO
 gcode:
-  {% set servo = params.SERVO|default('servo_x') %}
+  {% set servo = params.SERVO|default('motor_x') %}
   {% set pos_gain = params.POS_GAIN|default(400)|int %}
   {% set speed_gain = params.SPEED_GAIN|default(250)|int %}
   {% set integral = params.INTEGRAL|default(3184)|int %}
@@ -192,7 +191,7 @@ verbose: True
 [gcode_macro SERVO_CALIBRATE_GAINS]
 description: Gain sweep, shaper-calibrate style. Tests each speed-loop gain in SPEED_GAINS (0.1 Hz units, comma list), deriving position gain and integral from the vendor ratios; one capture per step; then renders a comparison PNG into ~/printer_data/config/servo_calibrate_results and prints a recommendation. Reverts to the first (lowest) gains afterwards. Params SPEED_GAINS AXIS START END SPEED ACCEL ITERATIONS DWELL_MS TAG SERVO
 gcode:
-  {% set servo = params.SERVO|default('servo_x') %}
+  {% set servo = params.SERVO|default('motor_x') %}
   {% set axis = params.AXIS|default('X')|upper %}
   {% set start = params.START|default(20)|float %}
   {% set end = params.END|default(200)|float %}
@@ -235,7 +234,7 @@ gcode:
 [gcode_macro SERVO_SET_STIFFNESS]
 description: Vendor-table tuning path - switch to standard mode (C00.04=1) and set C00.05 stiffness level 1..31 (factory 12). The drive derives all gain-set-1 values from the level. Params LEVEL SERVO
 gcode:
-  {% set servo = params.SERVO|default('servo_x') %}
+  {% set servo = params.SERVO|default('motor_x') %}
   {% set level = params.LEVEL|int %}
   {% if not 1 <= level <= 31 %}
     {action_raise_error("LEVEL=%d outside C00.05 range 1..31" % level)}

--- a/klippy/extras/servo_axis.py
+++ b/klippy/extras/servo_axis.py
@@ -51,6 +51,7 @@ class ServoRail(BaseRail):
                 "(got %r)" % (motor_config.get_name(), protocol)
             )
         self.node_name = motor_config.get("node")
+        self.motor_name = motor_config.get_name().split(None, 1)[1]
         self.rotation_distance = motor_config.getfloat(
             "rotation_distance", above=0.0
         )
@@ -134,6 +135,9 @@ class ServoRail(BaseRail):
 
     def get_node_name(self):
         return self.node_name
+
+    def get_motor_name(self):
+        return self.motor_name
 
     def get_counts_per_mm(self):
         return self.encoder_counts_per_rev / self.rotation_distance

--- a/klippy/extras/servo_param.py
+++ b/klippy/extras/servo_param.py
@@ -136,16 +136,24 @@ class ServoParam:
         from . import servo_axis
 
         toolhead = self.printer.lookup_object("toolhead")
-        for rail in getattr(toolhead.get_kinematics(), "rails", ()):
-            if (
-                isinstance(rail, servo_axis.ServoRail)
-                and rail.get_name() == servo_name
+        servo_rails = [
+            rail
+            for rail in getattr(toolhead.get_kinematics(), "rails", ())
+            if isinstance(rail, servo_axis.ServoRail)
+        ]
+        for rail in servo_rails:
+            if servo_name in (
+                rail.get_motor_name(),
+                rail.get_name(),
+                rail.get_name(short=True),
             ):
                 return self.printer.lookup_object(
                     "ethercat_node " + rail.get_node_name()
                 )
+        known = ", ".join(rail.get_motor_name() for rail in servo_rails)
         raise self.printer.command_error(
-            "SERVO_PARAM: no servo rail named %r" % (servo_name,)
+            "SERVO_PARAM: no servo motor named %r (known: %s)"
+            % (servo_name, known or "none")
         )
 
     def cmd_SERVO_PARAM(self, gcmd):

--- a/scripts/servo_capture.py
+++ b/scripts/servo_capture.py
@@ -7,7 +7,6 @@ time-series dashboard.
 """
 
 import argparse
-import glob
 import json
 import os
 import re
@@ -29,11 +28,16 @@ SETTLE_HOLD_MS = 50
 
 
 def resolve_newest_capture(captures_dir, name):
-    pattern = os.path.join(os.path.expanduser(captures_dir), name + "_*.scap")
-    matches = [p for p in glob.glob(pattern) if CAPTURE_TS_RE.search(p)]
-    if not matches:
+    directory = os.path.expanduser(captures_dir)
+    name_re = re.compile(r"^%s_(\d{8}_\d{6})\.scap$" % re.escape(name))
+    stamped = []
+    for entry in os.listdir(directory):
+        match = name_re.match(entry)
+        if match:
+            stamped.append((match.group(1), os.path.join(directory, entry)))
+    if not stamped:
         raise SystemExit("no capture named %r in %s" % (name, captures_dir))
-    return max(matches)
+    return max(stamped)[1]
 
 
 def load_capture(path):

--- a/test/test_motion_kinematics.py
+++ b/test/test_motion_kinematics.py
@@ -503,7 +503,7 @@ def _servo_rail():
 
     return servo_axis.ServoRail(
         FakeRailConfig("axis z", axis_opts),
-        FakeRailConfig("z_drive", motor_opts),
+        FakeRailConfig("motor z_drive", motor_opts),
     )
 
 

--- a/test/test_servo_fit_dynamics.py
+++ b/test/test_servo_fit_dynamics.py
@@ -46,6 +46,20 @@ def test_missing_capture_fails_loudly(tmp_path):
         sfd.resolve_newest_capture(str(tmp_path), "ident")
 
 
+def test_ignores_other_series_sharing_a_name_prefix(tmp_path):
+    d = str(tmp_path)
+    newest = _touch(d, "ident_20260616_010942.scap")
+    _touch(d, "ident_ha_20260611_181313.scap")
+    assert sfd.resolve_newest_capture(d, "ident") == newest
+
+
+def test_other_series_excluded_even_when_it_sorts_after(tmp_path):
+    d = str(tmp_path)
+    _touch(d, "ident_zzz_20260601_000000.scap")
+    newest = _touch(d, "ident_20260616_010942.scap")
+    assert sfd.resolve_newest_capture(d, "ident") == newest
+
+
 def test_profile_name_carries_capture_timestamp(tmp_path):
     path = sfd.profile_path(
         str(tmp_path), "ident", "/x/ident_20260611_230000.scap"

--- a/test/test_servo_homing.py
+++ b/test/test_servo_homing.py
@@ -101,7 +101,7 @@ def make_servo_rail(extra=(), drop=()):
         motor_options.pop(key, None)
     return servo_axis.ServoRail(
         FakeRailConfig("axis z", axis_options),
-        FakeRailConfig("z_drive", motor_options),
+        FakeRailConfig("motor z_drive", motor_options),
     )
 
 

--- a/test/test_servo_param.py
+++ b/test/test_servo_param.py
@@ -154,9 +154,10 @@ class FakePrinter:
 
 def make_servo_param(engine, node):
     rail = servo_axis.ServoRail.__new__(servo_axis.ServoRail)
-    rail.name = "servo_x"
+    rail.name = "axis x"
     rail.axis = "x"
     rail.node_name = "node_x"
+    rail.motor_name = "motor_x"
     sp = servo_param.ServoParam.__new__(servo_param.ServoParam)
     sp.printer = FakePrinter(
         {
@@ -171,7 +172,7 @@ def make_servo_param(engine, node):
 def test_cmd_get_reads_and_formats():
     engine = FakeEngine()
     sp = make_servo_param(engine, FakeNode(7))
-    gcmd = FakeGcmd({"SERVO": "servo_x", "GET": "0x2002.0"})
+    gcmd = FakeGcmd({"SERVO": "motor_x", "GET": "0x2002.0"})
     sp.cmd_SERVO_PARAM(gcmd)
     assert engine.reads == [(7, 0x2002, 0)]
     assert gcmd.responses == ["0x2002.0 = 0x0064 (u16: 100, i16: 100)"]
@@ -182,7 +183,7 @@ def test_cmd_set_typed_passes_size():
     engine.write_result = (2, 250)
     sp = make_servo_param(engine, FakeNode(7))
     gcmd = FakeGcmd(
-        {"SERVO": "servo_x", "SET": "0x2002.0", "VALUE": "250", "TYPE": "u16"}
+        {"SERVO": "motor_x", "SET": "0x2002.0", "VALUE": "250", "TYPE": "u16"}
     )
     sp.cmd_SERVO_PARAM(gcmd)
     assert engine.writes == [(7, 0x2002, 0, 2, 250)]
@@ -192,7 +193,7 @@ def test_cmd_set_typed_passes_size():
 def test_cmd_set_untyped_passes_size_zero():
     engine = FakeEngine()
     sp = make_servo_param(engine, FakeNode(7))
-    gcmd = FakeGcmd({"SERVO": "servo_x", "SET": "0x2002.0", "VALUE": "100"})
+    gcmd = FakeGcmd({"SERVO": "motor_x", "SET": "0x2002.0", "VALUE": "100"})
     sp.cmd_SERVO_PARAM(gcmd)
     assert engine.writes == [(7, 0x2002, 0, 0, 100)]
 
@@ -200,12 +201,12 @@ def test_cmd_set_untyped_passes_size_zero():
 def test_cmd_requires_exactly_one_of_get_set():
     sp = make_servo_param(FakeEngine(), FakeNode(7))
     with pytest.raises(RuntimeError, match="exactly one"):
-        sp.cmd_SERVO_PARAM(FakeGcmd({"SERVO": "servo_x"}))
+        sp.cmd_SERVO_PARAM(FakeGcmd({"SERVO": "motor_x"}))
     with pytest.raises(RuntimeError, match="exactly one"):
         sp.cmd_SERVO_PARAM(
             FakeGcmd(
                 {
-                    "SERVO": "servo_x",
+                    "SERVO": "motor_x",
                     "GET": "0x2002.0",
                     "SET": "0x2002.0",
                     "VALUE": "1",
@@ -217,13 +218,21 @@ def test_cmd_requires_exactly_one_of_get_set():
 def test_cmd_fails_without_engine_handle():
     sp = make_servo_param(FakeEngine(), FakeNode(None))
     with pytest.raises(RuntimeError, match="no engine handle"):
-        sp.cmd_SERVO_PARAM(FakeGcmd({"SERVO": "servo_x", "GET": "0x2002.0"}))
+        sp.cmd_SERVO_PARAM(FakeGcmd({"SERVO": "motor_x", "GET": "0x2002.0"}))
 
 
 def test_cmd_unknown_servo_fails():
     sp = make_servo_param(FakeEngine(), FakeNode(7))
-    with pytest.raises(RuntimeError, match="no servo rail"):
+    with pytest.raises(RuntimeError, match="no servo motor"):
         sp.cmd_SERVO_PARAM(FakeGcmd({"SERVO": "servo_q", "GET": "0x2002.0"}))
+
+
+@pytest.mark.parametrize("servo", ["motor_x", "axis x", "x"])
+def test_cmd_resolves_by_motor_axis_or_short_name(servo):
+    engine = FakeEngine()
+    sp = make_servo_param(engine, FakeNode(7))
+    sp.cmd_SERVO_PARAM(FakeGcmd({"SERVO": servo, "GET": "0x2002.0"}))
+    assert engine.reads == [(7, 0x2002, 0)]
 
 
 def test_cmd_propagates_engine_failure():
@@ -234,7 +243,7 @@ def test_cmd_propagates_engine_failure():
     sp = make_servo_param(FailingEngine(), FakeNode(7))
     with pytest.raises(RuntimeError, match="CoE abort"):
         sp.cmd_SERVO_PARAM(
-            FakeGcmd({"SERVO": "servo_x", "SET": "0x6041.0", "VALUE": "1"})
+            FakeGcmd({"SERVO": "motor_x", "SET": "0x6041.0", "VALUE": "1"})
         )
 
 


### PR DESCRIPTION
## Summary

The servo calibration toolkit (`config/servo_calibration.cfg` + `scripts/`) referenced objects that the motion-planner rewrite removed or renamed, so several macros failed outright and `SERVO_FIT_DYNAMICS` silently produced garbage. Three bugs:

- **`_SERVO_CAL_RESTORE` read `printer.configfile.settings.printer.max_accel`.** The `[printer]` section is gone (limits now live in `[limit <name>]`), so the macro raised `UndefinedError: 'dict object' has no attribute 'printer'`. It now calls `RESET_VELOCITY_LIMIT`, the proper counterpart to the `SET_VELOCITY_LIMIT` the strokes apply.

- **`SERVO_PARAM` only matched a rail's axis-section name.** Neither the macro default (`servo_x`) nor a motor name (`motor_x`) ever resolved, giving `no servo rail named 'motor_x'`. `ServoRail` now records its motor name and the resolver accepts the motor name, axis name, or short axis, with a known-names error listing the valid choices. Macro `SERVO` defaults point at `motor_x`.

- **`resolve_newest_capture` picked the wrong capture.** It globbed `<name>_*.scap` (prefix-matching sibling series like `ident_ha_*`) and selected with `max()` over full path strings — lexicographic order, not timestamp order. `ident_ha_20260611_181313.scap` sorted above the newer `ident_20260616_010942.scap` (`'h'` > `'2'`), so `SERVO_FIT_DYNAMICS` refit a stale capture every run and always overwrote the same `dynamics_<name>_<old-stamp>.toml`. It now matches the name exactly and orders by the embedded timestamp.

## Test Plan

- [x] `./scripts/ci.sh ruff` — clean (380 files)
- [x] `./scripts/ci.sh py` — 378 passed, 109 skipped, 2 xfailed
- [x] New regression tests: motor/axis/short-name resolution; capture prefix-collision and lexicographic-ordering traps
- [x] Deployed to the Neptune EtherCAT bench; klippy reaches `ready`; resolver now returns the genuinely-newest `ident` capture live