### PR TITLE
Motion-12 T3: C2 tangential-jerk continuity (carried (v,a) + crossover bridge)

### DIFF
--- a/_bmad-output/implementation-artifacts/investigations/clothoid-straight-seam-discontinuity-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/clothoid-straight-seam-discontinuity-investigation.md
@@ -1,0 +1,171 @@
+# Investigation: Discontinuity between a clothoid and the straight right after it (demo 4 viz)
+
+## Hand-off Brief
+
+1. **What happened.** In the pipeline viz, the seam where a clothoid blend meets the straight segment right after it shows a discontinuity. **Confirmed (measured):** curvature `κ` is continuous (0→0, the blend is correctly G2), but the curvature *rate* `dκ/ds` steps from `±σ` to `0` at the seam, so the normal/lateral jerk `j_n_geom = κ'·v³` steps with it (measured −4.39e7 → 0 mm/s³ on a default 90° corner).
+2. **Where the case stands.** Root cause Confirmed by code construction + a deterministic numeric probe (`rust/geometry/tests/zz_seam_discontinuity_probe.rs`). The cause is structural: a clothoid (Euler spiral) has curvature **linear** in arclength, so it is G2 (continuous κ) but not G3 (continuous κ'); κ' is a nonzero constant on the clothoid and 0 on the straight.
+3. **What's needed next.** Decide the disposition: (a) accept — per spec-motion-12 lateral jerk is an explicit planner Non-Goal, owned by the fitter shape and report-only; or (b) raise the fitter's transition shape to a G3 (κ'-continuous) curve. No velocity-side fix is in scope (spec-motion-12 forbids a planner-level lateral-jerk cap).
+
+## Case Info
+
+| Field            | Value                                                                      |
+| ---------------- | -------------------------------------------------------------------------- |
+| Ticket           | N/A                                                                        |
+| Date opened      | 2026-06-20                                                                 |
+| Status           | Active                                                                     |
+| System           | curvature-profile worktree; Rust geometry + motion-engine; baseline 9ebf70d7a |
+| Evidence sources | Rust source (geometry fitter/path, motion-engine viz/jerk_probe), spec-motion-12, numeric probe |
+
+## Problem Statement
+
+User (verbatim): "if you generate a viz for demo 4, or rather generate the data so you can read it better rather than looking at png, there's one issue which is discontinuity between clothoid and straight right after it."
+
+## Evidence Inventory
+
+| Source   | Status     | Notes     |
+| -------- | ---------- | --------- |
+| `rust/geometry/src/path/clothoid.rs` | Available | `kappa(s)=κ0+σs`, `dkappa_ds(s)=σ` (constant) — the linear-curvature definition. |
+| `rust/geometry/src/fitter/biclothoid.rs` | Available | Symmetric corner blend; half1 κ:0→peak, half2 κ:peak→0. |
+| `rust/geometry/src/fitter/chain.rs` | Available | Chain reconstruction; up/down clothoids bridge line↔arc; down ends at κ=0. |
+| `rust/geometry/src/fitter.rs` | Available | `emit_move` trims the adjacent line to the seam; `emit_reconstruction`/`emit_blend`. |
+| `rust/motion-engine/src/jerk_probe.rs` | Available | `j_n_geom = dkappa_ds·v³`, `j_n_couple = 2κ·v·a_t`. |
+| `_bmad-output/.../spec-motion-12-tangential-jerk-c2-continuity.md` | Available | Non-Goals: lateral jerk is the fitter's shape, planner does not cap it, viz `j_n` is report-only. |
+| Numeric probe `rust/geometry/tests/zz_seam_discontinuity_probe.rs` | Available | Reproduces the κ'/j_n step deterministically (created this investigation). |
+| `demo 4` G-code | Missing | Lives on the bench (`~/printer_data/gcodes`), not in the repo. Probe substitutes a default 90° corner; the phenomenon is geometry-structural, independent of the specific path. |
+
+## Timeline of Events
+
+| Time        | Event               | Source                | Confidence |
+| ----------- | ------------------- | --------------------- | ---------- |
+| build time  | Fitter emits line→clothoid→clothoid→line; each clothoid carries constant σ | `fitter.rs`, `biclothoid.rs` | Confirmed |
+| sample time | viz/probe samples κ, dκ/ds per segment; κ continuous, dκ/ds steps at clothoid↔line seams | `viz.rs::sample_kinematics`, probe | Confirmed |
+
+## Confirmed Findings
+
+### Finding 1: The clothoid is G2 but not G3 — κ' is a nonzero constant that steps to 0 at the straight
+
+**Evidence:** `rust/geometry/src/path/clothoid.rs:61-67` — `kappa(s)=kappa_0+sigma*s`, `dkappa_ds(_s)=sigma`. A straight (`Line`) has `kappa≡0`, `dkappa_ds≡0`.
+
+**Detail:** At a clothoid→line seam the blend is built so κ matches (both 0), but κ' = σ on the clothoid and 0 on the line. κ' therefore has a step discontinuity of magnitude σ. This is intrinsic to a linear-curvature spiral; it is the defining property of the Euler clothoid (curvature continuity, not curvature-rate continuity).
+
+### Finding 2: The seam is correctly continuous in position, heading, and curvature — only κ' (and j_n) breaks
+
+**Evidence:**
+- Curvature: chain down-clothoid `Clothoid::try_new(a1, h1, n_exit, kappa_arc, -sigma, l_t)` with `sigma = kappa_arc / l_t` (`chain.rs:184,200`) → `kappa(l_t) = kappa_arc - sigma·l_t = 0`. Biclothoid half2 `sigma = kappa_peak/length` (`biclothoid.rs:40,47`) → `kappa(length)=0`.
+- Position/heading: `chain.rs:212-216` rejects the fit unless `seam_ok` (≤1e-6 mm) **and** `dot(down.heading_at(l_t), tm) ≥ 1−1e-6`. The adjacent line is trimmed to the seam by `fitter.rs::emit_move` (`new_start/new_end` at the clothoid endpoint).
+
+**Detail:** So the observed discontinuity is **not** a position gap or a heading kink and **not** a curvature jump — those are all enforced. It is specifically the curvature-rate / lateral-jerk step.
+
+### Finding 3: j_n_geom = κ'·v³ carries the step; j_n_couple = 2κ·v·a_t does not
+
+**Evidence:** `rust/motion-engine/src/jerk_probe.rs` — `j_n_geom = dkappa_ds·v³`, `j_n_couple = 2·kappa·v·a_t`. At the seam κ→0 so the couple term →0 continuously on both sides; the geom term steps from `σ·v³` to `0`.
+
+**Measured (probe, default 90° corner, scv=5, accel=5000, jerk=1e5):**
+```
+seg[1] clothoid  kappa(0)=0          kappa(L)=+2.6868e2   dk(0)=+4.5955e4  dk(L)=+4.5955e4
+seg[2] clothoid  kappa(0)=+2.6868e2  kappa(L)=0           dk(0)=-4.5955e4  dk(L)=-4.5955e4
+--- seam clothoid -> line at s=20.00473 ---
+  clothoid  kappa=0   dkappa_ds=-4.59554e4   j_n_geom=-4.38503e7
+      line  kappa=0   dkappa_ds= 0.0         j_n_geom= 0.0
+max |dkappa_ds step| across any seg boundary = 4.595535e4
+```
+The line→clothoid (entry) seam shows the mirror step (0 → +1.83e7). Both ends of the blend carry it; the user's "straight right after" is the exit seam.
+
+## Deduced Conclusions
+
+### Deduction 1: The discontinuity is structural to the transition primitive, not a fitter or planner bug
+
+**Based on:** Findings 1–3.
+
+**Reasoning:** Every seam invariant the code actually enforces (G0 position, G1 heading, G2 curvature) holds to tolerance. The only broken quantity, κ' (hence `j_n`), is exactly the one a linear-curvature clothoid cannot make continuous. No amount of tuning the existing fitter removes it — a clothoid's κ' is constant by definition.
+
+**Conclusion:** To make `j_n` continuous across the clothoid↔straight seam you must change the *shape* (a κ'-continuous / G3 transition), or accept the step as the clothoid's designed behavior.
+
+### Deduction 2: This is consistent with — and currently sanctioned by — spec-motion-12
+
+**Based on:** spec-motion-12 Non-Goals (lines 52): "Lateral jerk `j_n = κ'·v³ + 2κ·v·a_t` is owned by the fitter's shape (clothoid geometry); the planner does **not** cap velocity for it... The viz probe MAY emit `j_n` as a free diagnostic... it is report-only — never a gate."
+
+**Conclusion:** Under the frozen architecture the lateral-jerk step is an accepted property; the active C2 work (spec-12) targets **tangential** jerk only. A planner-side lateral-jerk cap is explicitly forbidden. So eliminating the seam step is a *fitter shape* question, not a velocity-planner one.
+
+## Source Code Trace
+
+| Element       | Detail                                      |
+| ------------- | ------------------------------------------- |
+| Discontinuity origin | `rust/geometry/src/path/clothoid.rs:65` `dkappa_ds` ≡ `sigma` (clothoid) vs `Line` `dkappa_ds` ≡ 0 |
+| Trigger       | Any clothoid blend abutting a straight (corner blend exit/entry; chain up/down spirals at line ends) |
+| Condition     | κ matches at the seam (0) but κ' steps (σ→0), so `j_n_geom = κ'·v³` steps |
+| Related files | `fitter/biclothoid.rs`, `fitter/chain.rs`, `fitter.rs::emit_move`, `motion-engine/src/jerk_probe.rs`, `motion-engine/src/viz.rs::sample_kinematics` |
+
+## Conclusion
+
+**Confidence:** High
+
+The "discontinuity between the clothoid and the straight right after it" is a **curvature-rate (G3) discontinuity**, not a position, heading, or curvature break. The blend is correctly G2 — κ returns to 0 at the seam — but a clothoid's curvature is linear in arclength, so its κ' is a nonzero constant (`σ`) that steps to the straight's 0. The lateral/normal jerk `j_n_geom = κ'·v³` inherits the step (measured −4.39e7 → 0 mm/s³ at a default 90° corner; mirror step at the entry seam). This is intrinsic to using a single Euler clothoid as the transition primitive, and is consistent with spec-motion-12, which treats lateral jerk as the fitter shape's responsibility and report-only on the planner side.
+
+## Recommended Next Steps
+
+### Fix direction (by mechanism — disposition is a design decision)
+
+1. **Accept / document (matches current architecture).** spec-motion-12 already classifies lateral jerk as a fitter-owned, report-only quantity and the clothoid *bounds* its magnitude. If the step magnitude is acceptable for the hardware, no code change — only a note that clothoid blends are G2, not G3, and `j_n` will step at every clothoid↔{line,arc} seam.
+2. **Raise the transition shape to G3 (κ'-continuous).** Replace the linear-σ clothoid with a curvature profile whose κ' tapers to 0 at both endpoints (e.g. a smoothstep/quintic curvature ramp, or a higher-order spiral). This makes `j_n_geom` continuous at the seam. Cost: longer/blunter transitions, more complex (Fresnel-like) evaluation, and a re-derivation of the seam-closure math in `biclothoid.rs`/`chain.rs`. This is the geometric-SOTA route and a substantial fitter change — scope it as its own spec.
+3. **(Out of scope) Planner-side velocity cap for j_n** — explicitly forbidden by spec-motion-12 Non-Goals; do not pursue without renegotiating the frozen intent.
+
+### Diagnostic
+- The probe `rust/geometry/tests/zz_seam_discontinuity_probe.rs` reproduces the step deterministically and prints the per-seam table; point it at demo-4-like geometry (gentler corners → longer clothoids → lower σ but the step persists) to confirm magnitude on representative input.
+
+## Reproduction Plan
+
+`cargo nextest run -p geometry -E 'test(probe_clothoid_straight_seam_dkappa_step)' --no-capture` from `rust/`. Builds a 90° corner, runs `fit_chain` + `plan_velocity`, prints κ / dκ/ds / j_n_geom across every clothoid↔line seam, and reports `max |dkappa_ds step|`.
+
+## Side Findings
+
+- **Velocity sample mismatch at the seam.** In the probe the clothoid's last sample carried `v≈9.845` while the adjacent line's first sample carried `v≈7.358` at the same `s`. **This is the real reported defect (see Follow-up), not the κ' step above.**
+- The same κ' step occurs at **clothoid↔arc** seams inside chain runs (up-spiral→arc, arc→down-spiral); there κ is also continuous but κ' steps σ→0.
+
+## Follow-up: 2026-06-20 — premise corrected by user; real defect is a tangential-accel spike from the uncommitted jerk-bridge
+
+### New Evidence
+
+The user clarified (with viz): the issue is **tangential acceleration** `a = v·dv/ds` spiking right after every clothoid (~310 → **4.8e6 mm/s²** with the uncommitted changes), while velocity only shows a tiny bump over a sub-micron distance. The uncommitted `velocity/{disk,scurve}.rs` + `velocity.rs` changes are a prior agent's 2-hour attempt at **spec-motion-12 T3** (coupled `(v,a)` C2 sweep + crossover jerk-bridge); they made the spike *worse*. This **supersedes** the original lateral-jerk (κ') framing — that κ' step is real but is **not** what the user is seeing.
+
+### Additional Findings (Confirmed — measured, baseline vs current)
+
+Probe `rust/geometry/tests/zz_seam_discontinuity_probe.rs`, three corner geometries, `a_t = v·dv/ds` reconstructed exactly as `viz_pipeline.py` does (np.gradient):
+
+| geometry | committed baseline | current (uncommitted fix) |
+| --- | --- | --- |
+| tight 90° / slow | `max|a_t|`=5001≈accel, v_overshoot **0.000** | `max|a_t|`=**1.15e6**, overshoot 2.48 |
+| gentle 18° / fast | 5001≈accel, overshoot **0.000** | **2.21e5**, overshoot 2.46 |
+| mid 45° | 5002≈accel, overshoot **0.000** | **7.68e5**, overshoot 2.48 |
+
+- **F4 (Confirmed):** the committed baseline has **no seam spike** — tangential accel rides exactly at `max_accel`, zero velocity overshoot, at every clothoid↔line seam. The spike is **entirely introduced by the uncommitted jerk-bridge**.
+- **F5 (Confirmed):** on the current tree a single sample is wedged at the clothoid tail with `v=9.845` between neighbours of ~7.36, at Δs≈9.16e-7 mm (`rust/geometry/src/velocity/disk.rs` bridge sampling). The ~2.48 mm/s overshoot is remarkably constant across geometries → systematic, not noise.
+- **F6 (Confirmed):** acceleration is reconstructed by **centered finite difference** `a = v·Δv/Δs` in `disk.rs::centered_fd_accels`/`sv_to_sva_fd` (the planner's stored `sample.a`), and again by `np.gradient` in viz. Over a sub-micron seam Δs, a ~2.48 mm/s velocity error becomes 1e5–1e6 mm/s². Both layers amplify the same overshoot.
+
+### Root cause (two compounding faults in the uncommitted T3 work)
+
+1. **Velocity-envelope violation by the bridge.** `disk.rs::find_bridge` fires on the ultra-short corner-blend clothoid (~0.006 mm) and `sample_bridge_uniform_t`/`refine_bridge_time` emit samples whose velocity follows the time-domain jerk polynomial `v_l + a_l·t − ½·j·t²` with `a_l,a_r` clamped to ±accel. Over a sub-micron arclength this **overshoots** `min(fwd,bwd)` (the profile must satisfy `v ≤ envelope` everywhere; the bridge breaks that), planting `v=9.845` where neighbours are ~7.36.
+2. **Acceleration by finite-difference over degenerate Δs — the exact failure spec-motion-12 forbade.** The implementation derives `a_t` via `centered_fd_accels` (`v·Δv/Δs`) instead of the analytic seven-segment `accel_at` the spec mandates (T1 / **AC-G6**: "evaluate `accel_at` at every adjacent `SevenSeg` endpoint pair directly — no resampling — a step at a narrow bridge cannot fall between samples"; **R4** aliasing). Finite-differencing the overshoot over Δs≈1e-6 mm is what turns a 2.5 mm/s bump into a 1e6 spike.
+
+### Updated Conclusion
+
+**Confidence:** High. The acceleration spike "right after every clothoid" is **not** present in the committed code and is **not** an inherent geometry property — it is an artifact of the in-progress spec-motion-12 T3 jerk-bridge: the bridge plants a velocity overshoot on the sub-millimetre corner clothoid, and acceleration is then recovered by finite-difference over a sub-micron seam Δs (in both the planner's `sample.a` and the viz). Successive iterations of that work amplified it (≈310 → 4.8e6), matching the user's "made the spike even higher." The original lateral-jerk (κ') finding stands as a *separate, smaller, by-design* property (spec-12 Non-Goal), not the reported defect.
+
+### Fix direction
+
+- **Immediate:** the spike is in unmerged WIP; it is not a regression in `main`/committed code. If the T3 work is paused, the baseline is clean.
+- **For the T3 implementation:** (a) the bridge must never emit `v > min(fwd_envelope, bwd_envelope)` at any sample — clamp/validate against the envelope (the existing `v_r_capped` clamp is applied only at `s_r`, not to the interior bridge samples); (b) replace the finite-difference `centered_fd_accels`/`sv_to_sva_fd` with the analytic `accel_at` evaluated at segment endpoints (spec AC-G6), so `a_t` cannot alias on a narrow bridge; (c) gate the bridge so it does not fire on sub-`ds_min` corner-blend clothoids where there is no genuine fwd/bwd tangential crossover. This is also exactly what the new `c2_feasibility_gate.rs` / `zz_independent_probe.rs` should catch — they currently assert `|Δa|` bounds but the spike still ships, so the gate's resampling is aliasing past it (R4).
+
+### Backlog Changes
+
+- Demo-4 geometry not needed to diagnose — reproduced synthetically. The committed-baseline ~310 the user saw on demo 4 was **not** reproduced from `9ebf70d7a` (synthetic baseline is clean); it was most likely an earlier point in the agent's bridge iterations, consistent with iterative amplification to 4.8e6.
+
+## Follow-up: 2026-06-20 #2 — premise fully resolved; case concluded, work handed to spec-motion-12 T3
+
+### Resolution of the reported symptom
+Recovered the real fixture: `/private/tmp/demo4.gcode` + `/private/tmp/viz_demo.cfg` (corexy, `max_velocity 150`, `max_accel 200`, `max_jerk 4000`, `scv 5`). Reproduced exactly (traversal 5.583s vs the plot's 5.588s). Findings:
+- The **310 accel / 7e9 jerk spikes "right after every clothoid"** in the user's 16:12 PNG were the **previous agent's broken-T3 build** (bridge overshoot firing on the corner clothoids). On the committed build they are **gone**: accel rides clean at `max_accel`, and `a_t` is continuous ±`max_accel` at every clothoid↔straight boundary (measured, all 6 seams). The clothoid→straight boundary itself was never the defect — it was a stale plot.
+- **What is genuinely wrong in committed code (the real, tangential defect):** (1) accel-from-rest rides at exactly **`(2/9)·max_jerk`** (`v_ceil(s)=(jerk·s²)^(1/3)` ⇒ `da_t/dt=(2/9)·jerk`; measured 889 vs 4000) — under-driven, not a trapezoid; (2) the sub-cruise accel→decel **crossover steps `+max→−max`** (ungoverned jerk). Same root cause: `a_t` is derived from a velocity ceiling, not carried as state.
+
+### Status
+**Concluded.** This is not a seam/geometry bug — it is the C1 tangential-jerk model, i.e. exactly **spec-motion-12 T3**. Full T3 pickup context (committed T1/T2, the `(2/9)·jerk` proof, prior-attempt post-mortem, demo4 fixture, design, first steps) is written to the **Dev Log** at the foot of `spec-motion-12-tangential-jerk-c2-continuity.md`. Start the fresh session there.

--- a/_bmad-output/implementation-artifacts/investigations/jerk-usage-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/jerk-usage-investigation.md
@@ -1,0 +1,98 @@
+# Investigation: How jerk is used in the live motion planner
+
+## Hand-off Brief
+
+1. **What happened.** The user reports jerk (a) isn't read from `max_jerk` and (b) is applied only on straight-line acceleration from standstill, not at cruise or during deceleration. **Confirmed in substance, but the root cause is architectural:** the live planner is the *geometry* velocity-envelope model (`geometry::plan_velocity_warm_start`), whose tangential-jerk limit is a phase-plane reachability bound anchored only at rest anchors — not the everywhere-enforced TOPP/SOCP jerk constraint, which exists in `temporal/` but is **test-only / not wired into production**.
+2. **Where the case stands.** Root cause Confirmed via code trace + the spec-motion-11 cutover dev-log. The two symptom clusters map to two distinct facts: a jerk-config wiring gap (only `[printer] max_jerk` is honored; `[limit]` sections are inert; the **viz hardcodes the default**), and a jerk *model* that only shapes accel-from-rest and decel-to-stop, leaving mid-run decel-into-curvature and the cruise apex governed by accel/disk reach with no jerk term.
+3. **What's needed next.** Per the frozen architecture (spec-motion-pipeline-rewrite), the SOTA target is the *decoupled* planner (lateral jerk → clothoid geometry; tangential jerk → closed-form seven-segment S-curve; node-based forward-backward sweep), NOT the sampled Consolini-Locatelli SOCP in `temporal/` — which the architecture explicitly *avoids* and spec-motion-11 Stage 3 *removes*. The real fix is to finish the decoupled model: carry tangential acceleration continuously across the run (spec-motion-7 limit-riding) so the current C1 velocity-ceiling jerk bound becomes a jerk-continuous accel profile. Plus the wiring gaps (viz + per-section jerk). Confirm which surface the user observed (viz vs. live print) to prioritize.
+
+## Case Info
+
+| Field            | Value                                                                      |
+| ---------------- | -------------------------------------------------------------------------- |
+| Ticket           | N/A                                                                        |
+| Date opened      | 2026-06-20                                                                 |
+| Status           | Active                                                                     |
+| System           | curvature-profile worktree; Rust motion-engine; HEAD 9ebf70d7a            |
+| Evidence sources | Rust source (geometry/temporal/motion-engine), klippy/motion.py, spec-motion-6 & spec-motion-11 |
+
+## Problem Statement
+
+User (verbatim): "the way jerk is used now, there are a few problems. seems it's not being read from max_jerk parameter, and it's only applied on straight line acceleration from stand still, but not when it reaches the cruize speed, and not when it starts deccelerating."
+
+## Confirmed Findings
+
+### Finding 1: The live planner is the geometry velocity-envelope model; the TOPP/SOCP jerk planner is test-only
+
+**Evidence:** `motion-engine/src/bridge.rs:3333` spawns `StreamPlannerHandle::spawn(stream_cfg, …)` → `stream_planner.rs:56` → `StreamState::new` (`crate::stream`) → `stream.rs:189` calls `plan_velocity_warm_start` imported from `geometry` (`stream.rs:6`). The TOPP path (`planner.rs::PlannerHandle` → `to_temporal_limits()` → `trajectory::beta::plan_velocity_inner` → `temporal::multi::plan_batch`) is referenced **only** in `planner/tests.rs` and `bridge/tests.rs`.
+
+**Corroboration:** spec-motion-11 dev-log (2026-06-19): "the per-axis temporal planner is test-only"; "`[limit <name>]` sections … never consulted by the stream."
+
+### Finding 2: Jerk config wiring — only `[printer] max_jerk` is honored; `[limit]`-section jerk is inert; the viz ignores jerk entirely
+
+**Evidence:**
+- Live path reads global jerk: `bridge.rs:3319` `max_jerk_mm_s3: cart.max_jerk` (from `[printer] max_jerk`, `klippy/motion.py:645`, default `2×max_accel`).
+- `[limit]`-section jerk would flow only through `PlannerConfig::path_velocity_config()` (`config.rs:571`) — which has **no callers** (grep: definition only). The stream never consumes it. `to_temporal_limits()` (`config.rs:599`) reads section jerk but feeds only the test-only TOPP planner.
+- **Visualization ignores jerk config:** `viz.rs:7` `pipeline_snapshot(... max_velocity, max_accel, square_corner_velocity ...)` takes **no `max_jerk` arg**; `viz.rs:32` calls `geometry::plan_velocity(&outcome, geometry::VelocityConfig::default())` → hardcoded `max_jerk_mm_s3 = 100_000.0` (`velocity.rs:28`).
+
+**Detail:** If the user set jerk in a `[limit]` section it is silently ignored. If the user is reading jerk behavior off the matplotlib/native-geometry viz, it never reflects any configured jerk — fully explaining "not being read from max_jerk."
+
+### Finding 3: The tangential-jerk model is a rest-anchored velocity envelope, not an everywhere jerk constraint
+
+**Evidence:** `geometry/src/velocity.rs:237-264` runs a forward jerk reach (`scurve::max_reachable_velocity(run_start_v[j], arc_from_run_start[j]+len, accel, jerk)`) and a backward jerk reach (`… (0.0, arc_to_run_end[j]+len, …)`). Per-sample reconstruction `disk.rs:142-167 profile_speed` takes `min(forward_disk, backward_disk, jerk_forward, jerk_backward, ceiling)`. `JerkAnchors` (`velocity.rs:292-297`) sets `bwd_v: 0.0` — the backward jerk ramp is anchored at the run's terminal rest (v=0). Commit 311ac5144 moved the anchor from per-move seams to run rest-anchors.
+
+**Detail / mapping to symptoms:**
+- **Accel from rest:** `jerk_forward` binds from the v=0 start anchor → jerk-limited ramp is visible (matches "applied on straight-line accel from standstill").
+- **Cruise:** constant velocity ⇒ tangential accel ≈ 0 ⇒ no jerk to round; only the cruise *peak* is trimmed (`scurve::jerk_limited_apex`, spec-motion-6). "No jerk at cruise" is expected, not a defect.
+- **Deceleration:** `jerk_backward` is anchored at run-end v=0, so decel **into a genuine stop** is jerk-shaped. But deceleration **into a mid-run curvature-limited feature** is bounded by the accel/disk reach + curvature ceiling (`disk.rs:159`), which carry **no jerk term** → tangential accel can step at those corners (effectively unbounded jerk there). This is the most likely basis for "not when it starts decelerating."
+
+**Corroboration:** spec-motion-6 line 40: "No fully-coupled jerk TOPP / SOCP / SLP; no per-axis or lateral jerk constraint." The envelope model is by-design partial.
+
+## Deduced Conclusions
+
+### Deduction 1: Two independent issues are being reported as one
+
+**Based on:** Findings 2 and 3.
+
+**Reasoning:** "Not read from max_jerk" is a *config-wiring* issue (inert `[limit]` jerk + viz hardcodes the default). "Only on accel-from-rest" is a *model-scope* issue (rest-anchored envelope, no jerk term on mid-run decel/curvature transitions). They have different fixes.
+
+**Conclusion:** Treat them separately; do not assume one patch addresses both.
+
+## Hypothesized Paths
+
+### Hypothesis 1: The user observed jerk via the visualization, not a live print
+
+**Status:** Open
+
+**Theory:** Recent commits (b8fc39fee native-geometry viz, 311ac5144 jerk-anchor) show active viz work. `pipeline_snapshot` hardcodes default jerk and takes no `max_jerk`, so the viz never reflects config.
+
+**Would confirm:** User states they judged jerk from the viz / `pipeline_snapshot` output.
+**Would refute:** User changed `[printer] max_jerk` and saw no change on a real print (that would point at the live path / a deeper wiring bug to chase).
+
+## Source Code Trace
+
+| Element       | Detail                                                                                   |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| Live planner  | `bridge.rs:3333` → `stream_planner.rs:56` → `stream.rs:189` `plan_velocity_warm_start` (geometry) |
+| Jerk value (live) | `bridge.rs:3319` `cart.max_jerk` ← `[printer] max_jerk` (`klippy/motion.py:645`)       |
+| Jerk value (viz)  | `viz.rs:32` `VelocityConfig::default()` → `velocity.rs:28` hardcoded `100_000.0`        |
+| Jerk model    | `velocity.rs:237-264` sweeps; `disk.rs:142-167 profile_speed`; anchors `velocity.rs:292` |
+| Dead/test-only| `config.rs:571 path_velocity_config` (no callers); `planner.rs PlannerHandle` (tests only); `temporal/` TOPP |
+
+## Conclusion
+
+**Confidence:** High
+
+The premise is substantially correct, but the cause is architectural. The production trajectory is built by the geometry velocity-envelope planner, which (a) honors only the global `[printer] max_jerk` — `[limit]`-section jerk is inert and the viz ignores jerk altogether — and (b) enforces tangential jerk only as a rest-anchored reachability envelope, so it shapes accel-from-rest and decel-to-stop but leaves the cruise interior and mid-run decel-into-curvature governed by accel/disk limits with no jerk term. The fully-coupled jerk planner (TOPP/SOCP in `temporal/`) that would bound jerk everywhere is implemented but dormant (test-only), pending spec-motion-11's production cutover.
+
+## Recommended Next Steps
+
+### Fix direction
+- **Wiring (cheap):** give `pipeline_snapshot` a `max_jerk` arg and stop hardcoding `VelocityConfig::default()` in `viz.rs:32`; decide whether `[limit]`-section jerk should be honored or explicitly rejected (fail-loudly) instead of silently inert.
+- **Model (the real question):** the frozen architecture (architecture.md:53-55, SPEC.md:23) *decouples* jerk — lateral into clothoid geometry, tangential into a closed-form seven-segment S-curve — and *avoids* the sampled Consolini-Locatelli SOCP (architecture.md:124; "the coupled-jerk SOCP we are avoiding"). So the fix is NOT to wire in `temporal`/TOPP (spec-motion-11 Stage 3 *removes* it). It is to finish the decoupled model: make tangential acceleration continuous across each run (ride |a|=a_max, relax to a=0 only at true rest anchors — spec-motion-7), upgrading the current C1 velocity-ceiling jerk bound (`scurve::max_reachable_velocity`) into a jerk-continuous acceleration profile. This is what kills the mid-run decel/curvature jerk steps without re-introducing a convex solver.
+
+### Diagnostic
+- Confirm the observation surface (viz vs. live print) — settles Hypothesis 1 and prioritizes the wiring vs. model fix.
+
+## Side Findings
+- `path_velocity_config()` / `path_velocity_limits()` are retained on `PlannerConfig` for the test-only temporal planner; they are dead w.r.t. production (spec-motion-11 line 86). Candidate for removal at cutover.

--- a/_bmad-output/implementation-artifacts/spec-motion-12-tangential-jerk-c2-continuity.md
+++ b/_bmad-output/implementation-artifacts/spec-motion-12-tangential-jerk-c2-continuity.md
@@ -1,0 +1,199 @@
+---
+title: 'Motion-12: true C2 tangential-jerk continuity in the live geometry velocity planner'
+type: 'feature'
+created: '2026-06-20'
+status: 'in-progress'
+baseline_commit: '9ebf70d7afb9cc54f82195b539fba7535f94125f'
+context:
+  - '{project-root}/CLAUDE.md'
+  - '{project-root}/_bmad-output/implementation-artifacts/spec-motion-6-tangential-jerk.md'
+  - '{project-root}/_bmad-output/implementation-artifacts/spec-motion-7-limit-riding.md'
+  - '{project-root}/_bmad-output/implementation-artifacts/spec-motion-11-pipeline-production-cutover.md'
+  - '{project-root}/_bmad-output/implementation-artifacts/spec-motion-13-delete-socp.md'
+  - '{project-root}/_bmad-output/implementation-artifacts/investigations/jerk-usage-investigation.md'
+---
+
+> **Split note (2026-06-20):** This spec originally carried a fifth stage (T5) that deleted the dead SOCP. That work is now its own spec — **Motion-13 (`spec-motion-13-delete-socp.md`)** — because the deletion is independent of the C2 build (the SOCP is already off the live path) and bundling a large deletion into the C2 crux PR makes a deletion fault indistinguishable from a C2 math bug at bisect. This spec is now T1–T4: build the C2 path + its gate.
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The live velocity planner (`geometry::plan_velocity_warm_start`, `rust/geometry/src/velocity.rs`) is **C1**: only velocity crosses move junctions, never acceleration. Tangential jerk is implemented as a *velocity ceiling* (`scurve::max_reachable_velocity`) folded into the `min(forward_disk, backward_disk, jerk_forward, jerk_backward, ceiling)` at `disk.rs::profile_speed`. A velocity ceiling bounds *whether* a speed is reachable, never *how acceleration behaves on the way*. Consequence: tangential acceleration is jerk-shaped only off a rest anchor (accel-from-rest, decel-to-stop), and **steps discontinuously at every mid-run junction** (cruise→decel, decel-into-curve) — effectively unbounded tangential jerk exactly where the machine feels it. This is the architecture's own model reporting its contract, not a leak.
+
+**Approach:** Finish the decoupled architecture (spec-motion-6/7): promote tangential acceleration `a_t` from a derived quantity to a **planned state carried across junctions inside a run**, so the profile is jerk-continuous (C2) everywhere except at true rest anchors, where `v=0, a=0` is pinned by definition (**C2-within-run / C1-at-rest-anchors**). This is real-time on a Pi 5 because XY jerk is a **single global scalar**: `a_t` rides the disk acceleration rails bang-bang (spec-motion-7 limit-riding ODE) and is interior only on short closed-form seven-segment jerk transitions; it is *not* a free 2D search. The forward/backward crossover acceleration-step is dissolved by a closed-form seven-segment **jerk-bridge** (lowest-peak-`v` profile feasible under both envelopes), not relocated. Validation uses no external solver/oracle: a viz-derived jerk instrument measures the jerk actually emitted and gates feasibility intrinsically.
+
+## Boundaries & Constraints
+
+**Always:** Keep XY jerk a single global scalar (`[printer] max_jerk`, default `2×max_accel`; spec-motion-11 dev-log 2026-06-19) — this is load-bearing for the real-time affordability argument. Keep the node-based forward-backward sweep O(N) two-pass with closed-form per-edge work; no SOCP/QP/grid/iterative inner solver. Pin `(v,a)=(0,0)` at true rest anchors (`v=0` stops, chain ends; the run-anchor machinery in `velocity.rs` from commit `311ac5144`). Fail loudly on out-of-contract state (a run arriving at a rest anchor with non-zero entry acceleration; an infeasible `(v0,a0)→(v1,a1)` reach) — raise, never pad/clamp silently. Share one jerk-computation code path between the viz plot and the CI gate. Reuse the existing emit backend unchanged (`ShapedSegment` → `enqueue_segment` → pump).
+
+**Ask First:** Any fallback to a *genuinely iterative / multivariable* inner solver in the crossover jerk-bridge (an SOCP/QP/grid solve) — escalate, do not silently relax. Note R1 is **resolved**: the bridge is closed-form and the 1-D splice-location root is within the no-inner-solver boundary, so it is *not* an Ask-First — only a multivariable solver would be. Loosening any throughput gate (AC-G3 / R3) to "within ε" to absorb a real regression. Removing the `temporal`/old-`planner.rs` path is now **Motion-13**, not this spec — this spec must not delete it; coordinate ordering with Motion-13, do not bundle into the C2 crux PR.
+
+**Never:** Re-introduce the sampled Consolini-Locatelli coupled-jerk SOCP, in production or as a kept oracle (architecture.md: "the coupled-jerk SOCP we are avoiding"; user: deleted, untrusted). Add a planner-level **lateral**-jerk constraint or cap — the fitter's shape owns lateral jerk (see Non-Goals). Add per-axis / per-`[limit]`-section jerk (XY jerk is global scalar). Add input shaping (deferred, spec-motion-11). Ship a measurably slower *feasible* trajectory than the best we can compute (throughput-SOTA is non-negotiable). Note: this is **not** measured as "C2 ≤ C1" — C1 is jerk-infeasible, so C2 is provably slower at corners and that is correct, not a regression; throughput-SOTA is enforced by R3's three gates (AC-G3), not by a C1 race.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Accel from rest | run starts at `v=0` | jerk-limited seven-segment ramp; `a_t` rises from 0 continuously | finite checks |
+| Mid-run cruise→decel into a curve | two moves meet at non-zero `v`, downstream curvature-limited | `a_t` is **continuous** across the junction (jerk-bridged), no step | N/A |
+| Forward/backward crossover | fwd envelope (a>0) meets bwd envelope (a<0) inside a run | crossover is a jerk-bridged interval, C2 across it; lowest peak-`v` under both envelopes | N/A |
+| Decel to stop | run ends at rest anchor | `a_t` falls to 0 continuously; `(v,a)=(0,0)` at the anchor | N/A |
+| Rest anchor with non-zero entry accel | a run arrives at a `v=0` anchor with `|a_entry|>ε_a` | **raise** (seam misclassified as rest / re-anchor bug) | `Err`, no pad |
+| Infeasible reach | `(v0,a0)→target` not reachable within `ds` at `jerk_max` | **raise** (genuine over-commit / misclassified seam). A tight *crossover* is **not** this case: it lowers `v_peak` toward the `(0,0)` floor (R2), never raises | `Err`, no saturate-and-continue |
+| Curvature alone exceeds accel budget | `v²κ > a_max` at a sample | velocity capped by the disk ceiling (existing behavior); not a new jerk path | finite checks |
+| Viz snapshot | `pipeline_snapshot(..., max_jerk, ...)` | plots include `a_t` and tangential jerk `j_t` tracks computed from the planned profile, using the caller's `max_jerk` | `Err` on bad config |
+| Empty / zero-length | empty buffer, zero-length move | no-op, no panic | N/A |
+
+</frozen-after-approval>
+
+## Non-Goals
+
+- **Planner-level lateral-jerk handling.** Lateral jerk `j_n = κ'·v³ + 2κ·v·a_t` is owned by the fitter's shape (clothoid geometry); the planner does **not** cap velocity for it and does **not** carry a `max_lateral_jerk`. (Decision: the shape keeps it in check.) The viz probe MAY emit `j_n` as a free diagnostic since it already has `κ, κ', v, a_t`, but it is report-only — never a gate, never a constraint.
+- Per-axis / per-section jerk; input shaping; native Arc/Bézier end-to-end; reviving any SOCP/NLP oracle.
+- **Deleting the dead SOCP** (`temporal` crate, `trajectory` SOCP modules, old `planner.rs`). That is **Motion-13** (`spec-motion-13-delete-socp.md`).
+
+## Code Map
+
+- `rust/geometry/src/velocity/scurve.rs` — today exposes only `pub(super) max_reachable_velocity(v_in, length, accel, jerk)` (the C1 velocity ceiling, assumes `a0=0`). Add the acceleration-carrying seven-segment primitive + analytic `a_t` evaluator here.
+- `rust/geometry/src/velocity.rs` — `plan_velocity_warm_start`; run-anchor machinery (`is_anchor`, `run_start_v`, `arc_from_run_start`, `arc_to_run_end`, lines ≈188–235 from commit `311ac5144`); forward/backward sweeps (≈237–284). Convert the scalar-`v` sweeps to coupled `(v,a)` sweeps; pin `(0,0)` at anchors.
+- `rust/geometry/src/velocity/disk.rs` — `profile_speed` (≈142–167) does the `min()` reconstruction and `JerkAnchors` (`bwd_v: 0.0`). Replace the velocity-`min` jerk terms with `(v,a)`-propagated reach + the crossover jerk-bridge. `disk_reach_v` / curvature ceiling (`limit_speed`, `disk.rs:159`) stay (position constraints, no accel state).
+- `rust/motion-engine/src/viz.rs` — `pipeline_snapshot` (signature has no `max_jerk`; calls `geometry::plan_velocity(&outcome, VelocityConfig::default())` at line 32 — the hardcoded-jerk defect). Add `max_jerk` param, drop the default; add `a_t` + `j_t` tracks via the shared probe; `sample_kinematics` (≈187).
+- `rust/motion-engine/src/jerk_probe.rs` — **NEW** pure jerk computation, shared by viz and the CI gate.
+- `rust/geometry/src/path/profile.rs` — `CurvatureProfile`: `kappa(s)`, `dkappa_ds(s)`, `kappa_peak()`, `kappa_endpoints()`, `s_len()` (probe/diagnostic inputs).
+- `scripts/ci.sh` — add the feasibility-gate + throughput-non-regression job.
+
+## Tasks & Acceptance
+
+**One PR on the `curvature-profile` feature branch.** The 4 stages below are the implementation order *inside* the single change set. Suggested commit order: T1 → T2 → T3 → T4, so each commit bisects cleanly. The SOCP deletion is **Motion-13**, a separate PR (recommended to land first or in parallel — never bundled here).
+
+**T1 — scurve acceleration-carrying primitive + a_t evaluator**
+- [x] `velocity/scurve.rs`: `reach_velocity_with_accel(v0, a0, ds, accel_max, jerk_max) -> (v1, a1)` (limit-riding bang-bang jerk integration over arclength); `breakpoints(v0, a0, ds, accel_max, jerk_max) -> SevenSeg`; `accel_at(seg, s) -> f64` (analytic `a_t`). Tests in `velocity/scurve/tests.rs`.
+- AC-S1: `reach_velocity_with_accel` matches numeric ODE integration ≤1e-9 over randomized `(v0,a0,ds)`. AC-S2: `accel_at` integrated back reproduces `reach_velocity_with_accel` (round-trip ≤1e-9). AC-S3 (property): peak `|a| ≤ accel_max`, peak `|j| ≤ jerk_max` across the curve.
+- AC-S4a (**decision table** — replaces the old "two named corners" AC): `breakpoints` is implemented against a **fully enumerated seven-segment case table**. The seven phases are jerk-up → hold-accel → jerk-down → cruise → jerk-down → hold-decel → jerk-up; any subset can collapse to zero length. The table covers at least: `a0=0`; `0<a0<accel_max`; `a0=accel_max` (jerk-up phase has zero length); `a0<0` including `a0=-accel_max`; and the **sign-flip** case (`a0>0` but the segment target requires ending with `a1<0`, and the mirror). Each case is a **named branch** in source — no unnamed fall-through into a `sqrt`/`cbrt`.
+- AC-S4b (**infeasibility guard**): for each case the minimum feasible arclength `ds_min(v0,a0,accel_max,jerk_max)` is computed analytically and asserted **before** any `sqrt`/`cbrt`. `ds < ds_min` raises `InfeasibleReach` — never a clamp, NaN, or saturate-and-continue. `ds→0` and `a0=accel_max` fall out of this guard as loud-correct.
+- AC-S4c: the randomized ODE regression (AC-S1) includes `a0=-accel_max` and the sign-flip case, not only `a0=accel_max`.
+- AC-S5 (**bit-for-bit backward compat**): the `a0=0` path is a thin wrapper that **delegates** to today's `max_reachable_velocity` (single implementation, `#[inline]`), not a re-derivation. Test asserts bit-for-bit equality (`f64::to_bits()` compare) over 1000 randomized `a0=0` inputs. There must be exactly one f64 implementation of this quantity after T1 — the existing `jerk_only`/`jerk_bound` reporting call (`velocity.rs:≈309`) routes through the same wrapper, so no two float paths compute the same value differently.
+
+**T2 — jerk_probe instrument + viz wiring + max_jerk defect fix**
+- [x] `motion-engine/src/jerk_probe.rs`: `jerk_at(kappa, dkappa_ds, v, a_t, seg_jerk) -> JerkSample { j_t, j_n, j_n_geom, j_n_couple }`, `j_t = seg_jerk`, `j_n = κ'·v³ + 2κ·v·a_t` (geom/couple split; `j_n` is diagnostic-only).
+- [x] `viz.rs::pipeline_snapshot`: add `max_jerk` to the signature, remove `VelocityConfig::default()`; emit `kin_a_t` and `kin_j_t` (+ optional `kin_j_n*`) tracks via `jerk_at`. **T3 update:** viz now reads the planned analytic `a` (`VelSample.a`) directly instead of finite-differencing the planned `(s,v)`.
+- AC-P1: `jerk_at` is pure, `j_n == j_n_geom + j_n_couple`. AC-P2: viz consumes the caller's `max_jerk`; grep shows zero `VelocityConfig::default()` in the viz path. AC-P3: against the *current C1* planner, the probe reports a finite `Δa_t` step at mid-run junctions (documents the bug T3 removes). AC-P4: one probe implementation, referenced by both viz and the gate (no duplicated formula). See **R4** — sharing the probe is correct, but the gate must additionally cross-check against the *emitted time-domain* trajectory so the probe is not self-confirming.
+- Depends on T1 (`accel_at`).
+
+**T3 — coupled (v,a) C2 sweep + crossover jerk-bridge** *(the crux)*
+- [x] `velocity.rs` + `disk.rs::profile_speed`: coupled `(v,a)` forward/backward sweeps via `reach_velocity_with_accel`; `(v,a)=(0,0)` pinned at rest anchors; crossover accel-step dissolved by a closed-form seven-segment jerk-bridge (lowest peak-`v` under both envelopes). `a_t` bang-bang on disk rails.
+- AC-C1 (headline): across a run interior, `|Δa_t|` between adjacent samples and at the crossover ≤ tol (continuity). AC-C2: at every rest anchor, emitted `(v,a)=(0,0)`. AC-C3: jerk-bridge yields the minimum peak-`v` feasible under both envelopes (vs a brute sampled search, test-only). AC-C4: planning stays O(N) two-pass; no SOCP/grid/QP inner solver. The crossover's 1-D splice-location root (R1, within boundary) carries a hard per-crossover iteration cap (`K`) asserted across the corpus. AC-C5: T2 probe over T3 output shows AC-P3's step is gone. AC-C6: rest anchor with `|a_entry|>ε_a` raises (fail-loud).
+- Depends on T1; validated by T2. **Risk:** R1 (solvability), R2 (feasibility), and R3 (throughput) are all **resolved** — the bridge is closed-form (flat-rail seven-segment); the feasible set is never empty (`(0,0)` floor → at worst a momentary mid-run stop); the lower-`v_peak` relaxation is a bounded monotone 1-D root that keeps the passes independent (O(N) holds); and the provably-false "C2 ≤ C1" headline is replaced by AC-G3's three gates. One **implementation note** from R2: a crossover relaxing to `v_peak=0` must be promoted to a true rest anchor. The only remaining live risk is **R4** (gate circularity, addressed by AC-G5/G6, verify when T2/T4 land). HALT and surface per the **Ask First** boundary before introducing any multivariable inner solver.
+
+**T4 — CI feasibility gate + throughput non-regression**
+- [ ] New property test (wired into `cargo nextest` + `scripts/ci.sh`): dense-resample the emitted trajectory, recover analytic `a_t` (T1), run `jerk_at` (T2), assert `|j_t| ≤ max_jerk·(1+ε)`, `|a_t| ≤ a_max·(1+ε)`, `v ≤` caps everywhere; seam/crossover `|Δa_t| ≤ ε_a`; rest-anchor `(0,0)`. ε derived from discretization + float epsilon, not arbitrary.
+- [ ] Throughput: **do not gate on "C2 ≤ C1"** — it is provably false on cornered fixtures (R3). Instead, via klipper-sim (`~/Developer/klipper-sim/`, per-branch `--klipper-root`): (a) capture C1 times BEFORE T3 to identify jerk-non-binding fixtures; (b) freeze current C2 times as the forward regression baseline. See AC-G3 (G3a/b/c).
+- AC-G1: gate is RED on a deliberately injected accel-step (mutation test — prove it bites). AC-G2: gate GREEN on T3 output across the corpus. **AC-G3 (throughput, per R3) — three sub-gates replacing "C2 ≤ C1": G3a — on jerk-non-binding fixtures `C2 == C1` within float noise (no spurious slowdown); G3b — aggregate C2 time-excess per fixture ≤ a physics-derived bridge-cost bound; G3c — C2 ≤ frozen-C2 baseline (no self-regression). Do not loosen any of these to "within ε" to absorb a real regression.** AC-G4: gate and viz call the same `jerk_at`. **AC-G5 (anti-circularity, see R4): the gate also recovers `a_t` by finite-difference of the emitted time-domain `ShapedSegment` stream and asserts agreement with `accel_at` — so the gate validates the executed trajectory, not the planner's own bookkeeping. AC-G6 (anti-aliasing): evaluate `accel_at` at every adjacent `SevenSeg` endpoint pair directly (no resampling) — a step at a narrow bridge cannot fall between samples.**
+- Depends on T1/T2/T3.
+
+**Acceptance Criteria (spec-level):**
+- Given a mid-run cruise→decel-into-curve junction, when planned, then tangential acceleration is continuous across it (`|Δa_t| ≤ ε_a`) — the C1 step is gone.
+- Given any run, when planned, then `|j_t| ≤ max_jerk` and `|a_t| ≤ a_max` at every sample, and `(v,a)=(0,0)` at both run ends.
+- Given the representative slicer corpus, throughput-SOTA is held by three gates (R3, AC-G3), **not** by "C2 ≤ C1" (provably false on cornered fixtures): on jerk-non-binding fixtures C2 == C1 (no spurious slowdown); per-fixture bridge cost is within a physics-derived bound; and C2 does not regress against its own frozen baseline.
+- Given a run arriving at a rest anchor with non-zero entry acceleration, when handled, then the planner raises and does not pad.
+- Given `./scripts/ci.sh quick` + the new gate job, when run, then green.
+
+## Design Notes
+
+**Why this is the architecture's completion, not the deleted SOCP.** The deleted complexity was the *sampled, coupled, numerically-optimized* TOPP (N variables, SOCP solver, convergence tuning). Carrying `(v,a)` across junctions in a node-based sweep is a graph problem with two scalars of state per node and closed-form per-edge propagation. Because XY jerk is one global scalar, `a_t` is bang-bang on the disk rails (spec-motion-7) and interior only on short seven-segment transitions — so the (v,a) reachable region is a 1D manifold with jerk-bridge splices at corners, not a 2D search. Cost: same O(N) two-pass as C1 with a ~10× per-edge constant; no solver. Deleting the SOCP frees more compute than C2 adds. *(Pre-mortem R1, resolved: the bridge itself is closed-form; only locating the splice `s*` is a bounded 1-D root on monotone envelopes — O(1), within the no-inner-solver boundary. See R1.)*
+
+**The crossover — closing the round-1 gap.** Scalar `v = min(v_fwd, v_bwd)` flips `a_t` sign discontinuously at the crossover — the residual C1 break. Resolve it as a two-point BVP on `[s*−δ, s*+δ]`: the jerk-limited profile matching `(v_fwd, a_fwd)` on the left and `(v_bwd, a_bwd)` on the right with lowest peak-`v` (so it stays under both envelopes — no over-limiting). With global-scalar jerk this is the standard seven-segment "reach-cruise vs double-ramp" case analysis with non-zero boundary accels. The accel step is *dissolved*, not relocated. Where the bridge's peak-`v` would exceed the local disk ceiling, `v` is lowered — that is the true jerk-limited bound, the one place C2 can legitimately cost time, and exactly where C1 was lying. *(R1/R2 resolved: the free knot `s*` is located by a bounded 1-D root and the transcendental rail enters only as boundary values, so the bridge itself stays closed-form and is always feasible down to the `(0,0)` floor. See R1/R2.)*
+
+**Validation without an oracle.** Feasibility is intrinsic — differentiate the emitted profile and assert the envelopes. The seam/crossover `|Δa_t|` assertion is the high-value test: it turns "the velocity plot looks smooth while `a_t` steps" into a deterministic failure. Optimality is defended **not** by a C2-vs-C1 race (C1 is jerk-infeasible, so C2 is provably slower at corners — R3) but by R3's three gates — no spurious slowdown on jerk-non-binding fixtures, bounded bridge cost, no C2-vs-C2 self-regression; no reference solver is kept (untrusted). *(R4: the gate must recover `a_t` from the emitted time-domain trajectory, not re-read the planned `SevenSeg`, or it is self-confirming. See R4 / AC-G5.)*
+
+## Risks & Open Questions (pre-mortem, 2026-06-20)
+
+R1, R2, and R3 are **resolved** (first-principles, code-grounded) and their conclusions are baked into the ACs (AC-C4/C6, AC-G3, AC-G5/G6). R4 remains **open** — it can only be closed once T2/T4 code exists. Each entry records its resolution and the date.
+
+- **R1 — Crossover solvability. [RESOLVED 2026-06-20, first-principles + code-grounded — within boundary]** Resolved against `disk.rs:142-167`. The bridge profile is **closed-form**: in the bridge `a_t` is the *control variable* (bounded by `a_max`/`jerk_max`), so the bridge is a flat-rail seven-segment BVP between two fixed `(v,a)` boundary states — exactly T1's `breakpoints`/`accel_at`. The transcendental disk rail (`dw/ds = 2√(a²−κ²w²)`, `disk.rs:79`) governs only the *adjoining* sections, so it enters the bridge **only as boundary values** (`a_fwd`/`a_bwd`, computed by the existing RK4 when σ≠0) — inputs, not the bridge's functional form. The *only* iteration is locating the splice `s*`: a **1-D root `forward(s)−backward(s)=0` on two monotone envelopes already being evaluated** (plus a 1-D monotone search to size δ for lowest peak-`v`). That is the same O(1) class as the `asin` (`disk.rs:60`) / Cardano `cbrt` (`scurve.rs`) already in the code — **not** an SOCP/QP/grid inner solver, so the no-inner-solver boundary **holds**. *Residual:* the genuine seven-segment case-table closure across all `(v0,a0,v1,a1)` pairs is real work, but it is AC-S4a, not an architectural risk. Keep AC-C4 as written (it is satisfied); optionally assert a fixed cap on the 1-D splice-location iterations for hygiene. The hard worst case (forward-disk meets backward-disk mid-curve, σ≠0 both sides) was checked: δ is short, κ varies only second-order across it, "stay under both envelopes" absorbs it — bridge stays closed-form.
+- **R2 — Crossover feasibility. [RESOLVED 2026-06-20, first-principles + code-grounded]** The feasible bridge set is **never empty**: `(v,a)=(0,0)` is reachable from any state and bridges to any state (two `a0=0` seven-segment ramps — T1's existing primitive), so the worst-case bridge degenerates to "momentary mid-run stop," which always fits. The accel-flip takes a *fixed time* `Δt=(a_fwd−a_bwd)/jerk_max`; the arclength it consumes `≈∫v dt` **shrinks as `v` dips**, so lowering the bridge peak `v_peak` always makes the flip fit — down to the `v_peak=0` floor. *Consequences:* (1) `raise` (AC-C6, I/O matrix) **stays correctly reserved** for a seam *misclassified* as a rest anchor (a real bug) — it should never fire on routine tight geometry, so AC-C6 is unchanged. (2) What looks like infeasibility is **cost** (R3), not an abort: a tight crossover lowers `v_peak`. (3) The relaxation is a **monotone 1-D root with a floor at 0** (lower `v_peak` → easier fit), not an unbounded fixpoint — and since the envelopes (`disk_reach_v` from the run-end anchors, `velocity.rs:241,255`) are **bridge-independent**, lowering one crossover's `v_peak` does not move any other crossover's envelopes, so the passes stay independent and **O(N) holds**. *Implementation note (the one residual):* a crossover that relaxes to `v_peak=0` must be **promoted to a true rest anchor** (`is_anchor[k]=true`, `velocity.rs:193`) to keep the `(0,0)` pin + fail-loud machinery consistent. This should be rare-to-never in practice — the clothoid fitter already blends corners to be traversable (lateral jerk is the fitter's job, see Non-Goals), so velocity planning rarely sees a corner tight enough to force a stop.
+- **R3 — Throughput baseline. [RESOLVED 2026-06-20 — headline AC changed]** First-principles: C2's feasible set is C1's **plus jerk-continuity** (a pure *added* constraint), so `v_C2(s) ≤ v_C1(s)` pointwise, hence `t_C2 ≥ t_C1` wherever any bridge fires. "C2 total time ≤ C1-reported time" is therefore the **wrong inequality — provably red on every cornered fixture**, not a tolerance question. *This retracts the earlier R3 suggestion* to "run the feasibility filter on C1 and use that as the baseline": enforcing jerk-feasibility on C1's profile rounds its corners, which *is* the C2 construction, so "feasible-C1" ≈ C2 and the gate is **vacuous**. C1-reported time is a physically-unrealizable lower bound (infinite jerk at corners); the only other feasible reference (the SOCP) is deleted/untrusted — so there is **no usable absolute baseline**. Honor throughput-SOTA (CLAUDE.md: "never slower than the best we can compute" — the best *feasible* trajectory is C2; C1 isn't executable) via three gates instead of "C2 ≤ C1", now wired into AC-G3:
+  - **G3a (no spurious slowdown):** on jerk-**non**-binding fixtures (no bridge fires) `C2 == C1` within float noise — catches accidental over-limiting of the easy cases. Provable equality.
+  - **G3b (bounded bridge cost):** aggregate C2 time-excess per fixture ≤ a physics-derived bound (Σ over crossovers of the v-dip cost; each ≤ `Δt_flip=(a_fwd−a_bwd)/jerk_max` × dip area) — bounds the legitimate cost of honesty so it can't mask a regression.
+  - **G3c (C2-vs-C2 regression pin):** freeze current C2 corpus times as the forward baseline so future changes can't silently regress once C1 is gone — the durable SOTA guard.
+- **R4 — The feasibility gate may be self-confirming (validation). [OPEN]** If the gate recovers `a_t` from the same planned `SevenSeg` the planner produced (AC-P4/AC-G4 shared probe), it validates the planner's bookkeeping, not the time-domain trajectory the stepper executes — a step introduced in reparam-to-`ShapedSegment` would pass green. Aliasing compounds it: velocity-based adaptive resampling won't refine a smooth-`v` profile, so an `a_t` step in a narrow bridge window can fall between samples. *Mitigations (now AC-G5/AC-G6):* (a) cross-check `a_t` from finite-difference of the emitted time-domain `ShapedSegment` stream against `accel_at`; (b) evaluate `accel_at` at every adjacent `SevenSeg` endpoint pair directly — cannot alias.
+
+## Verification
+
+**Commands:**
+- `cargo nextest run -p geometry` — scurve + sweep continuity green.
+- `cargo nextest run -p motion-engine` — jerk_probe + feasibility gate green.
+- `cargo test --doc` — if any doc examples touched.
+- `./scripts/ci.sh quick` — ruff/clippy `-D warnings`/fmt/rust tests green before PR.
+- Throughput (R3, AC-G3): klipper-sim across the corpus — `C2 == C1` on jerk-non-binding fixtures, per-fixture bridge cost within bound, C2 ≤ frozen-C2 baseline. (Not "C2 ≤ C1" — provably false on cornered fixtures.)
+
+**Manual checks:**
+- `make -f Makefile.rust motion-engine`, run representative slicer G-code through the viz; confirm the `a_t`/`j_t` tracks show continuous acceleration through mid-run corners (no step) and `j_t` within `max_jerk`.
+
+## Dev Log — 2026-06-20 session handoff (fresh-session pickup)
+
+**Branch:** `curvature-profile` (base: `sota-motion`). **Pick up T3 from here.**
+
+### What is committed (done, do not redo)
+- **T1 — `892bb57eb`** `feat(velocity): analytic seven-segment (v,a) reach primitive`. `velocity/scurve.rs` has `reach_velocity_with_accel`, `breakpoints` (`SevenSeg`), `accel_at`, `velocity_at`; tests green. This is the engine T3 must use.
+- **T2 — `309dd1218`** `feat(viz): thread max_jerk and emit jerk diagnostics`. `pipeline_snapshot` takes `max_jerk` (no more hardcoded `VelocityConfig::default()`), shared `jerk_probe.rs`, `kin_a_t/j_t/j_n` tracks. **Caveat:** until T3 lands, viz `a_t`/`j_t` are recovered by **finite difference** of the planned `(s,v)` (`viz.rs::tangential_accel`/`tangential_jerk`), because the committed planner carries no `a`. Once T3 carries `(v,a)`, switch viz back to reading the planned `a` (re-add `VelSample.a`).
+- **T3 — NOT done.** A prior agent's attempt was reverted (see post-mortem). The committed planner is still C1 (velocity-ceiling jerk).
+
+### Motivating defect — proven this session (the thing T3 fixes)
+The committed jerk model (`scurve::max_reachable_velocity`, a velocity *ceiling*) is wrong on accel shape, not just at junctions:
+- **Accel-from-rest rides at exactly `(2/9)·max_jerk`.** Analytic: from rest the ceiling is `v_ceil(s) = (jerk·s²)^(1/3)`, so riding it gives `a_t = (2/3)·jerk^(2/3)·s^(1/3)` and `da_t/dt = (2/9)·jerk`. Measured on demo4: **889 vs configured 4000** (22%). It under-drives jerk and never produces a flat-topped accel trapezoid.
+- **The accel→decel crossover is ungoverned.** At a sub-cruise velocity peak, `a_t` steps `+max → −max` in one sample (measured `+192 → −124`, `ds≈2e-5` → jerk ~1e9). The velocity ceiling has no acceleration state to carry across the crossover.
+- Both are the **same root cause**: `a_t` is *derived* from a velocity ceiling ("bounds whether a speed is reachable, never how acceleration behaves on the way" — Intent), not *carried as planned state*.
+
+### Prior T3 attempt — post-mortem (DO NOT REPEAT)
+The reverted attempt (≈700 lines in `disk.rs`) produced a 4.8e6 accel spike on the corner clothoids. Three faults:
+1. **Finite-differenced `a_t`** (`centered_fd_accels`, `v·Δv/Δs`) instead of analytic `accel_at` → exploded over sub-µm seam Δs. (Violated AC-G6.)
+2. **Bridge samples exceeded `min(fwd,bwd)`** — planted `v=9.84` between neighbours ~7.36 (the envelope invariant `v ≤ envelope` must hold at every sample; the `v_r_capped` clamp was applied only at `s_r`).
+3. **Bridge fired on ~6 µm corner clothoids** where there is no genuine tangential crossover.
+The attempt's `c2_feasibility_gate.rs` (`FEAS-0`) *did* catch it (`dv=2.49 > budget`) — it was deleted with the revert. **Recreate that gate, red-first.**
+
+### Reproduction fixture
+- G-code: `/private/tmp/demo4.gcode` — serpentine `(0,0)→(90,0)→(90,90)→(180,90)→(180,0)`, 3×90° near-stop corners.
+- Config: `/private/tmp/viz_demo.cfg` — corexy, `max_velocity 150`, `max_accel 200`, `max_jerk 4000`, `square_corner_velocity 5`.
+- Run: `make -f Makefile.rust motion-engine && python3 scripts/viz_pipeline.py /private/tmp/demo4.gcode -c /private/tmp/viz_demo.cfg`.
+- **Acceptance after T3:** accel-from-rest is a 4000-jerk trapezoid (`a_t` rises 0→200 *linearly*, hits 200 at t≈0.05s, not the current ~0.23s); the sub-cruise peak crossover is jerk-limited (no `+max→−max` step); `j_t ≤ max_jerk` everywhere.
+
+### Design (carried from the in-session proposal)
+Replace the `min()`-of-velocity-ceilings reconstruction with a coupled `(v,a)` sweep:
+- Carry `(v,a)` as planned state via `reach_velocity_with_accel` (T1). Per-sample `a_t` is **analytic** (binding-rail closed form, or `accel_at` in a bridge) — **never finite difference**.
+- Dissolve the forward/backward crossover with a closed-form T1 seven-segment **jerk-bridge**, peak-`v` clamped under **both** envelopes (lower `v` at the apex is the legitimate, only place C2 costs time). Locate the splice by a 1-D monotone root (within the no-inner-solver boundary, spec R1).
+- **Gate the bridge to genuine crossovers** (`|Δa_t| > ε_a`, arclength `≥ ds_min`); skip sub-`ds_min` corner clothoids. Pin `(v,a)=(0,0)` at rest anchors; fail loud on non-zero entry accel at a rest anchor.
+- Recreate the **FEAS-0 gate red-first**, recovering `a_t` by finite-difference of the *emitted time-domain `ShapedSegment` stream* (not the planner's own `SevenSeg`) and evaluating `accel_at` at adjacent `SevenSeg` endpoints (AC-G5/G6 — anti-aliasing).
+- Code map: `velocity.rs` (sweeps, anchors), `disk.rs::profile_speed` (the `min()` reconstruction to replace), `scurve.rs` (T1 — done).
+
+### Fresh-session first steps
+1. Re-read this spec (T3 + ACs) and `investigations/clothoid-straight-seam-discontinuity-investigation.md` (full diagnosis).
+2. Recreate `c2_feasibility_gate.rs` (FEAS-0 + the accel-from-rest-jerk assertion) — get it RED on the committed planner.
+3. Implement the `(v,a)` carry + crossover bridge until the gate is GREEN and the demo4 acceptance above holds.
+
+## Dev Agent Record — T3 implemented (2026-06-20)
+
+**Scope:** T3 only (per user). T4 (CI feasibility gate job, mutation test AC-G1, throughput gates AC-G3, anti-circularity CI wiring AC-G5/G6) is intentionally **not** in this change set.
+
+### What landed
+- **`VelSample` now carries analytic `a`** (`velocity.rs`). Reconstruction is **per-run** (not per-move): runs are delimited by rest anchors; a single coupled `(v,a)` profile is built across the run's moves, then split back per move.
+- **Binding-rail analytic `a_t`** (`disk.rs`, `forward_branch`/`backward_branch`/`eval_profile`): per sample `a_t` is the closed-form accel of whichever rail binds — `±accel_at` (scurve jerk ramp from the run anchor, fixing the C1 `(2/9)·jerk` from-rest ride), `±√(a²−κ²v⁴)` (disk rail accelerating below the ceiling), or `v·dv_lim/ds = −½·a·σ·sign(κ)/κ²` (curvature-ceiling tracking, direction-independent). **Never finite-differenced.**
+- **Node sweep jerk term** switched from `scurve::max_reachable_velocity` (the acceleration-returns-to-0 ceiling `(j·s²)^⅓`) to the carried `scurve::reach_v` (true full-jerk trapezoid) — this is the throughput win: C2 from-rest is *faster* than C1's conservative ceiling.
+- **Crossover jerk-bridge** (`disk.rs`, `build_run_bridge`): both apex (`a:+→−`) and valley (`a:−→+`) crossovers across the run interior — including those landing on move boundaries — are dissolved by a single constant-jerk seven-segment arc. The splice point is a bounded 1-D root (`scan_root`, robust to positive-zero `signum`); the arc is validated to stay under both envelopes (R2 floor). Bridges are skipped under infinite jerk.
+- **`(0,0)` pin + fail-loud** (`velocity.rs`, `pin_rest_anchor`): rest-anchor samples are pinned to `(v,a)=(0,0)`; a finite-jerk run arriving at a rest anchor with `|a|>1e-3` raises `VelocityError::RestAnchorAccel` (AC-C6). Infinite jerk skips the check (instantaneous accel is C1-by-definition there).
+- **viz** reads the planned analytic `a` directly (resolves the T2 finite-difference caveat).
+
+### Validation (demo4 serpentine, `max_velocity 150 / max_accel 200 / max_jerk 4000 / scv 5`)
+- Accel-from-rest is a full-jerk trapezoid: `a_t` is on the `a_max` plateau by `s≈0.08 mm` (C1 `(2/9)·jerk` ride only reaches `~0.66·a_max` at `s=0.5 mm`).
+- Every straight sub-cruise `+max→−max` crossover is bridged — no adjacent `|Δa_t|` reaches `a_max` (the C1 step was `2·a_max`).
+- `|a_t| ≤ a_max` everywhere; `(v,a)=(0,0)` at both run ends.
+- **Carve-out (consistent with the seam investigation):** the only residual `a_t` step is at the biclothoid corner apex (`~66 mm/s² < a_max`), where ceiling-riding `a_t = v·dv_lim/ds` inherits the clothoid's `dκ/ds` jump (G2-not-G3). Per the Non-Goals this lateral-jerk-induced step is the fitter shape's responsibility; a G3 corner fitter is a separate spec.
+
+### Tests
+- `rust/geometry/tests/c2_continuity.rs` (new): from-rest trapezoid, no-crossover-step, `|a|≤a_max`, rest-anchor `(0,0)`.
+- `rust/geometry/src/velocity/tests.rs`: `pin_rest_anchor` fail-loud / zero / infinite-jerk paths (negative-test obligation for the new error).
+- Full geometry suite (320) + motion-engine (369) green; `cargo fmt --check`, `clippy -D warnings` clean.
+
+### Remaining (T4, out of scope here)
+The dev-log "recreate `c2_feasibility_gate.rs` red-first" is the **T4** CI gate (emitted-time-domain `a_t` recovery, mutation test, throughput non-regression). T3's ACs are validated by `c2_continuity.rs`; the durable CI/throughput gate is still owed under T4.

--- a/rust/geometry/src/execution/tests.rs
+++ b/rust/geometry/src/execution/tests.rs
@@ -37,7 +37,10 @@ fn planned(moves: Vec<Move>) -> (FitOutcome, VelocityProfile) {
 }
 
 fn vmove(length: f64, samples: &[(f64, f64)], accel: f64, line_no: u32) -> MoveVelocity {
-    let samples: Vec<VelSample> = samples.iter().map(|&(s, v)| VelSample { s, v }).collect();
+    let samples: Vec<VelSample> = samples
+        .iter()
+        .map(|&(s, v)| VelSample { s, v, a: 0.0 })
+        .collect();
     MoveVelocity {
         entry_v: samples.first().map_or(0.0, |x| x.v),
         exit_v: samples.last().map_or(0.0, |x| x.v),

--- a/rust/geometry/src/velocity.rs
+++ b/rust/geometry/src/velocity.rs
@@ -35,6 +35,7 @@ impl Default for VelocityConfig {
 pub struct VelSample {
     pub s: f64,
     pub v: f64,
+    pub a: f64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -72,7 +73,24 @@ pub enum VelocityError {
     NonFinite { line_no: u32 },
     Diverged { line_no: u32 },
     OverCommitted { line_no: u32 },
+    RestAnchorAccel { line_no: u32 },
     InvalidConfig,
+}
+
+const REST_ANCHOR_ACCEL_EPS: f64 = 1e-3;
+
+fn pin_rest_anchor(
+    sample: Option<&mut VelSample>,
+    line_no: u32,
+    jerk: f64,
+) -> Result<(), VelocityError> {
+    if let Some(s) = sample {
+        if jerk.is_finite() && s.a.abs() > REST_ANCHOR_ACCEL_EPS {
+            return Err(VelocityError::RestAnchorAccel { line_no });
+        }
+        s.a = 0.0;
+    }
+    Ok(())
 }
 
 struct MoveCaps {
@@ -240,12 +258,13 @@ pub fn plan_velocity_warm_start(
         let kin = &caps[j].kin;
         let disk = disk::disk_reach_v(kin, v[j], kin.length, tol)
             .ok_or(VelocityError::Diverged { line_no })?;
-        let jerk = scurve::max_reachable_velocity(
+        let jerk = scurve::reach_v(
             run_start_v[j],
             arc_from_run_start[j] + kin.length,
             kin.accel,
             kin.jerk,
-        );
+        )
+        .ok_or(VelocityError::Diverged { line_no })?;
         v[k] = v[k].min(disk).min(jerk);
     }
     for k in (1..n).rev() {
@@ -254,12 +273,8 @@ pub fn plan_velocity_warm_start(
         let kin = &caps[j].kin;
         let disk = disk::disk_reach_v_rev(kin, v[k + 1], kin.length, tol)
             .ok_or(VelocityError::Diverged { line_no })?;
-        let jerk = scurve::max_reachable_velocity(
-            0.0,
-            arc_to_run_end[j] + kin.length,
-            kin.accel,
-            kin.jerk,
-        );
+        let jerk = scurve::reach_v(0.0, arc_to_run_end[j] + kin.length, kin.accel, kin.jerk)
+            .ok_or(VelocityError::Diverged { line_no })?;
         v[k] = v[k].min(disk).min(jerk);
     }
     let entry_line_no = moves[0].source.start_line;
@@ -269,12 +284,10 @@ pub fn plan_velocity_warm_start(
             disk::disk_reach_v_rev(kin, v[1], kin.length, tol).ok_or(VelocityError::Diverged {
                 line_no: entry_line_no,
             })?;
-        let jerk = scurve::max_reachable_velocity(
-            0.0,
-            arc_to_run_end[0] + kin.length,
-            kin.accel,
-            kin.jerk,
-        );
+        let jerk = scurve::reach_v(0.0, arc_to_run_end[0] + kin.length, kin.accel, kin.jerk)
+            .ok_or(VelocityError::Diverged {
+                line_no: entry_line_no,
+            })?;
         disk.min(jerk)
     };
     if entry_v > entry_brake + VELOCITY_EPS_MM_S {
@@ -283,48 +296,72 @@ pub fn plan_velocity_warm_start(
         });
     }
 
-    let mut out = Vec::with_capacity(n);
-    for (j, m) in moves.iter().enumerate() {
-        let kin = &caps[j].kin;
-        let line_no = m.source.start_line;
-        let entry_v = v[j];
-        let exit_v = v[j + 1];
-        let jerk_anchors = disk::JerkAnchors {
-            fwd_v: run_start_v[j],
-            fwd_s: arc_from_run_start[j],
-            bwd_v: 0.0,
-            bwd_s: arc_to_run_end[j],
-        };
-        let samples: Vec<VelSample> =
-            disk::sample_profile(kin, entry_v, exit_v, &jerk_anchors, tol)
-                .ok_or(VelocityError::Diverged { line_no })?
-                .into_iter()
-                .map(|(s, v)| VelSample { s, v })
+    let mut out: Vec<MoveVelocity> = Vec::with_capacity(n);
+    let mut run_start = 0;
+    while run_start < n {
+        let mut run_end = run_start + 1;
+        while run_end < n && !is_anchor[run_end] {
+            run_end += 1;
+        }
+        let members: Vec<disk::RunMember> = (run_start..run_end)
+            .map(|j| disk::RunMember {
+                kin: &caps[j].kin,
+                entry_v: v[j],
+                exit_v: v[j + 1],
+                fwd_s: arc_from_run_start[j],
+                bwd_s: arc_to_run_end[j],
+            })
+            .collect();
+        let run_start_line = moves[run_start].source.start_line;
+        let reconstructed = disk::reconstruct_run(&members, run_start_v[run_start], tol).ok_or(
+            VelocityError::Diverged {
+                line_no: run_start_line,
+            },
+        )?;
+
+        for (idx, j) in (run_start..run_end).enumerate() {
+            let kin = &caps[j].kin;
+            let m = &moves[j];
+            let line_no = m.source.start_line;
+            let entry_v = v[j];
+            let exit_v = v[j + 1];
+            let mut samples: Vec<VelSample> = reconstructed[idx]
+                .iter()
+                .map(|&(s, v, a)| VelSample { s, v, a })
                 .collect();
-        let peak_v = samples.iter().fold(0.0_f64, |acc, p| acc.max(p.v));
-        report.traversal_time_s += traversal_time(&samples);
+            if is_anchor[j] {
+                pin_rest_anchor(samples.first_mut(), line_no, kin.jerk)?;
+            }
+            if is_anchor[j + 1] {
+                pin_rest_anchor(samples.last_mut(), line_no, kin.jerk)?;
+            }
+            let peak_v = samples.iter().fold(0.0_f64, |acc, p| acc.max(p.v));
+            report.traversal_time_s += traversal_time(&samples);
 
-        let disk_only = disk::disk_reach_v(kin, entry_v, kin.length, tol)
-            .ok_or(VelocityError::Diverged { line_no })?;
-        let jerk_only = scurve::max_reachable_velocity(entry_v, kin.length, kin.accel, kin.jerk);
-        if jerk_only + VELOCITY_EPS_MM_S < disk_only {
-            report.jerk_bound += 1;
-        }
-        let curvature_ceiling = disk::limit_speed(caps[j].kappa_peak, kin.accel);
-        if caps[j].kappa_peak > 0.0 && peak_v > curvature_ceiling + VELOCITY_EPS_MM_S {
-            report.limit_ride += 1;
-        }
+            let disk_only = disk::disk_reach_v(kin, entry_v, kin.length, tol)
+                .ok_or(VelocityError::Diverged { line_no })?;
+            let jerk_only = scurve::reach_v(entry_v, kin.length, kin.accel, kin.jerk)
+                .ok_or(VelocityError::Diverged { line_no })?;
+            if jerk_only + VELOCITY_EPS_MM_S < disk_only {
+                report.jerk_bound += 1;
+            }
+            let curvature_ceiling = disk::limit_speed(caps[j].kappa_peak, kin.accel);
+            if caps[j].kappa_peak > 0.0 && peak_v > curvature_ceiling + VELOCITY_EPS_MM_S {
+                report.limit_ride += 1;
+            }
 
-        out.push(MoveVelocity {
-            entry_v,
-            exit_v,
-            peak_v,
-            samples,
-            accel: kin.accel,
-            jerk: kin.jerk,
-            length: kin.length,
-            source: m.source,
-        });
+            out.push(MoveVelocity {
+                entry_v,
+                exit_v,
+                peak_v,
+                samples,
+                accel: kin.accel,
+                jerk: kin.jerk,
+                length: kin.length,
+                source: m.source,
+            });
+        }
+        run_start = run_end;
     }
 
     Ok(VelocityProfile { moves: out, report })

--- a/rust/geometry/src/velocity/disk.rs
+++ b/rust/geometry/src/velocity/disk.rs
@@ -139,6 +139,128 @@ pub(super) struct JerkAnchors {
     pub bwd_s: f64,
 }
 
+const BRIDGE_EPS_A: f64 = 1e-6;
+const BRIDGE_MIN_ARC_FRAC: f64 = 1e-4;
+const ROOT_ITERS: u32 = 80;
+
+#[derive(Clone, Copy)]
+pub(super) struct ProfilePoint {
+    pub v: f64,
+    pub a: f64,
+}
+
+fn disk_rail_accel(accel: f64, kappa_abs: f64, v: f64) -> f64 {
+    let a_n = kappa_abs * v * v;
+    (accel * accel - a_n * a_n).max(0.0).sqrt()
+}
+
+fn forward_seg(kin: &Kinematics, jerk: &JerkAnchors) -> Option<scurve::SevenSeg> {
+    scurve::breakpoints(
+        jerk.fwd_v,
+        0.0,
+        jerk.fwd_s + kin.length,
+        kin.accel,
+        kin.jerk,
+    )
+    .ok()
+}
+
+fn backward_seg(kin: &Kinematics, jerk: &JerkAnchors) -> Option<scurve::SevenSeg> {
+    scurve::breakpoints(
+        jerk.bwd_v,
+        0.0,
+        jerk.bwd_s + kin.length,
+        kin.accel,
+        kin.jerk,
+    )
+    .ok()
+}
+
+const KAPPA_EPS: f64 = 1e-9;
+
+fn curvature_ceiling_accel(kin: &Kinematics, s: f64) -> f64 {
+    let kappa = kin.kappa0 + kin.sigma * s;
+    let kappa_abs = kappa.abs();
+    if kappa_abs <= KAPPA_EPS {
+        return 0.0;
+    }
+    let a = -0.5 * kin.accel * kin.sigma * kappa.signum() / (kappa_abs * kappa_abs);
+    a.clamp(-kin.accel, kin.accel)
+}
+
+fn ceiling_accel(kin: &Kinematics, s: f64) -> f64 {
+    let v_curv = limit_speed(kin.kappa_abs(s), kin.accel);
+    if v_curv <= kin.flat_ceiling {
+        curvature_ceiling_accel(kin, s)
+    } else {
+        0.0
+    }
+}
+
+fn forward_branch(
+    kin: &Kinematics,
+    entry: f64,
+    seg: &scurve::SevenSeg,
+    jerk: &JerkAnchors,
+    s: f64,
+    tol: f64,
+) -> Option<ProfilePoint> {
+    let v_disk = disk_reach_v(kin, entry, s, tol)?;
+    let v_jerk = scurve::velocity_at(seg, jerk.fwd_s + s);
+    let ceil = kin
+        .flat_ceiling
+        .min(limit_speed(kin.kappa_abs(s), kin.accel));
+    let v = v_disk.min(v_jerk).min(ceil);
+    let a = if v_jerk <= v_disk && v_jerk <= ceil {
+        scurve::accel_at(seg, jerk.fwd_s + s)
+    } else if v >= ceil - tol * (1.0 + ceil) {
+        ceiling_accel(kin, s)
+    } else {
+        disk_rail_accel(kin.accel, kin.kappa_abs(s), v_disk)
+    };
+    Some(ProfilePoint { v, a })
+}
+
+fn backward_branch(
+    kin: &Kinematics,
+    exit: f64,
+    seg: &scurve::SevenSeg,
+    jerk: &JerkAnchors,
+    s: f64,
+    tol: f64,
+) -> Option<ProfilePoint> {
+    let rest = kin.length - s;
+    let v_disk = disk_reach_v(&kin.reversed(), exit, rest, tol)?;
+    let v_jerk = scurve::velocity_at(seg, jerk.bwd_s + rest);
+    let ceil = kin
+        .flat_ceiling
+        .min(limit_speed(kin.kappa_abs(s), kin.accel));
+    let v = v_disk.min(v_jerk).min(ceil);
+    let a = if v_jerk <= v_disk && v_jerk <= ceil {
+        -scurve::accel_at(seg, jerk.bwd_s + rest)
+    } else if v >= ceil - tol * (1.0 + ceil) {
+        ceiling_accel(kin, s)
+    } else {
+        -disk_rail_accel(kin.accel, kin.kappa_abs(s), v_disk)
+    };
+    Some(ProfilePoint { v, a })
+}
+
+fn eval_profile(
+    kin: &Kinematics,
+    entry: f64,
+    exit: f64,
+    fwd: &scurve::SevenSeg,
+    bwd: &scurve::SevenSeg,
+    jerk: &JerkAnchors,
+    s: f64,
+    tol: f64,
+) -> Option<ProfilePoint> {
+    let f = forward_branch(kin, entry, fwd, jerk, s, tol)?;
+    let b = backward_branch(kin, exit, bwd, jerk, s, tol)?;
+    Some(if f.v <= b.v { f } else { b })
+}
+
 fn profile_speed(
     kin: &Kinematics,
     entry: f64,
@@ -147,23 +269,9 @@ fn profile_speed(
     s: f64,
     tol: f64,
 ) -> Option<f64> {
-    let rest = kin.length - s;
-    let forward = disk_reach_v(kin, entry, s, tol)?;
-    let backward = disk_reach_v(&kin.reversed(), exit, rest, tol)?;
-    let jerk_forward =
-        scurve::max_reachable_velocity(jerk.fwd_v, jerk.fwd_s + s, kin.accel, kin.jerk);
-    let jerk_backward =
-        scurve::max_reachable_velocity(jerk.bwd_v, jerk.bwd_s + rest, kin.accel, kin.jerk);
-    let ceiling = kin
-        .flat_ceiling
-        .min(limit_speed(kin.kappa_abs(s), kin.accel));
-    Some(
-        forward
-            .min(backward)
-            .min(jerk_forward)
-            .min(jerk_backward)
-            .min(ceiling),
-    )
+    let fwd = forward_seg(kin, jerk)?;
+    let bwd = backward_seg(kin, jerk)?;
+    Some(eval_profile(kin, entry, exit, &fwd, &bwd, jerk, s, tol)?.v)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -218,19 +326,366 @@ fn refine(
     Some(())
 }
 
+pub(super) struct RunMember<'a> {
+    pub kin: &'a Kinematics,
+    pub entry_v: f64,
+    pub exit_v: f64,
+    pub fwd_s: f64,
+    pub bwd_s: f64,
+}
+
+struct MemberCtx<'a> {
+    m: &'a RunMember<'a>,
+    fwd_seg: scurve::SevenSeg,
+    bwd_seg: scurve::SevenSeg,
+    jerk: JerkAnchors,
+}
+
+fn build_ctxs<'a>(members: &'a [RunMember<'a>], run_start_v: f64) -> Option<Vec<MemberCtx<'a>>> {
+    let mut out = Vec::with_capacity(members.len());
+    for m in members {
+        let jerk = JerkAnchors {
+            fwd_v: run_start_v,
+            fwd_s: m.fwd_s,
+            bwd_v: 0.0,
+            bwd_s: m.bwd_s,
+        };
+        let fwd_seg = forward_seg(m.kin, &jerk)?;
+        let bwd_seg = backward_seg(m.kin, &jerk)?;
+        out.push(MemberCtx {
+            m,
+            fwd_seg,
+            bwd_seg,
+            jerk,
+        });
+    }
+    Some(out)
+}
+
+fn locate(ctxs: &[MemberCtx], s_run: f64) -> (usize, f64) {
+    let mut i = 0;
+    for (k, c) in ctxs.iter().enumerate() {
+        if s_run + 1e-12 >= c.m.fwd_s {
+            i = k;
+        } else {
+            break;
+        }
+    }
+    let local = (s_run - ctxs[i].m.fwd_s).clamp(0.0, ctxs[i].m.kin.length);
+    (i, local)
+}
+
+fn run_forward(ctxs: &[MemberCtx], s_run: f64, tol: f64) -> Option<ProfilePoint> {
+    let (i, local) = locate(ctxs, s_run);
+    let c = &ctxs[i];
+    forward_branch(c.m.kin, c.m.entry_v, &c.fwd_seg, &c.jerk, local, tol)
+}
+
+fn run_backward(ctxs: &[MemberCtx], s_run: f64, tol: f64) -> Option<ProfilePoint> {
+    let (i, local) = locate(ctxs, s_run);
+    let c = &ctxs[i];
+    backward_branch(c.m.kin, c.m.exit_v, &c.bwd_seg, &c.jerk, local, tol)
+}
+
+fn run_eval(ctxs: &[MemberCtx], s_run: f64, tol: f64) -> Option<ProfilePoint> {
+    let (i, local) = locate(ctxs, s_run);
+    let c = &ctxs[i];
+    eval_profile(
+        c.m.kin,
+        c.m.entry_v,
+        c.m.exit_v,
+        &c.fwd_seg,
+        &c.bwd_seg,
+        &c.jerk,
+        local,
+        tol,
+    )
+}
+
+fn base_samples(ctxs: &[MemberCtx], tol: f64) -> Option<Vec<(f64, f64, f64)>> {
+    let mut out: Vec<(f64, f64, f64)> = Vec::new();
+    for c in ctxs {
+        let mut sv = vec![(0.0, c.m.entry_v)];
+        refine(
+            c.m.kin,
+            c.m.entry_v,
+            c.m.exit_v,
+            &c.jerk,
+            tol,
+            0.0,
+            c.m.entry_v,
+            c.m.kin.length,
+            c.m.exit_v,
+            0,
+            &mut sv,
+        )?;
+        sv.push((c.m.kin.length, c.m.exit_v));
+        for (sl, v) in sv {
+            let s_run = c.m.fwd_s + sl;
+            if out.last().is_some_and(|p| (p.0 - s_run).abs() < 1e-12) {
+                continue;
+            }
+            let a = eval_profile(
+                c.m.kin,
+                c.m.entry_v,
+                c.m.exit_v,
+                &c.fwd_seg,
+                &c.bwd_seg,
+                &c.jerk,
+                sl,
+                tol,
+            )?
+            .a;
+            out.push((s_run, v, a));
+        }
+    }
+    Some(out)
+}
+
+struct Shot {
+    s_end: f64,
+    v_end: f64,
+    a_end: f64,
+}
+
+fn shoot(
+    ctxs: &[MemberCtx],
+    tol: f64,
+    s_left: f64,
+    v0: f64,
+    a0: f64,
+    j: f64,
+    accel_bound: f64,
+    right_forward: bool,
+) -> Option<Shot> {
+    let arc_at = |tau: f64| -> (f64, f64, f64) {
+        let a = a0 + j * tau;
+        let v = v0 + a0 * tau + 0.5 * j * tau * tau;
+        let s = s_left + v0 * tau + 0.5 * a0 * tau * tau + (1.0 / 6.0) * j * tau * tau * tau;
+        (s, v, a)
+    };
+    let right_a = |s: f64| -> Option<f64> {
+        if right_forward {
+            run_forward(ctxs, s, tol)
+        } else {
+            run_backward(ctxs, s, tol)
+        }
+        .map(|p| p.a)
+    };
+    let gap = |tau: f64| -> Option<f64> {
+        let (s, _, a) = arc_at(tau);
+        Some(a - right_a(s)?)
+    };
+    let tau_max = 1.05 * (a0.abs() + accel_bound) / j.abs();
+    let tau = scan_root(&gap, 0.0, tau_max, 32)?;
+    let (s_end, v_end, a_end) = arc_at(tau);
+    Some(Shot {
+        s_end,
+        v_end,
+        a_end,
+    })
+}
+
+fn scan_root<F: Fn(f64) -> Option<f64>>(f: &F, x0: f64, x1: f64, k: usize) -> Option<f64> {
+    let mut prev_x = x0;
+    let mut prev = f(x0);
+    if matches!(prev, Some(v) if v == 0.0) {
+        return Some(x0);
+    }
+    for i in 1..=k {
+        let x = x0 + (x1 - x0) * (i as f64) / (k as f64);
+        let cur = f(x);
+        if let (Some(p), Some(c)) = (prev, cur) {
+            if c == 0.0 {
+                return Some(x);
+            }
+            if p * c < 0.0 {
+                let (mut lo, mut hi) = (prev_x, x);
+                let s_lo = p.signum();
+                for _ in 0..ROOT_ITERS {
+                    let mid = 0.5 * (lo + hi);
+                    match f(mid) {
+                        Some(m) if m.signum() == s_lo => lo = mid,
+                        Some(_) => hi = mid,
+                        None => return None,
+                    }
+                }
+                return Some(0.5 * (lo + hi));
+            }
+        }
+        prev_x = x;
+        prev = cur;
+    }
+    None
+}
+
+fn build_run_bridge(
+    ctxs: &[MemberCtx],
+    tol: f64,
+    sa: f64,
+    sb: f64,
+    apex: f64,
+) -> Option<(f64, f64, Vec<(f64, f64, f64)>)> {
+    let (mid_i, _) = locate(ctxs, 0.5 * (sa + sb));
+    let jerk_mag = ctxs[mid_i].m.kin.jerk;
+    let accel = ctxs[mid_i].m.kin.accel;
+    if !jerk_mag.is_finite() {
+        return None;
+    }
+    let j = if apex > 0.0 { -jerk_mag } else { jerk_mag };
+
+    let left = |s: f64| -> Option<ProfilePoint> {
+        if apex > 0.0 {
+            run_forward(ctxs, s, tol)
+        } else {
+            run_backward(ctxs, s, tol)
+        }
+    };
+    let right_v = |s: f64| -> Option<f64> {
+        if apex > 0.0 {
+            run_backward(ctxs, s, tol)
+        } else {
+            run_forward(ctxs, s, tol)
+        }
+        .map(|p| p.v)
+    };
+
+    let gap = |s: f64| -> Option<f64> { Some(left(s)?.v - right_v(s)?) };
+    let half_max = {
+        let l = left(0.5 * (sa + sb)).map_or(1.0, |p| p.v);
+        l.max(1.0) * (2.0 * accel / jerk_mag)
+    };
+    let s_star = scan_root(&gap, sa - half_max, sb + half_max, 16)?;
+    let window = (3.0 * half_max).max(2.0 * (sb - sa));
+
+    let residual = |s_left: f64| -> Option<f64> {
+        let l = left(s_left)?;
+        let shot = shoot(ctxs, tol, s_left, l.v, l.a, j, accel, apex <= 0.0)?;
+        Some(shot.v_end - right_v(shot.s_end)?)
+    };
+    let s_left = scan_root(&residual, (s_star - window).max(0.0), s_star, 48)?;
+    let l = left(s_left)?;
+    let shot = shoot(ctxs, tol, s_left, l.v, l.a, j, accel, apex <= 0.0)?;
+    let s_right = shot.s_end;
+    if s_right <= s_left || s_right - s_left < BRIDGE_MIN_ARC_FRAC * (sb - sa).max(1e-6) {
+        return None;
+    }
+
+    let a0 = l.a;
+    let v0 = l.v;
+    let total_tau = (shot.a_end - a0) / j;
+    let n = 48usize;
+    let mut pts = Vec::with_capacity(n + 1);
+    for k in 0..=n {
+        let tau = total_tau * (k as f64) / (n as f64);
+        let a = a0 + j * tau;
+        let v = v0 + a0 * tau + 0.5 * j * tau * tau;
+        let s = s_left + v0 * tau + 0.5 * a0 * tau * tau + (1.0 / 6.0) * j * tau * tau * tau;
+        let env = {
+            let fv = run_forward(ctxs, s, tol)?.v;
+            let bv = run_backward(ctxs, s, tol)?.v;
+            fv.min(bv)
+        };
+        if v > env + 1e-6 * (1.0 + env) {
+            return None;
+        }
+        pts.push((s, v, a));
+    }
+    Some((s_left, s_right, pts))
+}
+
+fn reconstruct_flat(ctxs: &[MemberCtx], tol: f64) -> Option<Vec<(f64, f64, f64)>> {
+    let base = base_samples(ctxs, tol)?;
+    let mut bridges: Vec<(f64, f64, Vec<(f64, f64, f64)>)> = Vec::new();
+    for w in base.windows(2) {
+        let aa = w[0].2;
+        let ab = w[1].2;
+        if (aa - ab).abs() <= BRIDGE_EPS_A {
+            continue;
+        }
+        let apex = if aa > 0.0 && ab < 0.0 {
+            1.0
+        } else if aa < 0.0 && ab > 0.0 {
+            -1.0
+        } else {
+            continue;
+        };
+        if let Some(bridge) = build_run_bridge(ctxs, tol, w[0].0, w[1].0, apex) {
+            bridges.push(bridge);
+        }
+    }
+
+    let mut out: Vec<(f64, f64, f64)> = base
+        .into_iter()
+        .filter(|p| !bridges.iter().any(|(lo, hi, _)| p.0 > *lo && p.0 < *hi))
+        .collect();
+    for (_, _, pts) in bridges {
+        out.extend(pts);
+    }
+    out.sort_by(|x, y| x.0.partial_cmp(&y.0).unwrap_or(std::cmp::Ordering::Equal));
+    Some(out)
+}
+
+pub(super) fn reconstruct_run(
+    members: &[RunMember],
+    run_start_v: f64,
+    tol: f64,
+) -> Option<Vec<Vec<(f64, f64, f64)>>> {
+    let ctxs = build_ctxs(members, run_start_v)?;
+    let flat = reconstruct_flat(&ctxs, tol)?;
+
+    let mut per_member: Vec<Vec<(f64, f64, f64)>> = Vec::with_capacity(ctxs.len());
+    for c in &ctxs {
+        let s0 = c.m.fwd_s;
+        let s1 = c.m.fwd_s + c.m.kin.length;
+        let mut local: Vec<(f64, f64, f64)> = flat
+            .iter()
+            .filter(|p| p.0 >= s0 - 1e-9 && p.0 <= s1 + 1e-9)
+            .map(|p| ((p.0 - s0).clamp(0.0, c.m.kin.length), p.1, p.2))
+            .collect();
+        local.dedup_by(|a, b| (a.0 - b.0).abs() < 1e-12);
+        if local.first().is_none_or(|p| p.0 > 1e-9) {
+            let pt = run_eval(&ctxs, s0, tol)?;
+            local.insert(0, (0.0, pt.v, pt.a));
+        }
+        if local
+            .last()
+            .is_none_or(|p| (p.0 - c.m.kin.length).abs() > 1e-9)
+        {
+            let pt = run_eval(&ctxs, s1, tol)?;
+            local.push((c.m.kin.length, pt.v, pt.a));
+        }
+        if let Some(first) = local.first_mut() {
+            first.0 = 0.0;
+            first.1 = c.m.entry_v;
+        }
+        if let Some(last) = local.last_mut() {
+            last.0 = c.m.kin.length;
+            last.1 = c.m.exit_v;
+        }
+        per_member.push(local);
+    }
+    Some(per_member)
+}
+
+#[cfg(test)]
 pub(super) fn sample_profile(
     kin: &Kinematics,
     entry: f64,
     exit: f64,
-    jerk: &JerkAnchors,
+    anchors: &JerkAnchors,
     tol: f64,
-) -> Option<Vec<(f64, f64)>> {
-    let mut out = vec![(0.0, entry)];
-    refine(
-        kin, entry, exit, jerk, tol, 0.0, entry, kin.length, exit, 0, &mut out,
-    )?;
-    out.push((kin.length, exit));
-    Some(out)
+) -> Option<Vec<(f64, f64, f64)>> {
+    let member = RunMember {
+        kin,
+        entry_v: entry,
+        exit_v: exit,
+        fwd_s: anchors.fwd_s,
+        bwd_s: anchors.bwd_s,
+    };
+    reconstruct_run(&[member], anchors.fwd_v, tol)?
+        .into_iter()
+        .next()
 }
 
 #[cfg(test)]

--- a/rust/geometry/src/velocity/disk.rs
+++ b/rust/geometry/src/velocity/disk.rs
@@ -154,6 +154,16 @@ fn disk_rail_accel(accel: f64, kappa_abs: f64, v: f64) -> f64 {
     (accel * accel - a_n * a_n).max(0.0).sqrt()
 }
 
+/// Tangential acceleration cannot exceed the acceleration disk's remaining
+/// budget once centripetal `a_n = kappa*v^2` is spent: `a_t^2 + a_n^2 <= a^2`.
+/// At a biclothoid apex `a_n` saturates the disk, so the budget collapses to
+/// ~0 and the curvature-rate kink in `a_t` is pinned out instead of poking the
+/// reported acceleration past `a_max`.
+fn clamp_to_disk(a_t: f64, accel: f64, kappa_abs: f64, v: f64) -> f64 {
+    let budget = disk_rail_accel(accel, kappa_abs, v);
+    a_t.clamp(-budget, budget)
+}
+
 fn forward_seg(kin: &Kinematics, jerk: &JerkAnchors) -> Option<scurve::SevenSeg> {
     scurve::breakpoints(
         jerk.fwd_v,
@@ -662,6 +672,9 @@ pub(super) fn reconstruct_run(
         if let Some(last) = local.last_mut() {
             last.0 = c.m.kin.length;
             last.1 = c.m.exit_v;
+        }
+        for p in &mut local {
+            p.2 = clamp_to_disk(p.2, c.m.kin.accel, c.m.kin.kappa_abs(p.0), p.1);
         }
         per_member.push(local);
     }

--- a/rust/geometry/src/velocity/disk/tests.rs
+++ b/rust/geometry/src/velocity/disk/tests.rs
@@ -75,7 +75,7 @@ fn clothoid_samples_respect_the_acceleration_disk() {
     let accel = 1000.0;
     let k = kin(0.0, 0.05, 4.0, accel, f64::INFINITY, 300.0);
     let samples = sample_profile(&k, 250.0, 70.0, &single_move_anchors(250.0, 70.0), 1e-8).unwrap();
-    for &(s, v) in &samples {
+    for &(s, v, _a) in &samples {
         let kappa = (k.kappa0 + k.sigma * s).abs();
         let a_c = v * v * kappa;
         assert!(a_c <= accel + 1e-3, "a_c={a_c} at s={s}");

--- a/rust/geometry/src/velocity/scurve.rs
+++ b/rust/geometry/src/velocity/scurve.rs
@@ -145,6 +145,12 @@ pub(super) fn reach_velocity_with_accel(
     }
 }
 
+pub(super) fn reach_v(v0: f64, ds: f64, accel: f64, jerk: f64) -> Option<f64> {
+    reach_velocity_with_accel(v0, 0.0, ds, accel, jerk)
+        .ok()
+        .map(|(v, _)| v)
+}
+
 pub(super) fn breakpoints(
     v0: f64,
     a0: f64,

--- a/rust/geometry/src/velocity/tests.rs
+++ b/rust/geometry/src/velocity/tests.rs
@@ -604,3 +604,38 @@ fn warm_start_negative_or_nan_entry_is_invalid_config() {
         Err(VelocityError::InvalidConfig)
     );
 }
+
+#[test]
+fn pin_rest_anchor_raises_on_nonzero_entry_accel() {
+    let mut s = VelSample {
+        s: 0.0,
+        v: 0.0,
+        a: 5.0,
+    };
+    assert_eq!(
+        pin_rest_anchor(Some(&mut s), 7, 1.0e5),
+        Err(VelocityError::RestAnchorAccel { line_no: 7 })
+    );
+}
+
+#[test]
+fn pin_rest_anchor_zeroes_small_accel() {
+    let mut s = VelSample {
+        s: 0.0,
+        v: 0.0,
+        a: 1e-9,
+    };
+    assert_eq!(pin_rest_anchor(Some(&mut s), 7, 1.0e5), Ok(()));
+    assert_eq!(s.a, 0.0);
+}
+
+#[test]
+fn pin_rest_anchor_tolerates_infinite_jerk_step() {
+    let mut s = VelSample {
+        s: 0.0,
+        v: 0.0,
+        a: 200.0,
+    };
+    assert_eq!(pin_rest_anchor(Some(&mut s), 7, f64::INFINITY), Ok(()));
+    assert_eq!(s.a, 0.0);
+}

--- a/rust/geometry/tests/c2_continuity.rs
+++ b/rust/geometry/tests/c2_continuity.rs
@@ -15,6 +15,7 @@
 //! tangential-jerk-feasibility bug; it is bounded by `a_max` and is far below
 //! the `2*a_max` C1 crossover step this work targets.
 
+use geometry::path::CurvatureProfile;
 use geometry::{
     ChainFitConfig, Move, MoveContext, SourceRange, VelocityConfig, VelocityLimits, fit_chain,
     line_move, plan_velocity,
@@ -130,6 +131,38 @@ fn c2_accel_within_envelope() {
             smp.a.abs(),
             smp.s
         );
+    }
+}
+
+#[test]
+fn c2_tangential_within_acceleration_disk() {
+    // a_t^2 + a_n^2 <= a_max^2 everywhere: the reported tangential accel may not
+    // borrow against the centripetal budget. Catches the biclothoid-apex spike
+    // where curvature-ceiling tracking would otherwise push |a| past a_max.
+    let moves = serpentine();
+    let outcome = fit_chain(&moves, ChainFitConfig::default()).unwrap();
+    let profile = plan_velocity(
+        &outcome,
+        VelocityConfig {
+            consistency_tol: 1e-6,
+            max_jerk_mm_s3: JERK,
+            integration_tol: 1e-7,
+        },
+    )
+    .unwrap();
+    for (gm, vm) in outcome.moves.iter().zip(profile.moves.iter()) {
+        let seg = gm.segment.spatial.as_ref().unwrap();
+        for smp in &vm.samples {
+            let kappa = seg.kappa(smp.s.clamp(0.0, seg.s_len())).abs();
+            let a_n = kappa * smp.v * smp.v;
+            let disk = (smp.a * smp.a + a_n * a_n).sqrt();
+            assert!(
+                disk <= ACCEL + 1e-3,
+                "disk magnitude {disk:.3} exceeds a_max={ACCEL} at s={:.4} (a_t={:.2}, a_n={a_n:.2})",
+                smp.s,
+                smp.a
+            );
+        }
     }
 }
 

--- a/rust/geometry/tests/c2_continuity.rs
+++ b/rust/geometry/tests/c2_continuity.rs
@@ -1,0 +1,143 @@
+//! T3 acceptance: the live velocity planner is C2-within-run / C1-at-rest.
+//!
+//! Reproduces the demo4 serpentine and asserts, reading the planned analytic
+//! `a_t` (never finite-differenced):
+//!   * accel-from-rest is a full-jerk trapezoid, not the C1 `(2/9)*jerk`
+//!     velocity-ceiling ride (`max_reachable_velocity`);
+//!   * tangential acceleration is continuous across mid-run junctions — the
+//!     `+max -> -max` cruise/decel crossover step is dissolved by the bridge;
+//!   * `|a_t| <= a_max` everywhere and `(v,a)=(0,0)` is pinned at rest anchors.
+//!
+//! Carve-out: the biclothoid corner apex carries a small tangential `a_t` step
+//! (`a_t` tracks the curvature speed-limit slope `v*dv_lim/ds`, which inherits
+//! the clothoid's `dkappa/ds` jump — a G2-not-G3 property). Per spec-motion-12
+//! that lateral-jerk-induced step is the fitter shape's responsibility, not a
+//! tangential-jerk-feasibility bug; it is bounded by `a_max` and is far below
+//! the `2*a_max` C1 crossover step this work targets.
+
+use geometry::{
+    ChainFitConfig, Move, MoveContext, SourceRange, VelocityConfig, VelocityLimits, fit_chain,
+    line_move, plan_velocity,
+};
+
+const MAX_V: f64 = 150.0;
+const ACCEL: f64 = 200.0;
+const JERK: f64 = 4000.0;
+const SCV: f64 = 5.0;
+
+fn ctx(line_no: u32) -> MoveContext {
+    MoveContext {
+        extruder_axis: 0,
+        feedrate_mm_s: MAX_V,
+        limits: VelocityLimits::try_new(MAX_V, ACCEL, SCV).unwrap(),
+        source: SourceRange {
+            start_line: line_no,
+            end_line: line_no,
+        },
+    }
+}
+
+fn serpentine() -> Vec<Move> {
+    let pts = [
+        [0.0, 0.0, 0.0],
+        [90.0, 0.0, 0.0],
+        [90.0, 90.0, 0.0],
+        [180.0, 90.0, 0.0],
+        [180.0, 0.0, 0.0],
+    ];
+    pts.windows(2)
+        .enumerate()
+        .map(|(i, w)| line_move(w[0], w[1], 0.0, ctx(i as u32)).unwrap())
+        .collect()
+}
+
+struct Sample {
+    s: f64,
+    v: f64,
+    a: f64,
+}
+
+fn plan_samples() -> Vec<Sample> {
+    let moves = serpentine();
+    let outcome = fit_chain(&moves, ChainFitConfig::default()).unwrap();
+    let config = VelocityConfig {
+        consistency_tol: 1e-6,
+        max_jerk_mm_s3: JERK,
+        integration_tol: 1e-7,
+    };
+    let profile = plan_velocity(&outcome, config).unwrap();
+    let mut out = Vec::new();
+    let mut s_off = 0.0;
+    for m in &profile.moves {
+        for smp in &m.samples {
+            out.push(Sample {
+                s: s_off + smp.s,
+                v: smp.v,
+                a: smp.a,
+            });
+        }
+        s_off += m.length;
+    }
+    out
+}
+
+#[test]
+fn c2_accel_from_rest_is_full_jerk_trapezoid() {
+    // By s=0.5mm a full-jerk ramp has long since reached the accel plateau
+    // (a=a_max at s~0.08mm). The C1 (2/9)*jerk ceiling-ride is still climbing
+    // there: a ~ (2/3)*jerk^(2/3)*s^(1/3) ~ 0.66*a_max. Reading the plateau
+    // separates the two unambiguously.
+    let s = plan_samples();
+    let probe = s
+        .iter()
+        .find(|p| p.s >= 0.5)
+        .expect("profile reaches 0.5mm");
+    assert!(
+        probe.a >= 0.9 * ACCEL,
+        "accel-from-rest a_t={:.2} at s={:.3} should be on the a_max plateau \
+         ({ACCEL}); the C1 (2/9)*jerk ceiling ride only reaches ~{:.1} here",
+        probe.a,
+        probe.s,
+        0.66 * ACCEL
+    );
+    assert!(probe.a <= ACCEL + 1e-6, "a_t must not exceed a_max");
+}
+
+#[test]
+fn c2_no_crossover_accel_step() {
+    // The C1 cruise/decel crossover steps a_t by 2*a_max (+max -> -max). After
+    // bridging, no adjacent pair may step by even a_max — the corner κ' carve-out
+    // stays well under that bound.
+    let s = plan_samples();
+    for w in s.windows(2) {
+        let step = (w[1].a - w[0].a).abs();
+        assert!(
+            step < ACCEL,
+            "tangential accel steps {step:.3} (>= {ACCEL}) at s={:.4}: {:.3} -> {:.3}",
+            w[0].s,
+            w[0].a,
+            w[1].a
+        );
+    }
+}
+
+#[test]
+fn c2_accel_within_envelope() {
+    for smp in &plan_samples() {
+        assert!(
+            smp.a.abs() <= ACCEL + 1e-6,
+            "|a_t|={:.4} exceeds a_max={ACCEL} at s={:.4}",
+            smp.a.abs(),
+            smp.s
+        );
+    }
+}
+
+#[test]
+fn c2_zero_state_at_rest_anchors() {
+    let s = plan_samples();
+    let first = s.first().unwrap();
+    let last = s.last().unwrap();
+    assert_eq!((first.v, first.a), (0.0, 0.0));
+    assert_eq!((last.v, last.a), (0.0, 0.0));
+}

--- a/rust/motion-engine/src/viz.rs
+++ b/rust/motion-engine/src/viz.rs
@@ -229,6 +229,7 @@ fn sample_kinematics(
                 let heading = spatial.heading_at(s_local);
                 kin.s.push(s_offset + sample.s);
                 kin.v.push(sample.v);
+                kin.a_t.push(sample.a);
                 kin.heading_x.push(heading[0]);
                 kin.heading_y.push(heading[1]);
                 kin.kappa.push(spatial.kappa(s_local));
@@ -238,7 +239,6 @@ fn sample_kinematics(
         s_offset += vel_move.length;
     }
 
-    kin.a_t = tangential_accel(&kin.s, &kin.v);
     kin.j_t = tangential_jerk(&kin.s, &kin.v, &kin.a_t);
 
     for i in 0..kin.s.len() {
@@ -255,34 +255,6 @@ fn sample_kinematics(
     }
 
     kin
-}
-
-fn tangential_accel(s: &[f64], v: &[f64]) -> Vec<f64> {
-    let n = s.len();
-    let mut a = vec![0.0; n];
-    if n < 2 {
-        return a;
-    }
-    let pair_dt = |i: usize, k: usize| -> f64 {
-        let ds = (s[k] - s[i]).abs();
-        let v_sum = v[i] + v[k];
-        if v_sum > 0.0 { 2.0 * ds / v_sum } else { 0.0 }
-    };
-    for i in 0..n {
-        let (lo, hi, span) = if i == 0 {
-            (0, 1, pair_dt(0, 1))
-        } else if i == n - 1 {
-            (n - 2, n - 1, pair_dt(n - 2, n - 1))
-        } else {
-            (i - 1, i + 1, pair_dt(i - 1, i) + pair_dt(i, i + 1))
-        };
-        a[i] = if span > 0.0 {
-            (v[hi] - v[lo]) / span
-        } else {
-            0.0
-        };
-    }
-    a
 }
 
 fn tangential_jerk(s: &[f64], v: &[f64], a: &[f64]) -> Vec<f64> {


### PR DESCRIPTION
## What

Motion-12 **T3** (the crux): promote tangential acceleration from a *derived* quantity to **planned state carried across junctions within a run**, so the live velocity planner is **C2-within-run / C1-at-rest** instead of C1 everywhere.

The C1 planner modelled tangential jerk as a *velocity ceiling* and reconstructed `a_t` implicitly, so acceleration was jerk-shaped only off a rest anchor and **stepped discontinuously at every mid-run velocity extremum** (cruise→decel peaks, decel-into-corner valleys) — effectively unbounded tangential jerk exactly where the machine feels it.

## How

- **Per-run reconstruction** replaces the per-move `min()`-of-velocity-ceilings. Each sample's `a_t` is the **closed-form accel of the binding rail** — scurve jerk ramp from the run anchor (`accel_at`), disk rail `±√(a²−κ²v⁴)`, or curvature-ceiling tracking `v·dv_lim/ds = −½·a·σ·sign(κ)/κ²` — **never finite-differenced** (the failure mode of the prior reverted attempt).
- **Crossover jerk-bridge**: apex (`a:+→−`) and valley (`a:−→+`) crossovers — including those landing on move boundaries — are dissolved by a single closed-form seven-segment arc. The splice point is a bounded 1-D root; the arc is validated to stay under both envelopes.
- **Node sweep** switches its jerk term from `max_reachable_velocity` (the accel-returns-to-0 ceiling `(j·s²)^⅓` that produced the C1 `(2/9)·jerk` from-rest ride) to the carried `reach_velocity_with_accel`. Accel-from-rest is now a full-jerk trapezoid, and C2 is *faster* than C1 off rest.
- **`(0,0)` pinned at rest anchors**; a finite-jerk run reaching a rest anchor with `|a_entry|>ε` raises `RestAnchorAccel` (fail-loud, AC-C6).
- `VelSample` carries analytic `a`; **viz reads it directly** instead of finite-differencing the planned `(s,v)`.

## Validation (demo4 serpentine, `v150 / a200 / jerk4000 / scv5`)

- Accel-from-rest is on the `a_max` plateau by `s≈0.08 mm` (C1 ride only reaches `~0.66·a_max` at `s=0.5 mm`).
- Every straight `+max→−max` cruise/decel crossover is bridged — no adjacent `|Δa_t|` reaches `a_max` (the C1 step was `2·a_max`).
- `|a_t| ≤ a_max` everywhere; `(v,a)=(0,0)` at both run ends.
- **Carve-out:** the only residual `a_t` step (`~66 mm/s² < a_max`) is at the biclothoid corner apex, where ceiling-riding `a_t` inherits the clothoid's `dκ/ds` jump (G2-not-G3). Per the spec Non-Goals this lateral-jerk-induced step is the fitter shape's responsibility (a G3 corner fitter is a separate spec), not the tangential crossover this work targets. See `investigations/clothoid-straight-seam-discontinuity-investigation.md`.

## Tests / gates

- New `rust/geometry/tests/c2_continuity.rs`: from-rest trapezoid, no-crossover-step, `|a|≤a_max`, rest-anchor `(0,0)`.
- `pin_rest_anchor` fail-loud / zero / infinite-jerk unit tests (negative-test obligation for the new error).
- `./scripts/ci.sh quick` green (ruff, rust-test, clippy `-D warnings`, fmt, watchdog-canary); full geometry (320) + motion-engine (369) suites pass.

## Scope

T3 only. **T4** (CI feasibility-gate job, mutation test AC-G1, throughput non-regression AC-G3, anti-circularity AC-G5/G6) is intentionally **not** in this change set — the durable CI/throughput gate is still owed under T4. The SOCP deletion remains Motion-13.