### PR TITLE
fix(homing): G28 crash + drip not interrupted on endstop trip (post-#87)

### DIFF
--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -667,20 +667,6 @@ class Motion:
         self.min_cruise_ratio = 0.0
         self.orig_cfg = {}
 
-    def _axis_limit(self, axis, kind):
-        kind_idx = {"max_velocity": 2, "max_accel": 3, "max_jerk": 4}[kind]
-        caps = [
-            section[kind_idx]
-            for section in self.limit_sections
-            if axis in section[1] and section[kind_idx] is not None
-        ]
-        if not caps:
-            raise self.printer.config_error(
-                "no [limit] section declares %s covering axis '%s'"
-                % (kind, axis)
-            )
-        return min(caps)
-
     def _sync_print_time(self):
         if self.mcu is None:
             return

--- a/klippy/motion_kinematics.py
+++ b/klippy/motion_kinematics.py
@@ -273,8 +273,8 @@ class _LinearKinematics:
         self._check_endstops(move)
         z_ratio = move.move_d / abs(move.axes_d[2])
         move.limit_speed(
-            self._motion._axis_limit("z", "max_velocity") * z_ratio,
-            self._motion._axis_limit("z", "max_accel") * z_ratio,
+            self._motion.max_z_velocity * z_ratio,
+            self._motion.max_z_accel * z_ratio,
         )
 
     def set_position(self, newpos, homing_axes=()):

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -3999,6 +3999,7 @@ impl PyMotionEngine {
                 self.finish_homing();
                 let (trip_pos, final_pos, trip_clock) = result.map_err(PyRuntimeError::new_err)?;
                 *self.commanded_pos.lock().unwrap_or_else(|p| p.into_inner()) = final_pos;
+                self.reanchor_after_trip(final_pos)?;
                 Ok(Some((trip_pos, final_pos, trip_clock)))
             }
         }
@@ -4357,6 +4358,16 @@ impl PyMotionEngine {
             .unwrap_or_else(|p| p.into_inner()) = None;
         *self.homing_run.lock().unwrap_or_else(|p| p.into_inner()) = None;
         *self.homing_result.lock().unwrap_or_else(|p| p.into_inner()) = None;
+    }
+
+    fn reanchor_after_trip(&self, stop_pos: [f64; 3]) -> PyResult<()> {
+        let guard = self.planner.lock().unwrap_or_else(|p| p.into_inner());
+        match guard.as_ref() {
+            Some(planner) => planner
+                .reset(vec![stop_pos[0], stop_pos[1], stop_pos[2], 0.0])
+                .map_err(planner_err),
+            None => Ok(()),
+        }
     }
 
     fn ethercat_conn(&self, mcu_handle: u32, what: &str) -> PyResult<Arc<McuSerialConn>> {

--- a/test/test_motion_kinematics.py
+++ b/test/test_motion_kinematics.py
@@ -214,13 +214,8 @@ class FakeMotion:
     def __init__(self, axis_sections=()):
         self.engine = FakeEngine()
         self.axis_sections = list(axis_sections)
-        self._limits = {
-            ("z", "max_velocity"): 10.0,
-            ("z", "max_accel"): 100.0,
-        }
-
-    def _axis_limit(self, axis, kind):
-        return self._limits[(axis, kind)]
+        self.max_z_velocity = 10.0
+        self.max_z_accel = 100.0
 
 
 def motor_section(**extra):


### PR DESCRIPTION
Two independent homing regressions introduced by #87 (the geometry-pipeline / `[printer]`-limits cutover). Both root-caused and verified on the Neptune EtherCAT bench.

## Bug 1 — `G28` shuts down before anything moves
`motion_kinematics.check_move` capped Z-moves via `Motion._axis_limit("z", …)`, which only ever read the `[limit <name>]` sections. #87 migrated motion limits to `[printer]` and stopped populating those sections, so every kinematic Z-move (safe_z_home `z_hop`, the homing retract) raised:

```
configparser.Error: no [limit] section declares max_velocity covering axis 'z'
```

…and shut the printer down on `G28`. Pure-XY jogs survived because `check_move` returns before the Z branch — hence the "set kinematic position + jog works" workaround.

**Fix:** cap Z from the `[printer]` `max_z_velocity`/`max_z_accel` that `_read_limits` already populates, and delete the orphaned `_axis_limit`.

## Bug 2 — endstop trips but the drip move isn't interrupted
After the endstop tripped, the carriage stopped but the host waited out the **remaining planned-travel duration** before retracting (worst when starting close to the endstop — e.g. ~12 s after only 5 mm of travel; ~6 s after 123 mm).

Chain: trip → `broadcast_stop` truncates the queued move on the MCU and `ResumeStream` reopens the MCU stream, but nothing re-grounded the host `StreamPlanner`. Its `Flush` deadline is `sync_instant + (t_committed + LEAD)` = *(move start) + (full planned duration)*, so `set_position → flush_step_generation → engine.wait_moves → planner.flush()` slept until wall-clock reached the original planned move-end. The pre-#87 planner reset its timeline on trip; the stream-planner swap in #87 dropped that.

**Fix:** `home_axis_poll` now re-anchors the planner odometer/sync to the reconstructed stop position (`reanchor_after_trip`), so `flush()` has nothing pending and the retract fires immediately.

## Verification
- Bench: `G28 X` from next to the endstop now retracts immediately (the ~12 s dead-time is gone); no `_axis_limit` shutdown.
- `./scripts/ci.sh quick` green (ruff, rust-test, rust-clippy, rust-fmt, watchdog-canary). 369 motion-engine tests pass. Affected Python motion/limit/homing tests pass (151) — full `ci.sh py` needs Docker, run it in CI.

## Out of scope (pre-existing, not from these fixes)
- `resync_parked_servos` → `KeyError: 'x'` (`motion.py:352`): `query_motor_positions()` returns no `x` key for the EtherCAT-X servo. Predates #87.
- Intermittent EtherCAT X-servo drive fault `0xfecc` at endstop contact on a cold first homing (drive parked by the realtime endpoint); self-clears on restart. Servo-tuning matter, surfaced loudly by design.