### PR TITLE
homing: fix min_home_dist rehome backoff landing outside axis bounds

### DIFF
--- a/docs/rewrite/beacon-fork-survey.md
+++ b/docs/rewrite/beacon-fork-survey.md
@@ -111,7 +111,7 @@ credit-window deadline design (50 ms grants) from
 | API | Beacon's actual usage | Status in our tree | Resolution |
 |---|---|---|---|
 | `homing:home_rails_begin/end` events | Beacon SENDS them itself around its own homing (with minimal `BeaconHomingState`: `get_axes()→[2]`, no-op `set_homed_position`) and LISTENS to adjust position post-G28-Z | Listeners alive (gcode_move.py:27, z_thermal_adjust, z_calibration, endstop_phase). Our G28 emits **nothing** — only trad_rack emits these | Beacon's own synthesis keeps working. The listener path is dead on our G28 → post-home `_sample()` adjustment must move into our provider contract (post-trip hook / measured-position override) — spec B |
-| `homing_state.set_homed_position([None,None,dist])` | Override homed Z with measured distance after G28 | No Homing-state class; our homing.py sets position from `trigger_height + overshoot` | Provider contract extension: provider supplies measured trigger height post-trip (spec B) |
+| `homing_state.set_homed_position([None,None,dist])` | Override homed Z with measured distance after G28 | No Homing-state class; our homing.py sets position from `trigger_position + overshoot` | Provider contract extension: provider supplies measured trigger position post-trip (spec B) |
 | `kin.note_z_not_homed()` / `kin.clear_homing_state("z")` / `set_position(homing_axes=…)` | Mark Z unhomed around contact ops | All present on `BridgeKinematics` (motion.py:195-210), both string and index forms handled by beacon's own compat shim | Works as-is |
 
 ### Toolhead surface

--- a/docs/rewrite/virtual-endstops-and-probe.md
+++ b/docs/rewrite/virtual-endstops-and-probe.md
@@ -120,9 +120,9 @@ method on `Homing` that both `G28` and the probe commands call:
 7. Return `(trip_pos, final_pos)`.
 
 Callers differ only in what they do with the result:
-- `G28`: `newpos[axis] = trigger_height + overshoot`,
+- `G28`: `newpos[axis] = trigger_position + overshoot`,
   `toolhead.set_position(newpos, homing_axes=[axis])`, where
-  `trigger_height` is the provider override if present, else
+  `trigger_position` is the provider override if present, else
   `hi.position_endstop`.
 - `PROBE`: resync toolhead to `final_pos` (frame already established, no
   `homing_axes`), record `trip_pos[2]` as the measurement.

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -70,12 +70,12 @@ def _check_servo_drive_fault(gcmd, engine, axis, servo_handle):
         )
 
 
-def _homed_axis_position(provider, axis, trip_pos, final_pos, trigger_height):
+def _homed_axis_position(provider, axis, trip_pos, final_pos, trigger_position):
     if provider is not None and hasattr(provider, "measured_trip_position"):
         measured = provider.measured_trip_position(axis, trip_pos, final_pos)
         if measured is not None:
             return measured
