### PR TITLE
Support overlay moves in phase stepping mode

### DIFF
--- a/rust/runtime/src/dispatch_stepper.rs
+++ b/rust/runtime/src/dispatch_stepper.rs
@@ -3,8 +3,8 @@
 use core::sync::atomic::Ordering;
 
 use crate::fault_helpers::{
-    raise_multi_motor_mask, raise_overlay_unsupported, raise_position_count_overflow,
-    raise_step_queue_overflow, raise_steps_per_sample_exceeded, raise_unknown_step_mode,
+    raise_multi_motor_mask, raise_position_count_overflow, raise_step_queue_overflow,
+    raise_steps_per_sample_exceeded, raise_unknown_step_mode,
 };
 use crate::phase_lut::{PHASE_LUT, PHASE_LUT_SIZE};
 use crate::state::SharedState;
@@ -145,12 +145,19 @@ pub fn dispatch_axis(
             overlay_just_armed,
         ),
         m if m == StepMode::Phase as u8 => {
-            if motor_mask != 0 {
-                raise_overlay_unsupported(shared, axis_idx, motor_mask);
-                return;
-            }
             bump_relaxed(&shared.isr_phase_call_count);
-            dispatch_phase(axis_idx, axis, shared, p_end);
+            if motor_mask != 0 {
+                dispatch_phase_overlay(
+                    axis_idx,
+                    axis,
+                    shared,
+                    p_end,
+                    motor_mask,
+                    overlay_just_armed,
+                );
+            } else {
+                dispatch_phase(axis_idx, axis, shared, p_end);
+            }
         }
         _ => {
             raise_unknown_step_mode(shared, axis_idx, mode);
@@ -385,6 +392,50 @@ fn ramp_phase_offset(stepper: &crate::stepping_state::StepperRef, max_per_sample
         .store(current.wrapping_add(step), Ordering::Release);
 }
 
+fn dispatch_phase_overlay(
+    axis_idx: usize,
+    axis: &mut AxisConfig,
+    shared: &SharedState,
+    p_end: f32,
+    motor_mask: u8,
+    overlay_just_armed: bool,
+) {
+    let microstep_distance = axis.microstep_distance;
+    if !microstep_distance.is_finite() || microstep_distance == 0.0 {
+        return;
+    }
+    let sel = match crate::piece_ring::stepper_sel_from_mask(motor_mask) {
+        Ok(sel) => sel,
+        Err(()) => {
+            raise_multi_motor_mask(shared, axis_idx, motor_mask);
+            return;
+        }
+    };
+    let idx = (sel - 1) as usize;
+    let Some(stepper) = axis.steppers.get(idx) else {
+        raise_multi_motor_mask(shared, axis_idx, motor_mask);
+        return;
+    };
+    #[allow(clippy::cast_possible_truncation)]
+    let target = libm::roundf(p_end / microstep_distance) as i32;
+    let prev = if overlay_just_armed {
+        0
+    } else {
+        stepper.overlay_step_frame.load(Ordering::Acquire)
+    };
+    stepper.overlay_step_frame.store(target, Ordering::Release);
+    let delta = target.wrapping_sub(prev);
+    let cur = stepper.phase_offset_microsteps.load(Ordering::Acquire);
+    let new_off = cur.wrapping_add(delta);
+    stepper
+        .phase_offset_microsteps
+        .store(new_off, Ordering::Release);
+    stepper
+        .phase_offset_target
+        .store(new_off, Ordering::Release);
+    write_phase_coils(axis_idx, axis, shared);
+}
+
 fn dispatch_phase(axis_idx: usize, axis: &mut AxisConfig, shared: &SharedState, p_end: f32) {
     let microstep_distance = axis.microstep_distance;
     if !microstep_distance.is_finite() || microstep_distance == 0.0 {
@@ -400,11 +451,19 @@ fn dispatch_phase(axis_idx: usize, axis: &mut AxisConfig, shared: &SharedState, 
             .max_phase_offset_ramp_per_sample
             .load(Ordering::Acquire),
     );
-
     for stepper in &axis.steppers {
         ramp_phase_offset(stepper, max_ramp);
+    }
+
+    write_phase_coils(axis_idx, axis, shared);
+}
+
+fn write_phase_coils(axis_idx: usize, axis: &AxisConfig, shared: &SharedState) {
+    let base = axis.last_step_count;
+
+    for stepper in &axis.steppers {
         let phase_offset = stepper.phase_offset_microsteps.load(Ordering::Acquire);
-        let target_stepper = target_microsteps_axis.wrapping_add(phase_offset);
+        let target_stepper = base.wrapping_add(phase_offset);
         let prev_stepper = stepper.last_phase_target.load(Ordering::Acquire);
         let delta_stepper = target_stepper.wrapping_sub(prev_stepper);
         stepper

--- a/rust/runtime/src/dispatch_stepper/tests.rs
+++ b/rust/runtime/src/dispatch_stepper/tests.rs
@@ -465,56 +465,132 @@ fn overlay_arm_emits_zero_steps_and_seeds_frame_to_zero() {
 }
 
 #[test]
-fn overlay_on_phase_axis_raises_overlay_unsupported_no_slew() {
-    use crate::error::FaultCode;
-
+fn overlay_on_phase_axis_applies_phase_offset() {
     let shared = SharedState::new();
     let mut q = StepQueue::new();
-    let mut axis = make_axis(StepMode::Phase, 0.0125);
-    let last_coil_a_before = axis.steppers[0].last_coil_A.load(Ordering::Acquire);
-    let last_coil_b_before = axis.steppers[0].last_coil_B.load(Ordering::Acquire);
-    let pos_before = axis.steppers[0].position_count.load(Ordering::Acquire);
+    let msd = 0.0125_f32;
+    let mut axis = make_axis(StepMode::Phase, msd);
 
     let q_ptr: *mut StepQueue = &mut q;
     let axis_idx: usize = 1;
     let motor_mask: u8 = 0b01;
+    let overlay_msteps: i32 = 5;
+    let p_end = overlay_msteps as f32 * msd;
+
     dispatch_axis(
         axis_idx,
         &mut axis,
         motor_mask,
         q_ptr,
         &shared,
-        /* p_end */ 256.0 * 0.0125,
+        p_end,
         /* v_end */ 0.0,
         /* p_sample_start */ 0.0,
         /* sample_period_sec */ 25e-6,
         /* sample_start_cycles */ 0,
         /* cycles_per_second */ 520_000_000.0,
-        /* overlay_just_armed */ false,
+        /* overlay_just_armed */ true,
     );
 
     assert_eq!(
         shared.last_error.load(Ordering::Acquire),
-        FaultCode::OverlayUnsupported.as_i32(),
-        "overlay on phase axis must latch OverlayUnsupported"
-    );
-    let detail = shared.fault_detail.load(Ordering::Acquire);
-    let expected_detail = ((axis_idx as u32 & 0xFF) << 16) | u32::from(motor_mask);
-    assert_eq!(detail, expected_detail);
-    assert_eq!(
-        axis.steppers[0].last_coil_A.load(Ordering::Acquire),
-        last_coil_a_before,
-        "no phase slew: coil_A must not change"
+        0,
+        "overlay on phase axis must not fault"
     );
     assert_eq!(
-        axis.steppers[0].last_coil_B.load(Ordering::Acquire),
-        last_coil_b_before,
-        "no phase slew: coil_B must not change"
+        axis.steppers[0]
+            .phase_offset_microsteps
+            .load(Ordering::Acquire),
+        overlay_msteps,
+    );
+    assert_eq!(
+        axis.steppers[0].phase_offset_target.load(Ordering::Acquire),
+        overlay_msteps,
+    );
+    assert_eq!(
+        axis.steppers[0].overlay_step_frame.load(Ordering::Acquire),
+        overlay_msteps,
     );
     assert_eq!(
         axis.steppers[0].position_count.load(Ordering::Acquire),
-        pos_before,
-        "no phase slew: position_count must not change"
+        overlay_msteps,
     );
-    assert_eq!(q.tail, q.head, "no steps must be enqueued");
+    assert_eq!(q.tail, q.head, "no steps must be enqueued in phase mode");
+}
+
+#[test]
+fn overlay_on_phase_axis_accumulates_across_samples() {
+    let shared = SharedState::new();
+    let mut q = StepQueue::new();
+    let msd = 0.0125_f32;
+    let mut axis = make_axis(StepMode::Phase, msd);
+
+    let q_ptr: *mut StepQueue = &mut q;
+    let axis_idx: usize = 0;
+    let motor_mask: u8 = 0b01;
+
+    dispatch_axis(
+        axis_idx,
+        &mut axis,
+        motor_mask,
+        q_ptr,
+        &shared,
+        3.0 * msd,
+        0.0,
+        0.0,
+        25e-6,
+        0,
+        520_000_000.0,
+        /* overlay_just_armed */ true,
+    );
+    assert_eq!(
+        axis.steppers[0]
+            .phase_offset_microsteps
+            .load(Ordering::Acquire),
+        3,
+    );
+
+    dispatch_axis(
+        axis_idx,
+        &mut axis,
+        motor_mask,
+        q_ptr,
+        &shared,
+        7.0 * msd,
+        0.0,
+        0.0,
+        25e-6,
+        0,
+        520_000_000.0,
+        /* overlay_just_armed */ false,
+    );
+    assert_eq!(
+        axis.steppers[0]
+            .phase_offset_microsteps
+            .load(Ordering::Acquire),
+        7,
+        "second sample moves offset from 3 to 7 (delta 4 added to 3)"
+    );
+
+    dispatch_axis(
+        axis_idx,
+        &mut axis,
+        motor_mask,
+        q_ptr,
+        &shared,
+        2.0 * msd,
+        0.0,
+        0.0,
+        25e-6,
+        0,
+        520_000_000.0,
+        /* overlay_just_armed */ true,
+    );
+    assert_eq!(
+        axis.steppers[0]
+            .phase_offset_microsteps
+            .load(Ordering::Acquire),
+        9,
+        "new overlay armed: delta from 0 baseline, adds 2 to existing 7"
+    );
 }


### PR DESCRIPTION
## Summary
- Instead of faulting with `OverlayUnsupported` when a phase-stepping axis receives an overlay (per-motor nudge), convert the overlay into a `phase_offset_microsteps` delta on the targeted stepper
- Extract coil-writing loop into `write_phase_coils` so both normal dispatch and overlay dispatch share it without duplication
- Motors sync now works with phase stepping active — tested on the Trident bench

## How it works
`dispatch_phase_overlay` converts the overlay `p_end` to a microstep delta (tracked via `overlay_step_frame`, same as pulse mode), adds it to the targeted motor's `phase_offset_microsteps` and `phase_offset_target`, then `write_phase_coils` drives all motors at the last trajectory position plus their individual offsets.

## Test plan
- [x] `cargo nextest run -p runtime` — 274 pass
- [x] `./scripts/ci.sh quick` — 5/5 green
- [x] Flashed to Trident, ran SYNC_MOTORS with phase stepping active — no fault, sync completes