-    return trigger_height + (final_pos[axis] - trip_pos[axis])
+    return trigger_position + (final_pos[axis] - trip_pos[axis])
 
 
 def _commit_and_seed(
@@ -86,23 +86,23 @@ def _commit_and_seed(
     hi,
     trip_pos,
     final_pos,
-    trigger_height,
+    trigger_position,
     provider,
     servo_handle,
 ):
     overshoot = final_pos[axis] - trip_pos[axis]
     newpos = list(toolhead.get_position())
     newpos[axis] = _homed_axis_position(
-        provider, axis, trip_pos, final_pos, trigger_height
+        provider, axis, trip_pos, final_pos, trigger_position
     )
     toolhead.set_position(newpos, homing_axes=[axis])
     structured_log.event(
         "homing",
         "axis_homed",
         msg="homing: %s trigger=%.4f overshoot=%+.4f set %s=%.4f"
-        % ("XYZ"[axis], trigger_height, overshoot, "XYZ"[axis], newpos[axis]),
+        % ("XYZ"[axis], trigger_position, overshoot, "XYZ"[axis], newpos[axis]),
         axis="XYZ"[axis],
-        trigger_height=trigger_height,
+        trigger_position=trigger_position,
         overshoot=overshoot,
         homed_position=newpos[axis],
     )
@@ -126,6 +126,7 @@ def _run_homing_attempts(
     speed,
     first_max_travel,
     tolerance,
+    trigger_position,
     approach,
 ):
     start_pos = toolhead.get_position()
@@ -145,10 +146,10 @@ def _run_homing_attempts(
     if not needs_rehome:
         return trip_pos, final_pos
     haltpos = list(toolhead.get_position())
-    haltpos[axis] = final_pos[axis]
+    haltpos[axis] = trigger_position + (final_pos[axis] - trip_pos[axis])
     toolhead.set_position(haltpos, homing_axes=[axis])
     backoff = list(toolhead.get_position())
-    backoff[axis] = trip_pos[axis] - direction * hi.min_home_dist
+    backoff[axis] = trigger_position - direction * hi.min_home_dist
     toolhead.move(backoff, hi.retract_speed)
     toolhead.wait_moves()
     start_pos = toolhead.get_position()
@@ -262,7 +263,7 @@ class Homing:
                         pin_params, AXIS_ENDSTOP_IDS[axis_index]
                     ),
                     "provider": None,
-                    "trigger_height": None,
+                    "trigger_position": None,
                 }
             else:
                 raise config.error(
@@ -280,19 +281,19 @@ class Homing:
 
     def _provider_entry(self, axis_config, axis_index, chip, pin_params):
         endstop = chip.setup_motion_endstop(pin_params, axis_index)
-        trigger_height = None
+        trigger_position = None
         if hasattr(chip, "get_position_endstop"):
-            trigger_height = chip.get_position_endstop()
+            trigger_position = chip.get_position_endstop()
             if axis_config.get("position_endstop", None) is not None:
                 raise axis_config.error(
                     "[%s] must not set position_endstop: its virtual endstop"
-                    " '%s' supplies the trigger height"
+                    " '%s' supplies the trigger position"
                     % (axis_config.get_name(), pin_params["chip_name"])
                 )
         return {
             "endstop": endstop,
             "provider": chip,
-            "trigger_height": trigger_height,
+            "trigger_position": trigger_position,
         }
 
     def cmd_G28(self, gcmd):
@@ -391,9 +392,9 @@ class Homing:
             raise gcmd.error("G28: no rail for axis %s" % ("XYZ"[axis],))
         hi = rail.get_homing_info()
         pos_min, pos_max = rail.get_range()
-        trigger_height = entry["trigger_height"]
-        if trigger_height is None:
-            trigger_height = hi.position_endstop
+        trigger_position = entry["trigger_position"]
+        if trigger_position is None:
+            trigger_position = hi.position_endstop
         direction = 1.0 if hi.positive_dir else -1.0
         speed = speed_override if speed_override is not None else hi.speed
         max_travel = (
@@ -449,6 +450,7 @@ class Homing:
                 speed,
                 max_travel,
                 tolerance,
+                trigger_position,
                 approach,
             )
             _commit_and_seed(
@@ -459,7 +461,7 @@ class Homing:
                 hi,
                 trip_pos,
                 final_pos,
-                trigger_height,
+                trigger_position,
                 provider,
                 servo_handle,
             )

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -150,7 +150,7 @@ class PrinterProbe:
             {
                 "endstop": self._endstop,
                 "provider": self,
-                "trigger_height": None,
+                "trigger_position": None,
             },
         )
         if abs(trip_pos[Z_AXIS] - current_z) < NO_MOVEMENT_EPSILON:

--- a/test/test_homing_min_dist.py
+++ b/test/test_homing_min_dist.py
@@ -82,7 +82,7 @@ def test_commit_and_seed_seeds_post_retract_position():
         hi,
         trip_pos=[20.0, 0.0, 0.0],
         final_pos=[20.0, 0.0, 0.0],
-        trigger_height=20.0,
+        trigger_position=20.0,
         provider=None,
         servo_handle="h",
     )
@@ -101,7 +101,7 @@ def test_commit_and_seed_no_servo_does_not_seed():
         _hi(),
         trip_pos=[20.0, 0.0, 0.0],
         final_pos=[20.0, 0.0, 0.0],
-        trigger_height=20.0,
+        trigger_position=20.0,
         provider=None,
         servo_handle=None,
     )
@@ -143,13 +143,14 @@ def test_no_rehome_when_first_travel_exceeds_min():
         speed=50.0,
         first_max_travel=200.0,
         tolerance=0.5,
+        trigger_position=20.0,
         approach=approach,
     )
     assert len(calls) == 1
     assert trip[axis] == 100.0
 
 
-def test_rehome_then_legit_returns_second_trip():
+def test_rehome_backoff_stays_within_axis_bounds():
     axis = 0
     toolhead = FakeToolhead([0.0, 0.0, 0.0])
     approach, calls = _approach_script(toolhead, axis, [2.0, 20.0])
@@ -162,14 +163,41 @@ def test_rehome_then_legit_returns_second_trip():
         speed=50.0,
         first_max_travel=200.0,
         tolerance=0.5,
+        trigger_position=20.0,
         approach=approach,
     )
     assert len(calls) == 2
     assert calls[1][1] == 30.0
     assert calls[0][0] == 50.0
     assert calls[1][0] == 50.0
-    assert ("move", [-13.0, 0.0, 0.0], 25.0) in toolhead.events
-    assert trip[axis] == 7.0
+    # Backoff is computed from the endstop position (20) minus min_home_dist
+    # (15), landing at +5 inside the axis range rather than a negative
+    # raw-frame coordinate.
+    assert ("move", [5.0, 0.0, 0.0], 25.0) in toolhead.events
+    assert ("set_position", [20.0, 0.0, 0.0]) in toolhead.events
+    assert trip[axis] == 25.0
+
+
+def test_rehome_backoff_within_bounds_for_min_endstop():
+    axis = 0
+    toolhead = FakeToolhead([0.0, 0.0, 0.0])
+    approach, calls = _approach_script(toolhead, axis, [-2.0, -20.0])
+    hi = _hi(min_home_dist=15.0)
+    hi = hi._replace(positive_dir=False, position_endstop=0.0)
+    homing_mod._run_homing_attempts(
+        FakeGcmd(),
+        toolhead,
+        axis,
+        -1.0,
+        hi,
+        speed=50.0,
+        first_max_travel=200.0,
+        tolerance=0.5,
+        trigger_position=0.0,
+        approach=approach,
+    )
+    # Min endstop at 0, direction -1: backoff = 0 - (-1)*15 = +15, in range.
+    assert ("move", [15.0, 0.0, 0.0], 25.0) in toolhead.events
 
 
 def test_rehome_then_still_early_raises():
@@ -186,6 +214,7 @@ def test_rehome_then_still_early_raises():
             speed=50.0,
             first_max_travel=200.0,
             tolerance=0.5,
+            trigger_position=20.0,
             approach=approach,
         )
     assert len(calls) == 2
@@ -204,6 +233,7 @@ def test_min_home_dist_zero_never_rehomes():
         speed=50.0,
         first_max_travel=200.0,
         tolerance=0.5,
+        trigger_position=20.0,
         approach=approach,
     )
     assert len(calls) == 1

--- a/test/test_homing_trip_verify.py
+++ b/test/test_homing_trip_verify.py
@@ -77,7 +77,7 @@ class FakeProviderDeclines:
         return None
 
 
-def test_homed_position_default_is_trigger_height_plus_overshoot():
+def test_homed_position_default_is_trigger_position_plus_overshoot():
     pos = _homed_axis_position(
         FakeProviderNoHook(), 2, [0, 0, 1.0], [0, 0, 0.9], 0.5
     )

--- a/test/test_servo_homing.py
+++ b/test/test_servo_homing.py
@@ -430,7 +430,7 @@ def run_home_axis(overshoot, retract_dist, positive_dir):
     homer.printer = FakeHomingPrinter(FakeHomingStepperEnable())
 
     direction = 1.0 if positive_dir else -1.0
-    trigger_height = hi.position_endstop
+    trigger_position = hi.position_endstop
     trip_pos = [0.0, 0.0, 100.0]
     final_pos = [0.0, 0.0, 100.0 + direction * overshoot]
 
@@ -456,44 +456,44 @@ def run_home_axis(overshoot, retract_dist, positive_dir):
             engine=None,
             kin=kin,
             axis=2,
-            entry={"trigger_height": trigger_height, "provider": None},
+            entry={"trigger_position": trigger_position, "provider": None},
         )
     finally:
         homing_mod._run_servo_guarded_trip = orig_guarded
         homing_mod._check_servo_drive_fault = orig_fault
         homing_mod.get_danger_options = orig_danger
 
-    return toolhead, trigger_height
+    return toolhead, trigger_position
 
 
 def test_retract_compensates_for_overshoot():
     overshoot = 0.7
     retract_dist = 5.0
-    toolhead, trigger_height = run_home_axis(
+    toolhead, trigger_position = run_home_axis(
         overshoot, retract_dist, positive_dir=False
     )
     target, speed = toolhead.moves[-1]
-    assert target[2] == pytest.approx(trigger_height + retract_dist)
+    assert target[2] == pytest.approx(trigger_position + retract_dist)
     assert speed == 10.0
 
 
 def test_retract_lands_at_trigger_minus_dist_positive_dir():
     overshoot = 0.7
     retract_dist = 5.0
-    toolhead, trigger_height = run_home_axis(
+    toolhead, trigger_position = run_home_axis(
         overshoot, retract_dist, positive_dir=True
     )
     target, _ = toolhead.moves[-1]
-    assert target[2] == pytest.approx(trigger_height - retract_dist)
+    assert target[2] == pytest.approx(trigger_position - retract_dist)
 
 
 def test_retract_with_zero_overshoot_unchanged():
     retract_dist = 5.0
-    toolhead, trigger_height = run_home_axis(
+    toolhead, trigger_position = run_home_axis(
         0.0, retract_dist, positive_dir=False
     )
     target, _ = toolhead.moves[-1]
-    assert target[2] == pytest.approx(trigger_height + retract_dist)
+    assert target[2] == pytest.approx(trigger_position + retract_dist)
 
 
 def test_guarded_trip_failure_disables_servo_motor_and_reraises():


### PR DESCRIPTION
## Problem

When an endstop trips before `min_home_dist`, homing retracts by `min_home_dist` and re-approaches. The rehome path computed the backoff target in the engine's **raw** coordinate frame (homing starts near 0) but then seeded the **real** axis limits via `set_position(homing_axes=[axis])`. So an early trigger near the origin produced a negative backoff target — e.g. `min_home_dist=40`, trip at 5mm → backoff to `-35` — which `check_move` rejected as outside `(0, max)`.

Mainline avoids this by reseeding the coordinate so the trigger maps to `position_endstop` and computing the retract relative to that endstop, always landing back inside the valid range. Our rehome path skipped that reseed.

## Fix

In `_run_homing_attempts`, reseed into the homed frame before backing off (same conversion `_commit_and_seed` already uses for the final commit) and compute the backoff from the endstop position:

- halt seed: `trigger_position + (final_pos - trip_pos)` (homed position + overshoot) instead of raw `final_pos`
- backoff target: `trigger_position - direction * min_home_dist`, guaranteed inside `(0, max)` whenever `min_home_dist <= axis range`

If `min_home_dist` exceeds the axis range (a real misconfiguration) it still fails loudly, which is correct.

## Rename

Renamed the internal `trigger_height` variable/field/dict-key to `trigger_position` throughout the homing code — it's the axis coordinate where the endstop trips, equally X/Y/Z, not Z-specific. The user-facing `trigger_height` config option in `sim_remote_endstop.py` is left untouched (renaming would break configs).

Note: the `axis_homed` structured-log event now emits a `trigger_position` field instead of `trigger_height` — saved LogsQL queries/dashboards on that field name need updating.

## Tests

- Replaced the test that asserted the buggy negative backoff with tests asserting the backoff stays in-range for both max- and min-endstop directions.
- Updated `test_servo_homing.py` / `test_homing_trip_verify.py` for the rename.
- All homing/rail unit tests pass; ruff check + format clean.

Flashed to the Trident bench (both MCUs) on top of sota-motion; host comes up clean.