### PR TITLE
refactor: strip comment blocks from motion planner rust + python

### DIFF
--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -68,7 +68,6 @@ class Move:
         self.axes_d = axes_d = [end_pos[i] - start_pos[i] for i in (0, 1, 2, 3)]
         self.move_d = move_d = math.sqrt(sum([d * d for d in axes_d[:3]]))
         if move_d < 0.000000001:
-            # Extrude only move
             self.end_pos = (
                 start_pos[0],
                 start_pos[1],
@@ -328,10 +327,8 @@ class Motion:
         self.dwell(delay)
 
     def cmd_M204(self, gcmd):
-        # Use S for accel
         accel = gcmd.get_float("S", None, above=0.0)
         if accel is None:
-            # Use minimum of P and T for accel
             p = gcmd.get_float("P", None, above=0.0)
             t = gcmd.get_float("T", None, above=0.0)
             if p is None or t is None:
@@ -354,8 +351,6 @@ class Motion:
         self.kin.clear_parked_dirty(dirty)
 
     def move(self, newpos, speed):
-        # The engine replaces the lookahead, but Move/kin/extruder validation
-        # (unhomed, range checks) must still run before the move is issued.
         self.resync_parked_servos()
         move = Move(self, self.commanded_pos, newpos, speed)
         if not move.move_d:
@@ -389,33 +384,23 @@ class Motion:
         self._sync_print_time()
 
     def move_curve(self, newpos, interior_control_points, submit, speed):
-        # newpos: [x, y, z, e] absolute endpoint (already coordinate-resolved).
-        # interior_control_points: list of [x, y, z] interior CPs to range-check
-        #   (P0=start and the endpoint are covered by the endpoint check below).
-        # submit(dx, dy, dz, de, feedrate): engine call carrying the curve params.
         self.resync_parked_servos()
         move = Move(self, self.commanded_pos, newpos, speed)
         if move.is_kinematic_move:
             self.kin.check_move(move)
         if move.axes_d[3]:
             self.extruder.check_move(move)
-        # Convex-hull range guard: a Bézier can bulge outside the endpoint box.
         for cp in interior_control_points:
             cp_target = [cp[0], cp[1], cp[2], self.commanded_pos[3]]
             cp_move = Move(self, self.commanded_pos, cp_target, speed)
             if cp_move.move_d and cp_move.is_kinematic_move:
                 self.kin.check_move(cp_move)
-        # Deltas come straight from the endpoint, NOT move.axes_d: for a
-        # closed-loop curve (chord ~ 0) Move zeroes axes_d, which would drop the
-        # curve's endpoint delta. The engine rejects a genuinely zero curve
-        # (arc length 0 -> ZeroDisplacement), so no early-return here.
-        dx = newpos[0] - self.commanded_pos[0]
-        dy = newpos[1] - self.commanded_pos[1]
-        dz = newpos[2] - self.commanded_pos[2]
-        de = newpos[3] - self.commanded_pos[3]
-        # Feedrate is the path-speed cap; the chord length is meaningless for a
-        # curve, so cap directly. The Rust optimizer re-derives per-axis limits.
-        feedrate = min(speed, self.max_velocity)
+        endpoint_delta = [
+            newpos[i] - self.commanded_pos[i] for i in (0, 1, 2, 3)
+        ]
+        dx, dy, dz, de = endpoint_delta
+        path_speed_cap = min(speed, self.max_velocity)
+        feedrate = path_speed_cap
         if abs(dz) > 1e-9 and abs(dx) < 1e-9 and abs(dy) < 1e-9:
             feedrate = min(feedrate, self.max_z_velocity)
         self._fire_active_callbacks([dx, dy, dz, de])
@@ -439,9 +424,6 @@ class Motion:
                 owners.extend(rail.get_steppers())
         if abs(de) > 1e-9:
             owners.extend(self.follower_steppers)
-        # Motion pieces stream to every queue, including servo axes that hold
-        # still — so every servo must be powered the moment any motion starts,
-        # or the ec-rt torque gate faults on pieces-while-parked.
         owners.extend(
             rail
             for rail in getattr(self.kin, "rails", ())
@@ -527,9 +509,6 @@ class Motion:
         return floor
 
     def _ground_pending_end_time_after_engine_drain(self):
-        # wait_moves() means dispatched, not executed; ground subsequent
-        # cross-MCU scheduling in the live MCU clock rather than a stale,
-        # possibly-seconds-ahead projected motion end.
         if self.mcu is None:
             return
         est = self.mcu.estimated_print_time(self.reactor.monotonic())
@@ -654,8 +633,6 @@ class Motion:
         self.max_z_accel = config.getfloat(
             "max_z_accel", self._max_accel, above=0.0, maxval=self._max_accel
         )
-        # [limit <name>] sections are still parsed so existing configs load,
-        # but the planner now reads its motion limits from [printer] above.
         self.limit_sections = []
         for sc in config.get_prefix_sections("limit "):
             name = sc.get_name().split(None, 1)[1]
@@ -850,13 +827,6 @@ class Motion:
             raise
 
     def _follower_slots(self):
-        # Unclaimed follower axes ([axis <name>] with motors, not bound to a
-        # kinematics lane) occupy the motion slots NOT owned by a lane, in
-        # declared order. The slot is the free-slot position, NOT the raw
-        # declared-section index: an [include] that declares the follower before
-        # the spatial axes must not let it overwrite a lane slot (e.g. corexy
-        # motor A on slot 0). One source of truth so the stepper binding and the
-        # MCU-topology handle map cannot disagree.
         claimed = set(self.kin.claimed_axes())
         lane_slots = {
             lane_idx for lane_idx, _axis_name, _motor_names in self.kin.lanes()
@@ -900,14 +870,15 @@ class Motion:
 
         slot_steppers = self._build_slot_steppers()
 
-        PHASE_STEPPING_BIT = 0x1  # bit 0 of the IdentifyResponse caps bitmap
+        PHASE_STEPPING_CAPABILITY_BIT = 0x1
+        STEP_MODE_MODULATED = 0
+        STEP_MODE_STEP_TIME = 1
 
         for name, mcu_obj, mcu_handle in engine_mcus:
             present_mask = 0
             invert_mask = 0
             steps_per_mm = [0.0, 0.0, 0.0, 0.0]
-            # 0=Modulated (phase stepping), 1=StepTime; overridden per slot below.
-            step_modes = [1, 1, 1, 1]
+            step_modes = [STEP_MODE_STEP_TIME] * 4
             bind_list = []
             for i in range(4):
                 on_this_mcu = []
@@ -931,26 +902,16 @@ class Motion:
                 if getattr(primary, "_invert_dir", False):
                     invert_mask |= 1 << i
                 if getattr(primary, "phase_stepping", False):
-                    step_modes[i] = 0  # Modulated
+                    step_modes[i] = STEP_MODE_MODULATED
                 for sname, s in on_this_mcu:
                     inv = 1 if getattr(s, "_invert_dir", False) else 0
                     bind_list.append((i, sname, s.get_oid(), inv))
-            # One (bus_id, cs_pin_id, slot_idx) per physical phase-stepped motor;
-            # AWD partners share slot_idx but get their own entry so each
-            # TMC5160's XDIRECT register is written. Empty = no phase stepping.
             phase_configs = []
             any_phase_stepping = False
-            # On corexy kinematics the A and B motors (slots 0 and 1) move
-            # together for any X or Y motion, so a homing trip on either
-            # axis must switch ALL of them out of phase mode — one merged
-            # handover group. Cartesian axes move independently: one group
-            # per slot.
             xy_coupled = coupled
             phase_groups = {}
             for i, slot in enumerate(slot_steppers):
-                # step_modes[i] != 0 is the load-bearing guard (set to 0 only in
-                # the on_this_mcu branch, so cross-MCU slots stay != 0).
-                if step_modes[i] != 0 or not slot:
+                if step_modes[i] != STEP_MODE_MODULATED or not slot:
                     continue
                 group_key = "xy" if (xy_coupled and i in (0, 1)) else i
                 slot_tmcs = phase_groups.setdefault(group_key, [])
@@ -980,15 +941,12 @@ class Motion:
             for group in phase_groups.values():
                 for tmc in group:
                     tmc.set_phase_group(group)
-            # Soft cap mirrors firmware-side MAX_STEPPER_OIDS=16 (see
-            # rust/runtime/src/state.rs). Reject early with an
-            # operator-friendly message rather than letting the engine
-            # call return PyRuntimeError.
-            if len(phase_configs) > 16:
+            FIRMWARE_MAX_PHASE_STEPPED_MOTORS = 16
+            if len(phase_configs) > FIRMWARE_MAX_PHASE_STEPPED_MOTORS:
                 raise self.printer.config_error(
                     "phase_stepping enabled on %d motors but the firmware "
-                    "supports up to 16 phase-stepped motors total per MCU."
-                    % len(phase_configs)
+                    "supports up to %d phase-stepped motors total per MCU."
+                    % (len(phase_configs), FIRMWARE_MAX_PHASE_STEPPED_MOTORS)
                 )
             awd_mask = awd_default & present_mask
             if present_mask == 0:
@@ -998,14 +956,11 @@ class Motion:
                     name,
                 )
                 continue
-            # Capability check: any stepper requesting phase_stepping=True on
-            # an MCU that does not advertise PHASE_STEPPING_CAPABLE is a
-            # config error. The check happens here (connect time) because MCU
-            # capabilities are only known after attach_serial / identify, which
-            # runs after config-parse time.
             mcu_caps = self.engine.get_mcu_capabilities(mcu_handle)
             for i in range(4):
-                if step_modes[i] == 0 and not (mcu_caps & PHASE_STEPPING_BIT):
+                if step_modes[i] == STEP_MODE_MODULATED and not (
+                    mcu_caps & PHASE_STEPPING_CAPABILITY_BIT
+                ):
                     slot_name = (
                         slot_steppers[i][0][0]
                         if slot_steppers[i]
@@ -1022,11 +977,6 @@ class Motion:
                         "large runtime profile for the chip family) and "
                         "reflash." % (slot_name, name, mcu_caps)
                     )
-            # One kalico_configure_axis per axis carries a 4-byte-per-stepper
-            # blob { stepper_oid: u8, dir_invert: u8, tmc_cs_oid: u8, flags: u8 }.
-            # dir_invert (from `dir_pin: !PIN`) is forwarded because engine mode
-            # bypasses stepcompress's step-count sign flip; without it motors run
-            # reversed. MCUs lacking the command skip silently.
             try:
                 configure_axis_cmd = mcu_obj.lookup_command(
                     "kalico_configure_axis axis_idx=%c mode=%c"
@@ -1042,10 +992,6 @@ class Motion:
                 )
                 continue
 
-            # Reset before (re)configuring: the engine's ring allocator never
-            # frees and configure_axis re-runs every klippy:connect, so a
-            # reconnect without an MCU reboot would overflow the pool. Idempotent
-            # on a fresh MCU; same queue, so it runs before configure_axis.
             try:
                 reset_cmd = mcu_obj.lookup_command("runtime_reset")
             except Exception:
@@ -1058,9 +1004,6 @@ class Motion:
                 )
 
             if any_phase_stepping:
-                # Two-stage registration: shared SPI cfg once per bus_id, then a
-                # CS GPIO per motor (multiple drivers on one bus each need their
-                # own CS). motor_idx MUST match the phase_configs list position.
                 seen_buses = set()
                 for bus_id, _cs_pin_id, _slot_idx in phase_configs:
                     if bus_id == 0xFF:
@@ -1101,8 +1044,8 @@ class Motion:
             for slot_idx, sname, oid, inv in bind_list:
                 axis_bindings[slot_idx].append((sname, oid, inv))
 
-            MODE_PULSE = 0  # wire encoding: 0=Pulse, 1=Phase
-            MODE_PHASE = 1  # (host step_modes list: 0=Modulated, 1=StepTime)
+            MODE_PULSE = 0
+            MODE_PHASE = 1
             TMC_CS_OID_NONE = 0xFF
             FLAGS_DEFAULT = 0
 
@@ -1115,12 +1058,11 @@ class Motion:
                 if spm <= 0:
                     continue
                 microstep_distance = 1.0 / spm
-                # f32 packed as u32 bits for the wire.
                 microstep_bits = struct.unpack(
                     "<I", struct.pack("<f", microstep_distance)
                 )[0]
-                # extrusion_per_xy_mm unused by firmware; sent 0 for ABI compat.
-                extrusion_bits = 0
+                UNUSED_EXTRUSION_PER_XY_BITS = 0
+                extrusion_bits = UNUSED_EXTRUSION_PER_XY_BITS
                 blob = bytearray()
                 for motor_idx, (sname, oid, inv) in enumerate(bindings):
                     self._motor_bindings[sname] = (
@@ -1131,7 +1073,7 @@ class Motion:
                     blob.append(oid)
                     blob.append(inv & 0x01)
                     tmc_oid = TMC_CS_OID_NONE
-                    if step_modes[axis_idx] == 0:
+                    if step_modes[axis_idx] == STEP_MODE_MODULATED:
                         tmc_name = "tmc5160 " + sname
                         try:
                             tmc = self.printer.lookup_object(tmc_name)
@@ -1144,7 +1086,9 @@ class Motion:
                     mcu_handle, axis_idx
                 )
                 axis_mode = (
-                    MODE_PHASE if step_modes[axis_idx] == 0 else MODE_PULSE
+                    MODE_PHASE
+                    if step_modes[axis_idx] == STEP_MODE_MODULATED
+                    else MODE_PULSE
                 )
                 configure_axis_cmd.send(
                     [
@@ -1176,8 +1120,6 @@ class Motion:
                 any_phase_stepping,
                 len(phase_configs),
             )
-            # phase_stepping_enable_spi is sent later from
-            # TMC5160._xdirect_preload, after TMC register init.
 
     def cmd_DIAG_DUMP(self, gcmd):
         sent = []

--- a/klippy/motion_endstop.py
+++ b/klippy/motion_endstop.py
@@ -67,8 +67,6 @@ class RemoteMotionEndstop:
     provider's job, via trip_move_begin/trip_move_end."""
 
     def __init__(self, printer, mcu, trsync_oid):
-        # Constructed at provider config-load time, possibly before
-        # motion_engine exists — look the engine up lazily at arm time.
         self._printer = printer
         self.mcu = mcu
         self.trsync_oid = trsync_oid

--- a/klippy/motion_engine.py
+++ b/klippy/motion_engine.py
@@ -5,14 +5,10 @@ except ImportError:
 
 from . import structured_log
 
-# print_id is already bound when these fire, so the handler pushes the current
-# session + print context.
 _PRINT_ACTIVE_EVENTS = (
     "print_stats:start_printing",
     "print_stats:paused_printing",
 )
-# These fire BEFORE print_id is cleared, so the handler must push an explicit
-# empty print_id rather than read the still-stale module global.
 _PRINT_FINISH_EVENTS = (
     "print_stats:complete_printing",
     "print_stats:error_printing",
@@ -21,10 +17,6 @@ _PRINT_FINISH_EVENTS = (
 )
 
 
-# Methods that issue real motion/planner/MCU traffic. Under the stub engine
-# these MUST raise, not return None — a None would make Motion.move()
-# compute `None - None`, hanging the test suite on a path that reached real
-# motion without a real engine.
 _STUB_MOTION_METHODS = frozenset(
     {
         "submit_nudge",
@@ -71,10 +63,6 @@ _STUB_MOTION_METHODS = frozenset(
 
 
 def attach_structured_logging(native, printer, events_dir):
-    # Must run after session_id is bound (printer.py startup) and before any MCU
-    # attach/configure that could emit a Rust log. events_dir is None with no
-    # logfile (--debugoutput): the jsonl sink is skipped but session context is
-    # still pushed.
     if events_dir:
         native.init_logging(events_dir)
     native.set_session_context(
@@ -296,12 +284,9 @@ class MotionEngineWrapper:
         return bytes(self._engine.get_identify_data(mcu_handle))
 
     def get_mcu_capabilities(self, mcu_handle):
-        # Bit 0 = PHASE_STEPPING_CAPABLE; 0 for stock-Klipper MCUs or before
-        # attach_serial completes.
         return self._engine.get_mcu_capabilities(mcu_handle)
 
     def ring_depth_for_axis(self, mcu_handle, axis_idx):
-        # Requires init_planner first.
         return self._engine.ring_depth_for_axis(mcu_handle, axis_idx)
 
     def register_phase_bus(self, mcu_handle, bus_id, rate, timeout_s=5.0):

--- a/klippy/motion_kinematics.py
+++ b/klippy/motion_kinematics.py
@@ -67,11 +67,8 @@ def load_kinematics(config, motion):
             "[kinematics] type '%s' is not supported (supported: %s)"
             % (kind, ", ".join(sorted(KINEMATICS_TYPES)))
         )
-    # Frontends (Moonraker/Mainsail) read [printer] kinematics to detect a
-    # motion system and hide the movement panel when it resolves to 'none'.
-    # [kinematics] stays authoritative; mirror its type onto [printer]'s
-    # reported settings so the frontend sees a real kinematics.
-    config.getsection("printer").get("kinematics", kind)
+    frontend_visible_kinematics = kind
+    config.getsection("printer").get("kinematics", frontend_visible_kinematics)
     role_specs = KINEMATICS_TYPES[kind]
     kin = _LinearKinematics(config, motion, kind, role_specs)
     _reject_orphan_motors(config, motion, section, role_specs)

--- a/rust/gcode/tests/property_lex.rs
+++ b/rust/gcode/tests/property_lex.rs
@@ -2,14 +2,13 @@ use gcode::lex;
 use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
 
+const REGRESSIONS_RELATIVE_TO_CRATE_ROOT: &str = "proptest-regressions/property_lex.txt";
+
 proptest! {
-    // The default SourceParallel persistence cannot locate a source root for
-    // integration tests (no lib.rs/main.rs above tests/), so failing seeds
-    // were silently never saved; Direct resolves relative to the crate root.
     #![proptest_config(ProptestConfig {
         cases: 1024,
         failure_persistence: Some(Box::new(FileFailurePersistence::Direct(
-            "proptest-regressions/property_lex.txt",
+            REGRESSIONS_RELATIVE_TO_CRATE_ROOT,
         ))),
         ..Default::default()
     })]

--- a/rust/geometry/src/curve.rs
+++ b/rust/geometry/src/curve.rs
@@ -1,6 +1,3 @@
-/// Straight-line move as a degenerate cubic Bézier — control points collinear
-/// at the 1/3 and 2/3 marks. Relocated from `compat::collinear` so the live
-/// engine no longer links the offline preprocessor.
 #[must_use]
 pub fn to_collinear_bezier(start: [f64; 3], end: [f64; 3]) -> [[f64; 3]; 4] {
     let d = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
@@ -35,8 +32,6 @@ pub fn g5_control_points(
     [start, p1, p2, end]
 }
 
-/// G5.1 quadratic Bézier (single control point `i,j` offset from start),
-/// elevated *exactly* to cubic. Z interpolated linearly.
 #[must_use]
 pub fn g51_control_points(
     start: [f64; 3],

--- a/rust/geometry/src/curve/tests.rs
+++ b/rust/geometry/src/curve/tests.rs
@@ -4,7 +4,6 @@ use nurbs::eval::vector_eval;
 
 #[test]
 fn g51_elevation_is_exact_against_the_quadratic() {
-    // Quadratic: Q0=start, Q1=start+(I,J), Q2=end. Sample both, compare.
     let start = [0.0, 0.0, 0.0];
     let (i, j, dx, dy, dz) = (3.0, 5.0, 8.0, 0.0, 4.0);
     let cubic = g51_control_points(start, i, j, dx, dy, dz);
@@ -58,7 +57,6 @@ fn collinear_handles_3d_diagonal() {
 
 #[test]
 fn g5_assembles_control_points_with_linear_z() {
-    // start (0,0,0), endpoint delta (10,0,6), I/J=(2,4), P/Q=(-3,4)
     let cps = g5_control_points([0.0, 0.0, 0.0], 2.0, 4.0, -3.0, 4.0, 10.0, 0.0, 6.0);
     assert_eq!(cps[0], [0.0, 0.0, 0.0]); // P0 = start
     assert_eq!(cps[1], [2.0, 4.0, 2.0]); // P1 = start+(I,J), z = dz/3

--- a/rust/geometry/src/execution/tests.rs
+++ b/rust/geometry/src/execution/tests.rs
@@ -365,26 +365,26 @@ fn lower_with_samples(length: f64, samples: &[(f64, f64)]) -> Result<(), Geometr
 
 #[test]
 fn malformed_profile_samples_fail_loud() {
-    // Does not span the segment end.
-    assert!(lower_with_samples(100.0, &[(0.0, 0.0), (50.0, 30.0)]).is_err());
-    // Does not start at s=0.
-    assert!(lower_with_samples(100.0, &[(1.0, 0.0), (100.0, 30.0)]).is_err());
-    // Non-monotone arc length (Δs = 0).
-    assert!(
-        lower_with_samples(
-            100.0,
-            &[(0.0, 0.0), (50.0, 30.0), (50.0, 30.0), (100.0, 10.0)]
-        )
-        .is_err()
-    );
-    // Negative velocity.
-    assert!(lower_with_samples(100.0, &[(0.0, 0.0), (100.0, -5.0)]).is_err());
-    // Non-finite velocity.
-    assert!(lower_with_samples(100.0, &[(0.0, 0.0), (100.0, f64::NAN)]).is_err());
-    // Stalled at zero velocity over a positive interval.
-    assert!(lower_with_samples(100.0, &[(0.0, 0.0), (100.0, 0.0)]).is_err());
-    // Single sample (cannot form an interval).
-    assert!(lower_with_samples(100.0, &[(0.0, 0.0)]).is_err());
+    let does_not_span_segment_end = &[(0.0, 0.0), (50.0, 30.0)];
+    assert!(lower_with_samples(100.0, does_not_span_segment_end).is_err());
+
+    let does_not_start_at_s_zero = &[(1.0, 0.0), (100.0, 30.0)];
+    assert!(lower_with_samples(100.0, does_not_start_at_s_zero).is_err());
+
+    let non_monotone_arc_length = &[(0.0, 0.0), (50.0, 30.0), (50.0, 30.0), (100.0, 10.0)];
+    assert!(lower_with_samples(100.0, non_monotone_arc_length).is_err());
+
+    let negative_velocity = &[(0.0, 0.0), (100.0, -5.0)];
+    assert!(lower_with_samples(100.0, negative_velocity).is_err());
+
+    let non_finite_velocity = &[(0.0, 0.0), (100.0, f64::NAN)];
+    assert!(lower_with_samples(100.0, non_finite_velocity).is_err());
+
+    let stalled_at_zero_velocity = &[(0.0, 0.0), (100.0, 0.0)];
+    assert!(lower_with_samples(100.0, stalled_at_zero_velocity).is_err());
+
+    let single_sample_cannot_form_interval = &[(0.0, 0.0)];
+    assert!(lower_with_samples(100.0, single_sample_cannot_form_interval).is_err());
 }
 
 #[test]

--- a/rust/geometry/src/fitter/chain.rs
+++ b/rust/geometry/src/fitter/chain.rs
@@ -289,25 +289,22 @@ fn incircle(
     })
 }
 
-/// Solve for the arc radius `ρ_arc < ρ` whose transition spiral lands **exactly** on the
-/// facet lines: the spiral's perpendicular offset from its arc centre (`c_in`, evaluated
-/// from the real Fresnel figure) must equal the incircle radius `ρ`. The small-angle
-/// `p = L²/24R` form is only the seed; the exact value is found by bisection so the seam
-/// closes to machine precision at any faceting angle. `c_in` is monotone increasing in the
-/// radius over `[ρ/2, ρ]` for `l_t ≤ ρ/2`, bracketing the root.
 fn solve_rho_arc(rho: f64, l_t: f64, line_no: u32) -> Result<Option<f64>, FitError> {
-    let c_in = |r: f64| -> Result<f64, FitError> {
+    let spiral_offset_from_arc_centre = |r: f64| -> Result<f64, FitError> {
         let (_, c_in) = spiral_anchor_offset(1.0 / (r * l_t), l_t, r, line_no)?;
         Ok(c_in)
     };
     let mut lo = 0.5 * rho;
     let mut hi = rho;
-    if !(c_in(lo)? < rho && c_in(hi)? >= rho) {
+    let bracket_below = spiral_offset_from_arc_centre(lo)?;
+    let bracket_above = spiral_offset_from_arc_centre(hi)?;
+    let root_is_bracketed = bracket_below < rho && bracket_above >= rho;
+    if !root_is_bracketed {
         return Ok(None);
     }
     for _ in 0..RHO_ARC_BISECTIONS {
         let mid = 0.5 * (lo + hi);
-        if c_in(mid)? < rho {
+        if spiral_offset_from_arc_centre(mid)? < rho {
             lo = mid;
         } else {
             hi = mid;
@@ -392,18 +389,14 @@ fn seam_ok(p: [f64; 3], s: f64, line: &Line) -> bool {
     norm(sub(p, foot)) <= SEAM_TOL_MM
 }
 
-/// Every interior facet vertex must sit within the un-faceting tube of the reconstructed
-/// circle — its radial deviation bounded by the local chord sagitta. This is the real
-/// co-circularity guard at the minimum run length, where the incircle solve is exactly
-/// determined (zero residual by construction) and a non-circular chord triple would
-/// otherwise reconstruct as the triangle incircle and gross-cut the corner.
 fn vertices_within_tube(lines: &[&Line], origin: [f64; 3], radius: f64, tol: f64) -> bool {
     for k in 0..lines.len() - 1 {
         let vertex = lines[k].point_at(lines[k].s_len());
         let chord = lines[k].s_len().max(lines[k + 1].s_len());
         let sagitta = chord * chord / (8.0 * radius);
-        let deviation = (norm(sub(vertex, origin)) - radius).abs();
-        if deviation > 2.0 * sagitta + tol {
+        let radial_deviation = (norm(sub(vertex, origin)) - radius).abs();
+        let unfaceting_tube_halfwidth = 2.0 * sagitta + tol;
+        if radial_deviation > unfaceting_tube_halfwidth {
             return false;
         }
     }

--- a/rust/geometry/src/fitter/chain/tests.rs
+++ b/rust/geometry/src/fitter/chain/tests.rs
@@ -32,8 +32,6 @@ fn dist(a: [f64; 3], b: [f64; 3]) -> f64 {
     ((a[0] - b[0]).powi(2) + (a[1] - b[1]).powi(2) + (a[2] - b[2]).powi(2)).sqrt()
 }
 
-/// Quarter-circle vertices, radius `r`, centre `(0, r)`, starting at the origin heading +x,
-/// curving toward +y (a left turn), faceted into `n` equal-angle chords.
 fn arc_vertices(r: f64, n: usize, span: f64) -> Vec<[f64; 3]> {
     (0..=n)
         .map(|k| {
@@ -124,7 +122,6 @@ fn faceted_arc_reconstructs_to_clothoid_arc_clothoid() {
     );
     let (_, up, arc, down) = find_recon(&out.moves);
     assert!(arc.radius > 0.0 && arc.radius.is_finite());
-    // The transition spirals ramp curvature 0 -> kappa_arc -> 0.
     assert!(up.kappa(0.0).abs() < 1e-9);
     assert!(down.kappa(down.s_len()).abs() < 1e-9);
 }
@@ -141,8 +138,6 @@ fn no_arc_fit_config_never_chains() {
 
 #[test]
 fn sharp_corners_rejected_by_angle_gate() {
-    // 0.5 mm sides are within the length gate, but the 90 deg turns exceed the
-    // default angle gate, so a square stays sharp.
     let config = ChainFitConfig::with_arc_fit(1.0, 12f64.to_radians());
     let moves = vec![
         seg(1, 3000.0, 5.0, 200.0, [0.0, 0.0, 0.0], [0.5, 0.0, 0.0], 0.0),
@@ -155,8 +150,6 @@ fn sharp_corners_rejected_by_angle_gate() {
 
 #[test]
 fn faceted_arc_within_default_gates_reconstructs() {
-    // r=3, 12 facets over 90 deg: ~0.39 mm chords turning ~7.5 deg each, inside
-    // the default 1.0 mm / 12 deg gates.
     let config = ChainFitConfig::with_arc_fit(1.0, 12f64.to_radians());
     let moves = faceted_arc(3.0, 12, PI / 2.0, 3000.0, 20.0, 200.0, 0.0);
     let out = fit_chain(&moves, config).unwrap();
@@ -165,8 +158,6 @@ fn faceted_arc_within_default_gates_reconstructs() {
 
 #[test]
 fn long_facets_rejected_by_length_gate() {
-    // Shallow turns (~5.7 deg, within a generous angle gate) but ~10 mm chords:
-    // the length gate alone keeps the run from collapsing into an arc.
     let config = ChainFitConfig::with_arc_fit(1.0, 60f64.to_radians());
     let moves = faceted_arc(100.0, 4, 0.4, 3000.0, 20.0, 200.0, 0.0);
     let out = fit_chain(&moves, config).unwrap();
@@ -180,11 +171,9 @@ fn reconstruction_is_g2_and_seam_exact() {
     let (i, up, arc, down) = find_recon(&out.moves);
     let kappa_arc = arc.kappa(0.0);
 
-    // Curvature continuity (G2) across both transition seams.
     assert!((up.kappa(up.s_len()) - kappa_arc).abs() < 1e-9);
     assert!((down.kappa(0.0) - kappa_arc).abs() < 1e-9);
 
-    // Position + heading continuity (G1) through the whole reconstruction, via the oracle.
     let line_in = as_line(&out.moves[i - 2]);
     let line_out = as_line(&out.moves[i + 2]);
     assert!(dist(line_in.point_at(line_in.s_len()), up.point_at(0.0)) < 1e-6);
@@ -206,7 +195,6 @@ fn reconstructed_arc_passes_near_interior_vertices() {
     let out = fit_chain(&moves, cfg()).unwrap();
     let (_, _, arc, _) = find_recon(&out.moves);
 
-    // Interior vertices lie within the un-faceting tube of the reconstructed circle.
     let verts = arc_vertices(r, n, span);
     for v in &verts[2..n - 1] {
         let radial = dist(*v, arc.origin);
@@ -220,8 +208,6 @@ fn reconstructed_arc_passes_near_interior_vertices() {
 
 #[test]
 fn chain_fit_beats_the_per_corner_sawtooth() {
-    // Short facets + a generous square-corner velocity make every per-corner blend
-    // budget-bound (high kappa_peak), so the per-corner profile throttles at each apex.
     let moves = faceted_arc(3.0, 20, PI / 2.0, 3000.0, 45.0, 200.0, 0.3);
 
     let chain = fit_chain(&moves, cfg()).unwrap();
@@ -254,12 +240,11 @@ fn extrusion_is_conserved_across_the_run() {
 
 #[test]
 fn non_cocircular_run_falls_through_to_per_corner() {
-    // Same turn direction but curvature increases facet-to-facet: not one circle.
     let mut p = [0.0, 0.0, 0.0];
     let mut heading = 0.0_f64;
     let mut moves = Vec::new();
     for k in 0..8u32 {
-        heading += 0.12 + 0.04 * k as f64; // growing deflection => varying kappa
+        heading += 0.12 + 0.04 * k as f64;
         let next = [p[0] + heading.cos(), p[1] + heading.sin(), 0.0];
         moves.push(seg(k + 1, 3000.0, 20.0, 200.0, p, next, 0.0));
         p = next;
@@ -275,20 +260,16 @@ fn non_cocircular_run_falls_through_to_per_corner() {
 
 #[test]
 fn turn_reversal_splits_the_run() {
-    // A polyline that turns left for a while, then right: a single absolute-heading
-    // walk whose turn sign flips halfway. Detection must never merge across the flip.
     let mut p = [0.0, 0.0, 0.0];
     let mut ang = 0.0_f64;
     let mut moves = Vec::new();
     for k in 0..12u32 {
-        ang += if k < 6 { 0.2 } else { -0.2 }; // left, then right
+        ang += if k < 6 { 0.2 } else { -0.2 };
         let next = [p[0] + ang.cos(), p[1] + ang.sin(), 0.0];
         moves.push(seg(k + 1, 3000.0, 20.0, 200.0, p, next, 0.0));
         p = next;
     }
     let out = fit_chain(&moves, cfg()).unwrap();
-    // The left and right same-turn arcs are each co-circular and reconstruct independently;
-    // detection breaks at the sign flip, so it never forms one run spanning the reversal.
     assert!(out.report.chains <= 2);
 }
 
@@ -296,14 +277,11 @@ fn turn_reversal_splits_the_run() {
 fn arc_move_breaks_the_run() {
     let mut moves = faceted_arc(3.0, 6, PI / 3.0, 3000.0, 20.0, 200.0, 0.0);
     let split = moves.len() / 2;
-    // Inject a non-Line (virtual) move mid-chain.
     let mut virt = moves[split].clone();
     virt.segment.spatial = None;
     virt.segment.virtual_path_mm = Some(0.5);
     moves.insert(split, virt);
     let out = fit_chain(&moves, cfg()).unwrap();
-    // Each side may reconstruct independently, but the non-spatial move is never merged
-    // across — it survives verbatim in the output.
     assert!(out.report.chains <= 2);
     assert!(
         out.moves.iter().any(|m| m.segment.spatial.is_none()),
@@ -358,7 +336,6 @@ fn short_chain_passes_through() {
 
 #[test]
 fn run_velocity_profile_plans_without_error() {
-    // End-to-end: a reconstructed run is consumed by the velocity planner unchanged.
     let moves = faceted_arc(3.0, 12, PI / 2.0, 3000.0, 20.0, 200.0, 0.3);
     let out = fit_chain(&moves, cfg()).unwrap();
     let profile = plan_velocity(&out, VelocityConfig::default()).unwrap();
@@ -367,9 +344,6 @@ fn run_velocity_profile_plans_without_error() {
 
 #[test]
 fn coarse_facets_still_reconstruct_landing_on_the_last_chord() {
-    // ~12 deg per facet — the down-spiral exits along the LAST CHORD heading (the net
-    // turn equals the chord-to-chord total by construction), not the circle tangent, so
-    // the G1 tail-seam gate is satisfied even for coarse faceting.
     let moves = faceted_arc(4.0, 5, PI / 3.0, 3000.0, 20.0, 200.0, 0.0);
     let out = fit_chain(&moves, cfg()).unwrap();
     assert_eq!(out.report.chains, 1);
@@ -382,9 +356,6 @@ fn coarse_facets_still_reconstruct_landing_on_the_last_chord() {
 
 #[test]
 fn non_cocircular_triple_is_rejected_by_the_vertex_tube() {
-    // Three facets (the minimum run) whose incircle solve is exactly determined, so the
-    // residual is vacuously zero — but the chords sample no single circle. The vertex
-    // tube gate rejects it; without it the triangle incircle would gross-cut the corner.
     let mut p = [0.0, 0.0, 0.0];
     let mut moves = Vec::new();
     for (k, ang) in [0.0_f64, 0.25, 0.95].iter().enumerate() {
@@ -407,7 +378,6 @@ fn transition_shift_stays_within_delta() {
     let moves = faceted_arc(3.0, 12, PI / 2.0, accel, scv, 200.0, 0.0);
     let out = fit_chain(&moves, cfg()).unwrap();
     let (_, up, arc, _) = find_recon(&out.moves);
-    // p = L_t^2 / (24 R) is the inward shift of the spiral from the tangent; bounded by δ.
     let shift = up.s_len() * up.s_len() / (24.0 * arc.radius);
     assert!(
         shift <= delta * 1.001,

--- a/rust/geometry/src/path/lowering/fresnel.rs
+++ b/rust/geometry/src/path/lowering/fresnel.rs
@@ -1,5 +1,3 @@
-//! Fresnel integrals `C(x)`/`S(x)` via the Cephes rational approximation:
-//! max abs error ~2e-17, uniform over all finite x (no domain restriction).
 #![allow(clippy::excessive_precision)] // verbatim Cephes coefficients
 
 use core::f64::consts::{FRAC_PI_2, PI};

--- a/rust/geometry/src/reduce.rs
+++ b/rust/geometry/src/reduce.rs
@@ -82,7 +82,6 @@ pub(crate) enum ParseErrorKind {
     EmptyCommand,
     DuplicateParam,
     G5MissingTangent,
-    // active_plane G-code number is encoded in `text`; pipeline parses it back to populate Recovery.
     G5PlaneMismatch,
     G5MalformedTangent,
     UnsupportedGcode { kind: &'static str },

--- a/rust/geometry/src/segment.rs
+++ b/rust/geometry/src/segment.rs
@@ -42,8 +42,6 @@ pub struct CubicSegment {
     pub feedrate_mm_s: f64,
     pub source: SourceRange,
     pub split_info: Option<SplitInfo>,
-    /// `Some(length)` marks a follower-only move planned on a virtual path of
-    /// this arclength; the xyz curve has zero displacement.
     pub virtual_path_mm: Option<f64>,
 }
 

--- a/rust/geometry/src/velocity.rs
+++ b/rust/geometry/src/velocity.rs
@@ -24,8 +24,7 @@ impl Default for VelocityConfig {
     fn default() -> Self {
         Self {
             consistency_tol: 1e-6,
-            // TODO: jerk-limit floor is an open tuning question (spec-motion-6).
-            max_jerk_mm_s3: 100_000.0,
+            max_jerk_mm_s3: 100_000.0, // TODO: jerk-limit floor is an open tuning question (spec-motion-6)
             integration_tol: 1e-7,
         }
     }
@@ -105,14 +104,6 @@ pub fn plan_velocity(
     plan_velocity_warm_start(outcome, config, 0.0)
 }
 
-/// Streaming variant: the trajectory enters the first move at `entry_v`
-/// (the velocity already dispatched to the MCU at the commit boundary) rather
-/// than from rest. The terminal velocity stays pinned to zero (worst-case
-/// future), so a partially-known look-ahead window is always plannable to a
-/// stop. Fails loudly with [`VelocityError::OverCommitted`] when the pinned
-/// entry cannot brake to rest within the window — that is an over-commit
-/// (the planner emitted faster than the remaining look-ahead can absorb), not
-/// something to silently clamp. `entry_v == 0.0` reproduces [`plan_velocity`].
 pub fn plan_velocity_warm_start(
     outcome: &FitOutcome,
     config: VelocityConfig,

--- a/rust/geometry/src/velocity/disk.rs
+++ b/rust/geometry/src/velocity/disk.rs
@@ -126,12 +126,6 @@ pub(super) fn disk_reach_v_rev(kin: &Kinematics, v_in: f64, s: f64, tol: f64) ->
     disk_reach_v(&kin.reversed(), v_in, s, tol)
 }
 
-/// Run-anchored tangential-jerk context for one move's profile reconstruction.
-/// The forward jerk ramp is measured from the run's start anchor velocity
-/// `fwd_v` over cumulative arc `fwd_s + s`; the backward ramp from the run's
-/// end anchor velocity `bwd_v` over `bwd_s + (length - s)`. The jerk magnitude
-/// therefore only relaxes to zero at the run's rest anchors (stops / chain
-/// ends), not at internal clothoid seams.
 pub(super) struct JerkAnchors {
     pub fwd_v: f64,
     pub fwd_s: f64,
@@ -154,11 +148,6 @@ fn disk_rail_accel(accel: f64, kappa_abs: f64, v: f64) -> f64 {
     (accel * accel - a_n * a_n).max(0.0).sqrt()
 }
 
-/// Tangential acceleration cannot exceed the acceleration disk's remaining
-/// budget once centripetal `a_n = kappa*v^2` is spent: `a_t^2 + a_n^2 <= a^2`.
-/// At a biclothoid apex `a_n` saturates the disk, so the budget collapses to
-/// ~0 and the curvature-rate kink in `a_t` is pinned out instead of poking the
-/// reported acceleration past `a_max`.
 fn clamp_to_disk(a_t: f64, accel: f64, kappa_abs: f64, v: f64) -> f64 {
     let budget = disk_rail_accel(accel, kappa_abs, v);
     a_t.clamp(-budget, budget)

--- a/rust/geometry/src/velocity/tests.rs
+++ b/rust/geometry/src/velocity/tests.rs
@@ -573,12 +573,22 @@ fn warm_start_is_faster_than_starting_from_rest() {
 
 #[test]
 fn warm_start_over_commit_cannot_brake_in_window() {
-    // 1 mm at a_max 1000 brakes from at most sqrt(2*1000*1) ≈ 44.7 mm/s; the
-    // feed ceiling (200) admits the 100 mm/s entry, so this exercises the
-    // can't-stop guard, not the ceiling guard.
-    let out = outcome(vec![line_move(1.0, 200.0, 200.0, 1000.0, 5)], Vec::new());
+    let (length, accel, feed_ceiling, entry_v) = (1.0_f64, 1000.0_f64, 200.0_f64, 100.0_f64);
+    let max_brakeable_entry_v = (2.0 * accel * length).sqrt();
+    assert!(
+        entry_v <= feed_ceiling,
+        "entry must clear the feed ceiling so this exercises the can't-stop guard, not the ceiling guard"
+    );
+    assert!(
+        entry_v > max_brakeable_entry_v,
+        "entry must exceed the braking-distance budget so the can't-stop guard trips"
+    );
+    let out = outcome(
+        vec![line_move(length, feed_ceiling, feed_ceiling, accel, 5)],
+        Vec::new(),
+    );
     assert_eq!(
-        plan_velocity_warm_start(&out, VelocityConfig::default(), 100.0),
+        plan_velocity_warm_start(&out, VelocityConfig::default(), entry_v),
         Err(VelocityError::OverCommitted { line_no: 5 })
     );
 }

--- a/rust/geometry/tests/c2_continuity.rs
+++ b/rust/geometry/tests/c2_continuity.rs
@@ -1,20 +1,3 @@
-//! T3 acceptance: the live velocity planner is C2-within-run / C1-at-rest.
-//!
-//! Reproduces the demo4 serpentine and asserts, reading the planned analytic
-//! `a_t` (never finite-differenced):
-//!   * accel-from-rest is a full-jerk trapezoid, not the C1 `(2/9)*jerk`
-//!     velocity-ceiling ride (`max_reachable_velocity`);
-//!   * tangential acceleration is continuous across mid-run junctions — the
-//!     `+max -> -max` cruise/decel crossover step is dissolved by the bridge;
-//!   * `|a_t| <= a_max` everywhere and `(v,a)=(0,0)` is pinned at rest anchors.
-//!
-//! Carve-out: the biclothoid corner apex carries a small tangential `a_t` step
-//! (`a_t` tracks the curvature speed-limit slope `v*dv_lim/ds`, which inherits
-//! the clothoid's `dkappa/ds` jump — a G2-not-G3 property). Per spec-motion-12
-//! that lateral-jerk-induced step is the fitter shape's responsibility, not a
-//! tangential-jerk-feasibility bug; it is bounded by `a_max` and is far below
-//! the `2*a_max` C1 crossover step this work targets.
-
 use geometry::path::CurvatureProfile;
 use geometry::{
     ChainFitConfig, Move, MoveContext, SourceRange, VelocityConfig, VelocityLimits, fit_chain,
@@ -84,15 +67,12 @@ fn plan_samples() -> Vec<Sample> {
 
 #[test]
 fn c2_accel_from_rest_is_full_jerk_trapezoid() {
-    // By s=0.5mm a full-jerk ramp has long since reached the accel plateau
-    // (a=a_max at s~0.08mm). The C1 (2/9)*jerk ceiling-ride is still climbing
-    // there: a ~ (2/3)*jerk^(2/3)*s^(1/3) ~ 0.66*a_max. Reading the plateau
-    // separates the two unambiguously.
+    let accel_plateau_probe_mm = 0.5;
     let s = plan_samples();
     let probe = s
         .iter()
-        .find(|p| p.s >= 0.5)
-        .expect("profile reaches 0.5mm");
+        .find(|p| p.s >= accel_plateau_probe_mm)
+        .expect("profile reaches the accel plateau probe distance");
     assert!(
         probe.a >= 0.9 * ACCEL,
         "accel-from-rest a_t={:.2} at s={:.3} should be on the a_max plateau \
@@ -106,9 +86,6 @@ fn c2_accel_from_rest_is_full_jerk_trapezoid() {
 
 #[test]
 fn c2_no_crossover_accel_step() {
-    // The C1 cruise/decel crossover steps a_t by 2*a_max (+max -> -max). After
-    // bridging, no adjacent pair may step by even a_max — the corner κ' carve-out
-    // stays well under that bound.
     let s = plan_samples();
     for w in s.windows(2) {
         let step = (w[1].a - w[0].a).abs();
@@ -136,9 +113,6 @@ fn c2_accel_within_envelope() {
 
 #[test]
 fn c2_tangential_within_acceleration_disk() {
-    // a_t^2 + a_n^2 <= a_max^2 everywhere: the reported tangential accel may not
-    // borrow against the centripetal budget. Catches the biclothoid-apex spike
-    // where curvature-ceiling tracking would otherwise push |a| past a_max.
     let moves = serpentine();
     let outcome = fit_chain(&moves, ChainFitConfig::default()).unwrap();
     let profile = plan_velocity(

--- a/rust/geometry/tests/cubic_segment.rs
+++ b/rust/geometry/tests/cubic_segment.rs
@@ -178,10 +178,6 @@ fn live_reduce_rejects_g2() {
 fn live_g0_then_g5_aborts_before_emitting_stale_cubic() {
     use geometry::{Fatal, FitterParams, GeometryPipeline, Item, Segment, TelemetryEvent};
 
-    // Pre-fix bug: G0 X10 was rejected without updating state.position, so
-    // the subsequent G5 emitted a cubic with cps[0] = [0,0,0] instead of
-    // [10,0,0] — silent 10mm geometric corruption. Post-fix: G0 produces
-    // Item::Fatal which terminates the iterator before the G5 is processed.
     let mut p = GeometryPipeline::new(FitterParams::default(), vec![]);
     let mut sink = |_e: TelemetryEvent| {};
     let src = "G0 X10 Y0\nG5 X20 Y0 I3 J3 P-3 Q3 F1000\n";
@@ -211,8 +207,6 @@ fn live_g0_then_g5_aborts_before_emitting_stale_cubic() {
 fn z_plus_e_classifies_as_ordinary_move_with_3d_ratio() {
     use geometry::{FitterParams, FollowerWord, GeometryPipeline, Item, Segment, TelemetryEvent};
 
-    // Previously Fatal::HelicalExtrusionUnsupported; the follower ratio is
-    // delta over 3D path length, so Z+E is an ordinary move.
     let mut p = GeometryPipeline::new(
         FitterParams::default(),
         vec![FollowerWord {
@@ -241,8 +235,6 @@ fn z_plus_e_classifies_as_ordinary_move_with_3d_ratio() {
 fn helical_move_with_follower_classifies_and_pipeline_continues() {
     use geometry::{FitterParams, FollowerWord, GeometryPipeline, Item, Segment, TelemetryEvent};
 
-    // Previously the first move was a fatal helical rejection; now both
-    // moves classify and the pipeline keeps going.
     let mut p = GeometryPipeline::new(
         FitterParams::default(),
         vec![FollowerWord {
@@ -273,10 +265,6 @@ fn g92_resets_modal_position_for_subsequent_g5() {
     use geometry::{FitterParams, GeometryPipeline, Item, Segment, TelemetryEvent};
     use nurbs::eval::vector_eval;
 
-    // Pre-fix bug: G92 X10 Y20 didn't update state.position. The subsequent
-    // G5 emitted P0 = [0,0,0] instead of [10,20,0] — silent geometric
-    // corruption. Post-fix: G92 binds params and writes them through to
-    // state.position before the marker break.
     let mut p = GeometryPipeline::new(FitterParams::default(), vec![]);
     let mut sink = |_: TelemetryEvent| {};
     let src = "G92 X10 Y20\nG5 X20 Y30 I0 J5 P0 Q-5 F1500\n";
@@ -301,8 +289,6 @@ fn g92_resets_modal_position_for_subsequent_g5() {
 fn g92_e_resets_follower_ledger_for_subsequent_g5_delta() {
     use geometry::{FitterParams, FollowerWord, GeometryPipeline, Item, Segment, TelemetryEvent};
 
-    // Pre-fix: G92 E5 didn't update the ledger. The next G5 with E10 computed
-    // delta = 10 - <stale>, instead of 10 - 5.
     let mut p = GeometryPipeline::new(
         FitterParams::default(),
         vec![FollowerWord {
@@ -335,8 +321,6 @@ fn g92_e_resets_follower_ledger_for_subsequent_g5_delta() {
 fn g18_then_g5_emits_plane_mismatch_recovery() {
     use geometry::{FitterParams, GeometryPipeline, Item, Recovery, TelemetryEvent};
 
-    // Pre-fix: G5 ignored active_plane and emitted a CurveGeom::Cubic as if
-    // XY. Post-fix: mirrors G5.1's plane check; emits Recovery::G5PlaneMismatch.
     let mut p = GeometryPipeline::new(FitterParams::default(), vec![]);
     let mut sink = |_: TelemetryEvent| {};
     let src = "G18\nG5 X10 Y0 I3 J3 P-3 Q3 F1500\n";
@@ -385,15 +369,6 @@ fn g19_then_g5_emits_plane_mismatch_recovery() {
 fn nan_g5_produces_malformed_params_recovery_not_silent_drop() {
     use geometry::{FitterParams, GeometryPipeline, Item, Recovery, TelemetryEvent};
 
-    // Pre-Fix-H: silent ZeroMotion drop. Rust's f64::FromStr accepts "NaN",
-    // so the lexer surfaced the move with NaN-poisoned XY params. The
-    // pipeline's ZeroMotion classifier then dropped the move (NaN > 1e-6
-    // is false), and modal state.position became NaN-poisoned for every
-    // subsequent G5 — silent geometric corruption with zero telemetry.
-    //
-    // Post-Fix-H: lexer rejects NaN as MalformedNumber, the geometry
-    // pipeline maps the parse error to Recovery::MalformedParams via the
-    // existing handle_event::ParseError path.
     let mut p = GeometryPipeline::new(FitterParams::default(), vec![]);
     let mut sink = |_e: TelemetryEvent| {};
     let src = "G5 XNaN Y0 I0 J3 P0 Q-3 F1500\n";

--- a/rust/geometry/tests/integration_pipeline.rs
+++ b/rust/geometry/tests/integration_pipeline.rs
@@ -1,11 +1,3 @@
-//! End-to-end integration of the new `Move` trajectory pipeline:
-//! `fit_chain` -> `plan_velocity` -> `lower_profile`.
-//!
-//! Each stage has its own unit tests; this exercises the seams between them on
-//! representative multi-move paths. Moves are built through the public
-//! `line_move`/`arc_move` API — the same shape the Python -> PyO3 bridge feeds —
-//! so no gcode parsing is involved.
-
 use geometry::path::Segment;
 use geometry::path::lowering::LoweredSample;
 use geometry::{
@@ -105,10 +97,6 @@ fn assert_trajectory_invariants(p: &Planned) {
         "total trajectory time must be positive"
     );
 
-    // lower_profile emits at a fixed rate: every interval but the final clamped
-    // one spans exactly 1/RATE_HZ. This also rules out a truncated or degenerate
-    // trajectory passing the endpoint check with too few samples.
-    // chord <= arc traversed <= v_max * dt, so per-step speed is bounded by v_max.
     let step = 1.0 / RATE_HZ;
     let cap = MAX_V * (1.0 + SPEED_REL_TOL);
     for (i, w) in s.windows(2).enumerate() {
@@ -130,7 +118,6 @@ fn assert_trajectory_invariants(p: &Planned) {
         }
     }
 
-    // Adjacent moves share a velocity node: a move's exit velocity is the next's entry.
     for w in p.profile.moves.windows(2) {
         let diff = (w[0].exit_v - w[1].entry_v).abs();
         assert!(
@@ -157,16 +144,14 @@ fn assert_reaches(p: &Planned, terminal: [f64; 3]) {
 
 #[test]
 fn cornered_polyline_blends_and_slows_through_corners() {
-    // Irregular vertices: no run of consecutive corners is co-circular, so each
-    // corner falls back to a per-corner clothoid blend (rather than a chain).
-    let verts = [
+    let non_cocircular_verts = [
         [0.0, 0.0, 0.0],
         [50.0, 0.0, 0.0],
         [80.0, 35.0, 0.0],
         [30.0, 55.0, 0.0],
         [5.0, 20.0, 0.0],
     ];
-    let p = plan(&polyline(200.0, &verts));
+    let p = plan(&polyline(200.0, &non_cocircular_verts));
 
     assert!(
         p.geometry.report.blended > 0,
@@ -201,17 +186,14 @@ fn cornered_polyline_blends_and_slows_through_corners() {
 
 #[test]
 fn square_stays_sharp_without_arc_fit() {
-    // A square's four corners are co-circular, but arc fitting is off by
-    // default, so the chain fitter must not collapse the square into a circle:
-    // the corners stay per-corner rather than reconstructing as a chain.
-    let verts = [
+    let cocircular_square_verts = [
         [0.0, 0.0, 0.0],
         [50.0, 0.0, 0.0],
         [50.0, 50.0, 0.0],
         [0.0, 50.0, 0.0],
         [0.0, 0.0, 0.0],
     ];
-    let p = plan(&polyline(200.0, &verts));
+    let p = plan(&polyline(200.0, &cocircular_square_verts));
 
     assert_eq!(
         p.geometry.report.chains, 0,
@@ -221,8 +203,6 @@ fn square_stays_sharp_without_arc_fit() {
     assert_trajectory_invariants(&p);
     assert_reaches(&p, [0.0, 0.0, 0.0]);
 
-    // Start and terminal coincide on a closed loop, so confirm the trajectory
-    // actually rounded the far side rather than barely moving.
     let excursion = p
         .samples
         .iter()
@@ -238,13 +218,17 @@ fn square_stays_sharp_without_arc_fit() {
 #[test]
 fn arc_path_is_curvature_bounded() {
     let feed = 250.0;
-    // Tight (r=5) arc: curvature cap sqrt(accel/kappa)=sqrt(5000*5)~158 mm/s,
-    // below the 250 mm/s feed, so the arc is curvature-bounded.
+    let arc_radius = 5.0;
+    let curvature_speed_cap = (ACCEL * arc_radius).sqrt();
+    assert!(
+        curvature_speed_cap < feed,
+        "test only exercises curvature binding when the cap {curvature_speed_cap} is below feed {feed}"
+    );
     let arc = arc_move(
         [20.0, 0.0, 0.0],
         [25.0, 5.0, 0.0],
         0.0,
-        5.0,
+        arc_radius,
         true,
         0.0,
         ctx(2, feed),
@@ -268,8 +252,6 @@ fn arc_path_is_curvature_bounded() {
 
 #[test]
 fn extruding_move_lowers_monotone_followers() {
-    // Single extruding move: followers are per-segment-local (ratio*s), so a
-    // lone segment yields a clean monotone 0 -> e_delta follower ramp.
     let e_delta = 2.0;
     let moves = vec![line(1, 60.0, [0.0, 0.0, 0.0], [40.0, 0.0, 0.0], e_delta)];
     let p = plan(&moves);

--- a/rust/geometry/tests/split_segment_to_cap.rs
+++ b/rust/geometry/tests/split_segment_to_cap.rs
@@ -1,7 +1,3 @@
-// `metadata_propagates` asserts byte-equal pass-through of the f64 fields the
-// splitter copies verbatim (no arithmetic, no conversion). Comparing those with
-// `assert_eq!` is the precise check for that contract — `float_cmp` does not
-// apply to "this field is unchanged".
 #![allow(clippy::float_cmp)]
 
 use geometry::{CubicSegment, FollowerDemand, SourceRange, split_segment_to_cap};
@@ -80,10 +76,6 @@ fn metadata_propagates() {
 
 #[test]
 fn boundary_continuity_within_round_off() {
-    // Round-1-review fix: split_piece_at re-shifts coefficients, and
-    // to_bernstein/from_bernstein adds another floating-point pass on the
-    // way through vector_nurbs_from_pieces. Use a tolerance bound, not
-    // assert_eq!.
     const BOUNDARY_TOL: f64 = 1e-12;
     use nurbs::eval::vector_eval;
     let seg = straight_cubic(50.0);

--- a/rust/motion-engine/examples/piece_stream_diff.rs
+++ b/rust/motion-engine/examples/piece_stream_diff.rs
@@ -1,13 +1,3 @@
-/// Piece-stream comparison harness for diagnosing the "grindy motion" regression
-/// introduced by commit 6ca2d685a ("fix(trajectory): emit constant axes as cubic").
-///
-/// Run this on the current branch (6ca2d685a) and on the parent commit (387534eec)
-/// worktree to compare the dispatched PieceEntry streams.
-///
-/// Usage (from rust/):
-///   cargo run --example piece_stream_diff 2>/dev/null
-///   # in /tmp/kalico-387534eec/rust/:
-///   cargo run --example piece_stream_diff 2>/dev/null
 use std::sync::{Arc, Mutex};
 
 use _motion_engine::classify::classify_and_build;

--- a/rust/motion-engine/examples/plan_gcode.rs
+++ b/rust/motion-engine/examples/plan_gcode.rs
@@ -65,11 +65,8 @@ fn trident_limit_sections() -> Vec<LimitSection> {
     ]
 }
 
-// Three-element array: segment count, total pieces summed per axis [x, y, z], max pieces per
-// segment per axis — all accessed by index so a single atomic array suffices.
 struct DispatchStats {
     segments: AtomicU64,
-    // pieces_total[ax] and pieces_max[ax] each hold per-axis values.
     pieces_total: [AtomicU64; 3],
     pieces_max: [AtomicU64; 3],
 }

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -260,7 +260,6 @@ fn message_for_claim_error(label: &str, interface: &str, e: &EndpointClaimError)
                  (bringup rc=-{fault_code}) — grant CAP_SYS_NICE + CAP_IPC_LOCK to \
                  klipper.service and isolate a CPU core, then FIRMWARE_RESTART"
             ),
-            // 0 = no bringup rc (e.g. the stub's simulated failure) — omit the suffix.
             0 => format!(
                 "ethercat {label}: drive (slave {slave_idx}) offline \
                  — check drive power, then FIRMWARE_RESTART"
@@ -390,12 +389,6 @@ mod claim_error_message_tests {
     }
 }
 
-/// The caller (`claim_ethercat_node`) removes any stale socket file at
-/// `socket_path` before calling this function. That pre-spawn removal is
-/// necessary: `FrameServer::bind` unlinks-and-rebinds on the path, but that
-/// happens *after* the process starts — between spawn and bind, a pre-existing
-/// file would let `poll_socket_ready` return immediately on existence, racing
-/// `handshake_ethercat_endpoint`'s connect ahead of the actual listener.
 fn spawn_ethercat_endpoint(
     binary: &str,
     interface: &str,
@@ -470,10 +463,6 @@ fn handshake_ethercat_endpoint(
     use mcu_protocol::codec::{Cursor, Decode};
     use mcu_protocol::messages::ClaimHandshakeReply;
 
-    // Retry connect until the endpoint's listener is up. ConnectionRefused and
-    // NotFound both mean the endpoint hasn't bound yet (bind latency, or the
-    // endpoint is mid-unlink-and-rebind of a stale path). Every other error is
-    // immediately fatal as a Protocol error — we don't mask real failures.
     let conn = loop {
         match McuSerialConn::connect(socket_path) {
             Ok(c) => break c,
@@ -564,9 +553,6 @@ fn planner_err(e: StreamPlannerError) -> PyErr {
     PyRuntimeError::new_err(e.to_string())
 }
 
-/// Look-ahead horizon the streaming planner holds back from each non-forced
-/// commit, so newly-arriving moves are planned with their predecessors still
-/// buffered. Drained to rest on flush/dwell/idle.
 const STREAM_KEEP_SECS: f64 = 0.5;
 
 fn resolve_motion_caps(
@@ -609,10 +595,6 @@ pub struct PyMotionEngine {
     events: Arc<Mutex<VecDeque<EngineEvent>>>,
     #[allow(dead_code)]
     handlers: Mutex<HashMap<(u32, String, u32), Py<PyAny>>>,
-    // `Mutex<Option<..>>` (not `OnceLock`) so `shutdown()` can *take* the handle
-    // and join the `kalico-planner` thread. A `OnceLock` cannot be drained, so
-    // the planner thread would only be joined when the whole engine dropped —
-    // which never happens on klippy's in-process FIRMWARE_RESTART loop.
     planner: Mutex<Option<StreamPlannerHandle>>,
     planner_config: Mutex<PlannerConfig>,
     commanded_pos: Mutex<[f64; 3]>,
@@ -644,9 +626,6 @@ pub struct PyMotionEngine {
         Mutex<Option<crossbeam_channel::Receiver<Result<([f64; 3], [f64; 3], u64), String>>>>,
     latched_drive_fault: Arc<Mutex<HashMap<u32, u16>>>,
     remote_triggers: Mutex<HashMap<u8, (u32, host_rt::host_io::InterceptorId)>>,
-    // Latched once `shutdown()` has run a full teardown. Subsequent calls (the
-    // Drop backstop, a second `klippy:disconnect`, the failed-connect path) see
-    // this and no-op, so double-teardown is provably safe and observable.
     shut_down: AtomicBool,
 }
 
@@ -1323,43 +1302,21 @@ impl PyMotionEngine {
     }
 
     fn release_mcu(&self, handle: u32) -> PyResult<()> {
-        // Pull the whole McuConnection out of the map but keep it alive (it owns
-        // `host_io`) until *after* the endpoint child is reaped. Teardown order
-        // matters: the endpoint must see session-end (socket close + SIGTERM)
-        // before we close the host_io pts fd, which is the EBUSY-relevant step.
-        //
-        // Removing from the map BEFORE closing the endpoint socket (below) is
-        // also the ec-heartbeat-poll race guard: the supervision thread confirms
-        // every EOF/child-exit fault against `mcus.get(&mcu_id)` under the lock,
-        // so by the time the socket close it observes as peer_closed() has
-        // happened, the entry is already gone and the fault is read as a clean
-        // release rather than fired into std::process::abort().
         let Some(mut conn) = ({
             let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
             mcus.remove(&handle)
         }) else {
-            // Already released — idempotent no-op (shutdown may call twice, the
-            // failed-connect path may call before any attach).
             return Ok(());
         };
 
         let mut endpoint_process = conn.endpoint_process.take();
         let endpoint_conn = conn.endpoint_conn.take();
 
-        // Drop our Arc on the endpoint connection so the socket closes (signals
-        // session end to the endpoint). Router/pump Arcs may still be live;
-        // SIGTERM is the authoritative termination signal below.
         drop(endpoint_conn);
 
         if let Some(ref mut child) = endpoint_process {
-            // Capture PID before any wait so it is valid in diagnostic messages
-            // (after wait() the OS may reuse the pid_t value).
             let pid = libc::pid_t::try_from(child.id()).expect("child PID exceeds pid_t range");
 
-            // SIGTERM: ask the endpoint to exit gracefully.
-            // `libc::kill` is the only stable way to send a specific signal to
-            // a child process on Unix; there is no safe std API for this.
-            // ESRCH (no such process) = already exited = fine; discard the return value.
             #[allow(unsafe_code)]
             let _ = unsafe { libc::kill(pid, libc::SIGTERM) };
 
@@ -1385,11 +1342,6 @@ impl PyMotionEngine {
             }
         }
 
-        // Endpoint is dead; now close the host_io. Dropping the McuConnection
-        // drops its `Arc<McuHostIo>` — the last strong ref (pump/heartbeat
-        // hold `Weak` only), so `McuHostIo::Drop` runs here: it sends the
-        // reactor Shutdown and joins the reactor thread, which closes the pts
-        // fd and releases TIOCEXCL — clearing the EBUSY for the next process.
         drop(conn);
 
         let mut router = self.router.lock().unwrap_or_else(|p| p.into_inner());
@@ -1401,37 +1353,6 @@ impl PyMotionEngine {
         Ok(())
     }
 
-    /// The single, complete, ordered, idempotent teardown primitive.
-    ///
-    /// It is the authoritative release path on every klippy exit that can leave
-    /// state behind (`klippy:disconnect`, the failed-connect arms, and the Drop
-    /// backstop). Calling it more than once is a clean no-op — the second call
-    /// finds empty maps / `None` handles and the latched `shut_down` flag.
-    ///
-    /// Ordering — two hazards drive the order, one in each direction:
-    ///
-    ///   Hazard A (planner → pump): while the planner holds an uncommitted decel
-    ///   tail (`t_dispatched < t_appended`, true after essentially any motion),
-    ///   its `recv_timeout` fires `run_commit_and_dispatch`, whose dispatch closure
-    ///   does `pump_tx.send(..)`. If the pump's `Receiver` were already gone that
-    ///   send yields `DispatchError::PumpGone` → the planner calls `fatal()` →
-    ///   `std::process::abort()`, which skips every `Drop` — leaking the pts fd.
-    ///   Fix: join the planner BEFORE sending `PumpMsg::Shutdown`; once the
-    ///   planner thread is joined no further dispatch can fire.
-    ///
-    ///   Hazard B (pump → EtherCAT conn): the pump may still be draining
-    ///   already-queued pieces for an EtherCAT MCU after `release_mcu` drops the
-    ///   last strong `Arc<McuSerialConn>`. In `call_push_pieces` the
-    ///   `Weak::upgrade()` then returns `None` → `SendError::Fatal` →
-    ///   `on_fatal_transport` → `std::process::abort()` — the same pts-fd leak.
-    ///   Fix: join the pump BEFORE calling `release_mcu`; once the pump thread is
-    ///   joined no send can be in flight.
-    ///
-    ///   Together: planner join → pump Shutdown + join → per-MCU release_mcu.
-    ///
-    ///   Post-join heartbeat sends: the ec-heartbeat-poll thread holds a clone of
-    ///   `pump_tx`. After the pump's `Receiver` is dropped (pump joined), those
-    ///   sends silently return `Err` and are discarded by the callback — harmless.
     fn shutdown(&self) {
         if self.shut_down.swap(true, Ordering::SeqCst) {
             tracing::debug!(
@@ -1442,8 +1363,6 @@ impl PyMotionEngine {
             return;
         }
 
-        // Step 1 — planner: join before the pump receives Shutdown so the planner
-        // can never dispatch into a dead pump Receiver (Hazard A).
         let planner = self
             .planner
             .lock()
@@ -1453,11 +1372,6 @@ impl PyMotionEngine {
             p.shutdown();
         }
 
-        // Step 2 — pump: join before releasing MCU transports so no queued piece
-        // can hit a dead EtherCAT Weak after release_mcu drops the strong Arc
-        // (Hazard B). run_pump exits immediately on Shutdown, abandoning queued
-        // pieces — safe because the planner is already joined and no new pieces
-        // will arrive.
         let pump_join = {
             let tx = self
                 .pump_tx
@@ -1496,16 +1410,12 @@ impl PyMotionEngine {
             }
         }
 
-        // Step 3 — per-MCU release_mcu: endpoint socket/child first, then
-        // host_io fd (the EBUSY-relevant close), then router prune. The pump is
-        // already joined so no send is in flight when the strong Arc drops.
         let handles: Vec<u32> = {
             let mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
             mcus.keys().copied().collect()
         };
         for h in handles {
             if let Err(e) = self.release_mcu(h) {
-                // Fail loud: a release error means an fd / child may be leaked.
                 tracing::error!(
                     subsystem = "engine",
                     event = "shutdown_release_mcu_failed",
@@ -1693,11 +1603,6 @@ impl PyMotionEngine {
         Ok(())
     }
 
-    // Narrow fd-release hook for the serial arduino-reset path (MCU._disconnect
-    // → serial.disconnect()). It only nils host_io/runtime_rx for one MCU; it
-    // does NOT touch endpoint_conn/endpoint_process, so it cannot tear an
-    // EtherCAT MCU down on its own. The authoritative full teardown is
-    // `shutdown()`; detach_serial is harmless before it (shutdown is idempotent).
     fn detach_serial(&self, mcu_handle: u32) -> PyResult<()> {
         let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(conn) = mcus.get_mut(&mcu_handle) {
@@ -2618,9 +2523,6 @@ impl PyMotionEngine {
         cfg.axis_registry = axis_registry;
         cfg.limit_sections = limit_sections;
         cfg.cartesian = cartesian;
-        // [limit <name>] sections are parsed so existing configs load, but they
-        // are no longer the motion-limit source ([printer] is) and the live
-        // stream pipeline never consults them — so they are left unvalidated.
         cfg.post_processors = post_processor_set;
         cfg.window_capacity = window_capacity;
         cfg.beta_max_iters = beta_max_iters;
@@ -2647,8 +2549,6 @@ impl PyMotionEngine {
             .unwrap_or_else(|p| p.into_inner()) = cfg.clone();
 
         let ec_conns: HashMap<u32, Arc<McuSerialConn>> = {
-            // Collect (handle, conn, socket_path) in one lock acquisition to
-            // close the release_mcu race window between separate lookups.
             let ethercat_handles: Vec<(u32, Arc<McuSerialConn>, String)> = {
                 let mcus_lock = self.mcus.lock().unwrap_or_else(|p| p.into_inner());
                 mcus.iter()
@@ -2993,13 +2893,6 @@ impl PyMotionEngine {
                     },
                 ));
 
-                // Weak so the supervision thread never keeps the conn (and its
-                // reader thread / socket) alive past release_mcu: when the last
-                // strong Arc drops, upgrade() fails and the thread exits quietly,
-                // letting Drop run shutdown(Both)+join. A strong Arc here would
-                // pin the reader thread until this loop happened to notice the
-                // release, leaking finished-but-unjoined readers across repeated
-                // standalone claim/release.
                 let conn_for_poll = Arc::downgrade(&conn);
                 let mcus_for_supervision = Arc::clone(&self.mcus);
                 let label_for_supervision = mcu_label.clone();
@@ -3019,37 +2912,18 @@ impl PyMotionEngine {
                     .name(format!("ec-heartbeat-poll-{mcu_id}"))
                     .spawn(move || {
                         loop {
-                            // Released conn -> exit quietly. This is the common
-                            // case: release_mcu drops the last strong Arc, the
-                            // upgrade fails, and the thread exits before probing.
-                            // The residual race — upgrading the Weak while the conn
-                            // is still strong but the MCU was already removed from
-                            // the map — is closed by the mcus-map re-check below,
-                            // which confirms every fault under the lock.
                             let Some(conn) = conn_for_poll.upgrade() else {
                                 return;
                             };
 
-                            // The reader thread sets peer_closed on EOF/IO; no poll here.
                             let peer_eof = conn.peer_closed();
                             drop(conn);
 
-                            // Both fault probes (EOF and child-exit) are confirmed
-                            // against the mcus map under one lock acquisition, so a
-                            // deliberate release can never be misread as a fault.
-                            // release_mcu removes the McuConnection from the map
-                            // BEFORE it closes the endpoint socket; that socket
-                            // close is exactly what sets peer_closed(). So if we
-                            // upgraded the Weak in the race window where the conn
-                            // was still strong but the MCU was already removed,
-                            // `mcus.get(&mcu_id)` is None here and we exit quietly
-                            // instead of firing EXIT_ON_FAULT.
                             let fault_reason = {
                                 let mut mcus = mcus_for_supervision
                                     .lock()
                                     .unwrap_or_else(|p| p.into_inner());
                                 let Some(c) = mcus.get_mut(&mcu_id) else {
-                                    // MCU was released — normal shutdown, exit quietly.
                                     return;
                                 };
                                 if peer_eof {
@@ -3758,9 +3632,6 @@ impl PyMotionEngine {
     }
 
     fn update_post_processor(&self, name: &str, key: &str, value: f64) -> PyResult<()> {
-        // Input shaping is not applied by the V1 streaming pipeline; record the
-        // parameter on the config so it round-trips, but there is no planner
-        // kernel to update yet.
         self.planner_config
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -4101,9 +3972,6 @@ impl PyMotionEngine {
             Some(io) => io.unregister_frame_interceptor(id).map_err(|e| {
                 PyRuntimeError::new_err(format!("disarm_remote_trigger: unregister failed: {e:?}"))
             }),
-            // MCU detached: its reactor (and the interceptor with it) is
-            // already gone. Disarm runs on cleanup paths — don't mask the
-            // original error.
             None => Ok(()),
         }
     }
@@ -4308,11 +4176,6 @@ impl PyMotionEngine {
 }
 
 impl Drop for PyMotionEngine {
-    // Backstop for the true-process-exit path: SIGTERM → request_exit → the
-    // klippy loop breaks → Py_Finalize → pyo3 drops the engine (if collected).
-    // The primary release stays the explicit `klippy:disconnect` → `shutdown()`
-    // call so it runs even under `gc.disable()` on the in-process restart loop.
-    // `shutdown()` is idempotent, so this never double-tears-down.
     fn drop(&mut self) {
         self.shutdown();
     }
@@ -4775,9 +4638,6 @@ mod ethercat_endpoint_tests {
             .spawn()
             .expect("sh must be available");
 
-        // Give the process time to exit so try_wait will see it on the first
-        // poll iteration (poll_socket_ready already does this internally, but
-        // a brief spin here makes the test deterministic on loaded CI runners).
         let waited = {
             let start = Instant::now();
             loop {
@@ -4854,7 +4714,6 @@ mod ethercat_endpoint_tests {
     fn handshake_retries_past_stale_socket_file() {
         use std::os::unix::net::UnixListener;
 
-        // Use pid + thread-id to avoid collisions when tests run in parallel.
         let path = format!(
             "/tmp/kalico_test_stale_{}_handshake.sock",
             std::process::id()
@@ -4883,15 +4742,7 @@ mod ethercat_endpoint_tests {
                     let cid = extract_correlation_id(&buf[..n]);
                     let reply = encode_claim_handshake_reply(cid);
                     let _ = stream.write_all(&reply);
-                    // Shutdown the write half — sends a clean FIN so the
-                    // foreground's mcu_call read loop exits on EOF (Closed)
-                    // *after* it has already matched the correlated reply frame
-                    // and returned Ok.  Without this, dropping the stream under
-                    // parallel load can race with the foreground's read.
                     let _ = stream.shutdown(std::net::Shutdown::Write);
-                    // Block on a final drain read so we don't release the fd
-                    // (and any kernel-buffered data) until the foreground has
-                    // consumed everything.
                     let _ = stream.read(&mut buf);
                 }
             }
@@ -4905,8 +4756,6 @@ mod ethercat_endpoint_tests {
         let _ = std::fs::remove_file(&path);
 
         let succeeded = result.is_ok();
-        // Drop the McuSerialConn before joining so the foreground side closes,
-        // unblocking the background thread's drain read.
         drop(result);
         let _ = bg.join();
 
@@ -4972,10 +4821,6 @@ mod ethercat_endpoint_tests {
             Err(e) => Some(format!("{e:?}")),
         };
 
-        // Drop the McuSerialConn first so the listener thread's drain read
-        // sees EOF and exits. If the handshake never connected at all, the
-        // listener is still parked in accept() — unblock it with a throwaway
-        // connection so lt.join() cannot hang the test harness.
         let _ = stop_tx.send(());
         drop(result);
         let _ = std::os::unix::net::UnixStream::connect(&path);

--- a/rust/motion-engine/src/bridge/tests.rs
+++ b/rust/motion-engine/src/bridge/tests.rs
@@ -1,21 +1,3 @@
-//! Teardown-determinism tests for the EtherCAT FIRMWARE_RESTART wedge fix.
-//!
-//! Root cause: on klippy's in-process FIRMWARE_RESTART loop the old
-//! `PyMotionEngine` was never dropped, so its `McuHostIo` reactor kept the
-//! pts fd open (with TIOCEXCL on Linux), and the next process's `attach_serial`
-//! spun on EBUSY. These tests pin the fixed contract: `shutdown()` is the single
-//! complete, ordered, idempotent teardown — it drops the host_io Arc (closing
-//! the fd), reaps the EtherCAT child, closes the EtherCAT socket, and joins the
-//! pump/planner threads, on every call and safely more than once.
-//!
-//! Note on the fd-release assertion: `TTYPort::from_raw_fd`'s TIOCEXCL only
-//! makes a second `open()` of the same pts return EBUSY on Linux; macOS pts do
-//! not honour TIOCEXCL that way (verified on the bench). So the load-bearing,
-//! portable proof of fd release is "the last `Arc<McuHostIo>` is dropped" —
-//! observed via a `Weak` that no longer upgrades — because `McuHostIo::Drop`
-//! is exactly what closes the fd. The live Linux bench check (a fresh open
-//! succeeding first-try) is in the design's verification section.
-
 use std::os::unix::io::FromRawFd;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
@@ -30,13 +12,9 @@ use trajectory::ShapedSegment;
 
 use super::{McuConnection, PyMotionEngine};
 
-/// Open a pty pair and return (master_fd, slave_path). The master fd is kept
-/// open by the caller so the slave stays valid; close it at end of test.
 fn open_pty() -> (libc::c_int, String) {
     let mut master: libc::c_int = 0;
     let mut slave: libc::c_int = 0;
-    // SAFETY: openpty writes two valid fds; the name buffer is large enough for
-    // any pts path. We check the return code before using the fds.
     #[allow(unsafe_code)]
     let path = unsafe {
         let mut name_buf = [0i8; 256];
@@ -48,23 +26,15 @@ fn open_pty() -> (libc::c_int, String) {
             std::ptr::null_mut(),
         );
         assert_eq!(r, 0, "openpty failed: {}", std::io::Error::last_os_error());
-        // We build McuHostIo from the slave fd; the master fd is the "peer".
-        // The slave path is what a real attach_serial would open.
         let cstr = std::ffi::CStr::from_ptr(name_buf.as_ptr());
         let p = cstr.to_str().expect("pts path is utf-8").to_owned();
-        // Close the slave fd we got from openpty — McuHostIo opens its own
-        // handle to the slave via the path below, mirroring attach_serial.
         libc::close(slave);
         p
     };
     (master, path)
 }
 
-/// Build a `McuHostIo` bound to `slave_path` (the reactor owns a real fd),
-/// skipping the wire identify handshake. Returns the Arc plus a Weak to observe
-/// the Arc's strong-count dropping to zero on teardown.
 fn host_io_on_pty(slave_path: &str) -> (Arc<McuHostIo>, Weak<McuHostIo>) {
-    // SAFETY: open + from_raw_fd are FFI boundaries; we check `fd >= 0`.
     #[allow(unsafe_code)]
     let port: Box<dyn serialport::SerialPort> = unsafe {
         let cpath = std::ffi::CString::new(slave_path).unwrap();
@@ -115,9 +85,6 @@ fn mcus_is_empty(engine: &PyMotionEngine) -> bool {
         .is_empty()
 }
 
-/// Seed a real pump channel + thread into the engine, mirroring the wiring
-/// init_planner installs, so `shutdown()`'s pump-join path is exercised.
-/// The thread runs until it receives `PumpMsg::Shutdown`.
 fn seed_pump_thread(engine: &PyMotionEngine) -> Arc<std::sync::atomic::AtomicBool> {
     let (tx, rx) = std::sync::mpsc::channel::<crate::pump::PumpMsg>();
     let exited = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -138,10 +105,6 @@ fn seed_pump_thread(engine: &PyMotionEngine) -> Arc<std::sync::atomic::AtomicBoo
     exited
 }
 
-/// (a) The host_io Arc is the last strong ref and is dropped by `shutdown()`,
-/// which is exactly what `McuHostIo::Drop` uses to close the pts fd — the
-/// direct EBUSY-release proof. (b) The pump thread is joined (Shutdown sent,
-/// handle taken → None, thread observed exited). (c) The mcus map is emptied.
 #[test]
 fn shutdown_releases_pty_and_joins_threads() {
     let engine = PyMotionEngine::new();
@@ -149,9 +112,6 @@ fn shutdown_releases_pty_and_joins_threads() {
 
     let (io_arc, io_weak) = host_io_on_pty(&slave_path);
     insert_mcu(&engine, 1, serial_mcu_conn("mcu", &slave_path, io_arc));
-    // Drop our own strong ref: the only remaining strong ref is inside the
-    // McuConnection, mirroring production where attach_serial's local Arcs have
-    // already been dropped and pump/heartbeat hold Weak only.
     assert!(
         io_weak.upgrade().is_some(),
         "host_io must be alive pre-shutdown"
@@ -187,15 +147,12 @@ fn shutdown_releases_pty_and_joins_threads() {
         "shut_down flag must be latched"
     );
 
-    // SAFETY: master_fd is the pty master we kept open; close it now.
     #[allow(unsafe_code)]
     unsafe {
         libc::close(master_fd);
     }
 }
 
-/// `shutdown()` must reap the EtherCAT child and close the endpoint socket so
-/// the peer sees EOF.
 #[test]
 fn shutdown_releases_ethercat_socket_and_child() {
     use std::io::Read;
@@ -203,12 +160,9 @@ fn shutdown_releases_ethercat_socket_and_child() {
 
     let engine = PyMotionEngine::new();
 
-    // socketpair: one end becomes the McuSerialConn (endpoint_conn), the other
-    // is the test-held "peer" that must observe EOF when the conn is dropped.
     let (conn_stream, peer_stream) = UnixStream::pair().expect("socketpair must be available");
     let native = McuSerialConn::from_stream(conn_stream).expect("from_stream");
 
-    // A long-lived child that SIGTERM will terminate (mirrors the endpoint).
     let child = std::process::Command::new("sh")
         .args(["-c", "sleep 30"])
         .spawn()
@@ -233,11 +187,6 @@ fn shutdown_releases_ethercat_socket_and_child() {
 
     engine.shutdown();
 
-    // Peer sees EOF: the conn's socket (and its try_clones) are all closed.
-    // `shutdown()` synchronously joins McuSerialConn's reader (Drop does
-    // shutdown(Both)+join), so the socket is fully closed before it returns and
-    // this read returns EOF immediately. Run it in a watchdog thread so a
-    // regression (socket left open) surfaces as a test failure, not a hang.
     let (done_tx, done_rx) = std::sync::mpsc::channel::<std::io::Result<usize>>();
     std::thread::spawn(move || {
         let mut peer = peer_stream;
@@ -253,9 +202,6 @@ fn shutdown_releases_ethercat_socket_and_child() {
         "peer must see EOF (0 bytes) after endpoint_conn dropped"
     );
 
-    // Child is reaped: the pid is no longer a live process we can signal
-    // (SIGTERM was sent + reaped by release_mcu). kill(pid, 0) must fail ESRCH.
-    // SAFETY: signal 0 only probes existence; it never delivers a signal.
     #[allow(unsafe_code)]
     let alive = unsafe { libc::kill(child_pid as libc::pid_t, 0) };
     assert_eq!(
@@ -274,8 +220,6 @@ fn shutdown_releases_ethercat_socket_and_child() {
     );
 }
 
-/// `shutdown(); shutdown();` — the second call is a clean no-op: no panic, no
-/// double-join, and the `shut_down` flag is observed on entry.
 #[test]
 fn double_shutdown_is_safe() {
     let engine = PyMotionEngine::new();
@@ -290,20 +234,15 @@ fn double_shutdown_is_safe() {
     );
     assert!(engine.shut_down.load(std::sync::atomic::Ordering::SeqCst));
 
-    // Second call must short-circuit on the latched flag and not panic.
     engine.shutdown();
     assert!(mcus_is_empty(&engine));
 
-    // SAFETY: master_fd is the pty master we kept open; close it now.
     #[allow(unsafe_code)]
     unsafe {
         libc::close(master_fd);
     }
 }
 
-/// A no-op dispatch closure paired with an invocation counter — the trivial
-/// seam (mirrors `planner::tests::counting_dispatch`) for spawning a real
-/// `kalico-planner` thread without a transport behind it.
 fn counting_dispatch() -> (
     Arc<dyn Fn(&ShapedSegment) -> Result<(), DispatchError> + Send + Sync>,
     Arc<AtomicUsize>,
@@ -323,8 +262,6 @@ fn noop_nudge_dispatch()
     Arc::new(|_mcu_id: u32, _np: &crate::nudge::NudgePiece| Ok(()))
 }
 
-/// Loosened fit tolerance for fast planning in tests (mirrors
-/// `planner::tests::relaxed_config`).
 fn relaxed_planner_config() -> PlannerConfig {
     let mut c = PlannerConfig::default();
     c.fit_tolerance_mm = 0.05;
@@ -346,11 +283,6 @@ fn stream_config_from(cfg: &PlannerConfig) -> (crate::stream::StreamConfig, Vec<
     (sc, vec![0.0; cfg.axis_registry.n_axes().max(3)])
 }
 
-/// `shutdown()` must drain the `Mutex<Option<PlannerHandle>>` and join the
-/// `kalico-planner` thread. The OnceLock→Mutex<Option> migration is the
-/// centerpiece of this change; this is the engine-level proof that
-/// `shutdown()`'s planner take()+`PlannerHandle::shutdown()` path actually runs
-/// (planner::tests only covers `PlannerHandle::shutdown()` in isolation).
 #[test]
 fn shutdown_takes_and_joins_planner() {
     let engine = PyMotionEngine::new();
@@ -385,35 +317,10 @@ fn shutdown_takes_and_joins_planner() {
     );
 }
 
-/// Regression test for the teardown-ordering blocker: the planner must be joined
-/// BEFORE the pump's `Receiver` is dropped.
-///
-/// Mechanism guarded against: while the planner holds an uncommitted decel tail
-/// (`t_dispatched < t_appended`), its `recv_timeout` fires
-/// `run_commit_and_dispatch`, which calls the dispatch closure → `pump_tx.send`.
-/// If the pump's `Receiver` were already gone, that send fails →
-/// `DispatchError::PumpGone` → the real planner calls `fatal()` →
-/// `std::process::abort()`, which skips every `Drop` and re-leaks the pts fd.
-///
-/// We reproduce the exact dependency WITHOUT the real abort path so the bug
-/// surfaces as a clean assertion failure, not a test-binary abort: the test's
-/// dispatch sends into the same channel whose `Receiver` `shutdown()` drops, and
-/// on a send failure it *records a flag and returns Ok* (so the real planner's
-/// `fatal()`/`abort()` is never reached). A background thread keeps submitting
-/// moves so the planner always holds a pending tail and is continuously firing
-/// timeout-commit dispatches across the teardown window. With the fixed order
-/// (planner joined first), the pump's Receiver outlives every dispatch and
-/// `saw_pump_gone` stays false; with the pre-fix pump-first order the planner
-/// dispatches into the already-dropped Receiver and the flag flips true.
 #[test]
 fn shutdown_joins_planner_before_dropping_pump_receiver() {
     let engine = PyMotionEngine::new();
 
-    // The channel the dispatch closure sends into. Its Receiver lives in the
-    // pump thread we seed below; `shutdown()` drops it when it tears the pump.
-    // A clone goes into engine.pump_tx so shutdown()'s `Shutdown` reaches the
-    // pump thread (mirroring production: pump_tx and the dispatch's tx are the
-    // same channel; the pump owns the single Receiver).
     let (pump_tx, pump_rx) = std::sync::mpsc::channel::<crate::pump::PumpMsg>();
     let pump_tx_for_engine = pump_tx.clone();
 
@@ -424,13 +331,6 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
     let dispatch: Arc<dyn Fn(&ShapedSegment) -> Result<(), DispatchError> + Send + Sync> =
         Arc::new(move |_seg: &ShapedSegment| {
             dispatch_count_cb.fetch_add(1, Ordering::SeqCst);
-            // Mirror the production dispatch's pump-send. We send a (cheap)
-            // Heartbeat, NOT Shutdown — Shutdown is the pump's own exit signal,
-            // which only `engine.shutdown()` may send. A failed send means the
-            // pump's Receiver is already dropped — the exact condition that yields
-            // DispatchError::PumpGone in production. We record it and return Ok so
-            // the real planner never reaches fatal()/abort() and the test can
-            // assert cleanly.
             let hb = crate::pump::PumpMsg::Heartbeat(crate::pump::HeartbeatMsg {
                 mcu_id: 0,
                 retired_counts: Vec::new(),
@@ -443,8 +343,6 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
 
     let (sc, home) = stream_config_from(&relaxed_planner_config());
     let planner = StreamPlannerHandle::spawn(sc, home, dispatch, noop_nudge_dispatch());
-    // Prime one move so the planner has a pending tail before the submitter and
-    // pump are even wired — the recv_timeout branch is armed from the start.
     planner
         .submit_move(
             crate::classify::build_move([0.0; 3], 50.0, 0.0, 0.0, 0, 0.0, test_limits(), 200.0, 0)
@@ -454,11 +352,6 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
     let engine = Arc::new(engine);
     *engine.planner.lock().unwrap_or_else(|p| p.into_inner()) = Some(planner);
 
-    // Seed the pump thread holding the matching Receiver, mirroring production:
-    // run_pump owns pump_rx by value and exits on PumpMsg::Shutdown — at which
-    // point pump_rx is dropped *while the dispatch closure's Sender is still
-    // alive*. That is precisely the window in which the wrong teardown order lets
-    // the planner's next timeout-commit dispatch hit a dead Receiver.
     let pump_handle = std::thread::Builder::new()
         .name("push-pieces-pump".into())
         .spawn(move || {
@@ -473,11 +366,6 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
     *engine.pump_thread.lock().unwrap_or_else(|p| p.into_inner()) = Some(pump_handle);
     *engine.pump_tx.lock().unwrap_or_else(|p| p.into_inner()) = Some(pump_tx_for_engine);
 
-    // Background submitter: keep the planner perpetually holding an uncommitted
-    // decel tail so its recv_timeout branch stays armed and it fires timeout-
-    // commit dispatches continuously — including through the teardown window. It
-    // drives the planner through the engine's Mutex<Option<PlannerHandle>>; once
-    // shutdown() take()s the planner it observes None and stops.
     let stop = Arc::new(AtomicBool::new(false));
     let stop_sub = Arc::clone(&stop);
     let engine_sub = Arc::clone(&engine);
@@ -511,7 +399,6 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
         })
         .expect("spawn test submitter");
 
-    // Let the planner run long enough to be actively firing timeout-commits.
     std::thread::sleep(std::time::Duration::from_millis(300));
     assert!(
         dispatch_count.load(Ordering::SeqCst) > 0,
@@ -540,30 +427,6 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
     );
 }
 
-/// Regression for the EtherCAT pump-abort ordering bug:
-///
-/// With the old ordering (`release_mcu` first, pump last), a pump that still
-/// holds queued pieces for an EtherCAT MCU would call `send_frame` after the
-/// last strong `Arc<McuSerialConn>` was dropped by `release_mcu`. The
-/// `Weak::upgrade()` returns `None` → `SendError::Fatal` → `on_fatal_transport`
-/// → `std::process::abort()`, which skips every `Drop` and re-leaks the pts fd.
-///
-/// With the fixed ordering (planner join → pump join → release_mcu), the pump
-/// receives `PumpMsg::Shutdown` and exits before any send can fire against a
-/// dead transport. This test pins that contract without touching production
-/// abort semantics:
-///
-///   (a) A `WireSink` is wired with a detached EtherCAT `Weak` (no strong Arc)
-///       and an injectable `on_fatal_transport` that sets a flag instead of
-///       aborting — identical to the seam used in pump's own unit tests.
-///   (b) Pieces for the dead mcu_id are enqueued into the pump BEFORE
-///       `shutdown()` is called. The pump is held in `StallAhead` (clock
-///       horizon is behind the pieces' start-time) so it cannot drain the
-///       queue before `Shutdown` arrives.
-///   (c) `engine.shutdown()` runs: planner join → pump Shutdown+join →
-///       release_mcu.  The `on_fatal_transport` flag must remain `false`
-///       throughout — proving the pump exited via `Shutdown` before it could
-///       touch the dead transport.
 #[test]
 fn shutdown_does_not_abort_on_detached_ethercat_weak() {
     use runtime::piece_ring::PieceEntry;
@@ -574,9 +437,6 @@ fn shutdown_does_not_abort_on_detached_ethercat_weak() {
 
     const EC_MCU_ID: u32 = 42;
 
-    // Detached Weak: the strong Arc is never stored anywhere, so upgrade() always
-    // returns None → Fatal.  This mirrors the state after the old release_mcu had
-    // dropped the last strong Arc while the pump was still alive.
     let detached_weak: std::sync::Weak<host_rt::mcu_serial_conn::McuSerialConn> =
         std::sync::Weak::new();
 
@@ -593,16 +453,7 @@ fn shutdown_does_not_abort_on_detached_ethercat_weak() {
         freq_of: Arc::new(|_| None),
     };
 
-    // mcu_clock_of returns a horizon behind any realistic start_time so that
-    // schedule() always returns StallAhead — pieces stay queued, send_frame is
-    // never called, and the pump blocks on recv_timeout(50ms) waiting for more
-    // messages.  When Shutdown arrives via recv_timeout, run_pump returns
-    // immediately without touching the dead transport.
-    let mcu_clock_of = |_mcu_id: u32| -> Option<(u64, f64)> {
-        // ack_now=1, freq=1.0 → horizon = 1 + 1 = 2. Any piece with
-        // start_time > 2 stalls.
-        Some((1, 1.0))
-    };
+    let mcu_clock_of = |_mcu_id: u32| -> Option<(u64, f64)> { Some((1, 1.0)) };
 
     let (pump_tx, pump_rx) = std::sync::mpsc::channel::<PumpMsg>();
 
@@ -623,9 +474,6 @@ fn shutdown_does_not_abort_on_detached_ethercat_weak() {
         })
         .expect("spawn test pump thread");
 
-    // Enqueue pieces with start_time well above the horizon (2) so schedule()
-    // stalls rather than sending. The pump enters StallAhead and blocks on
-    // recv_timeout(50ms) — pieces are live in the queue when shutdown() runs.
     let pieces_to_enqueue = vec![(
         PieceEntry {
             start_time: 1_000_000,
@@ -648,16 +496,12 @@ fn shutdown_does_not_abort_on_detached_ethercat_weak() {
         }))
         .expect("enqueue must succeed before shutdown");
 
-    // Give the pump time to process the Enqueue message and enter StallAhead
-    // so it is blocking on recv_timeout when Shutdown arrives.
     std::thread::sleep(Duration::from_millis(30));
 
-    // Seed the pump into the engine so shutdown() drives it.
     let engine = Arc::new(PyMotionEngine::new());
     *engine.pump_tx.lock().unwrap_or_else(|p| p.into_inner()) = Some(pump_tx);
     *engine.pump_thread.lock().unwrap_or_else(|p| p.into_inner()) = Some(pump_handle);
 
-    // Also seed a planner so the planner-join step of shutdown() is exercised.
     let (dispatch, _counter) = counting_dispatch();
     let (sc, home) = stream_config_from(&relaxed_planner_config());
     *engine.planner.lock().unwrap_or_else(|p| p.into_inner()) = Some(StreamPlannerHandle::spawn(
@@ -748,7 +592,6 @@ fn partial_state_teardown_at_exit() {
     );
     assert!(mcus_is_empty(&engine));
 
-    // SAFETY: master_fd is the pty master we kept open; close it now.
     #[allow(unsafe_code)]
     unsafe {
         libc::close(master_fd);

--- a/rust/motion-engine/src/classify.rs
+++ b/rust/motion-engine/src/classify.rs
@@ -86,10 +86,6 @@ pub fn classify_and_build(
     })
 }
 
-/// Build a geometry-pipeline `Move` (line, with an optional extruder follower)
-/// from a start position and per-axis deltas. This is the new-pipeline
-/// counterpart to `classify_and_build`: instead of a host-NURBS `CubicSegment`
-/// it produces a `frontend::Move` the streaming planner buffers and blends.
 #[allow(clippy::too_many_arguments)]
 pub fn build_move(
     start: [f64; 3],

--- a/rust/motion-engine/src/classify/tests.rs
+++ b/rust/motion-engine/src/classify/tests.rs
@@ -66,8 +66,6 @@ fn nominal_duration_uses_3d_distance() {
 
 #[test]
 fn classify_bezier_uses_arc_length_for_distance_and_ratio() {
-    // A curved G5 with an E delta. distance_mm must be the arc length (> chord),
-    // and the follower ratio must be de / arc_length (not de / chord).
     let start = [0.0, 0.0, 0.0];
     let m = classify_bezier(
         start,
@@ -101,8 +99,6 @@ fn classify_quadratic_builds_a_segment() {
 
 #[test]
 fn chain_reflection_negates_previous_pq() {
-    // Chained G5: omitted I/J => (I,J) = (-P_prev, -Q_prev). The reflection is
-    // XY-only; P1.z stays on the linear-Z assembly, NOT a 3D reflection.
     let prev_pq = (3.0, -2.0);
     let (i, j) = (-prev_pq.0, -prev_pq.1);
     let cps = g5_control_points([0.0, 0.0, 0.0], i, j, 1.0, 1.0, 10.0, 0.0, 0.0);
@@ -113,11 +109,6 @@ fn chain_reflection_negates_previous_pq() {
 
 #[test]
 fn experiment_cusp_and_near_cusp_classification_is_finite() {
-    // Exact cusp: i=j=0 => P1 == P0 (zero start tangent, fold-back curve).
-    // Near-cusp: tiny start leg (i=1e-7).
-    // Both must either (a) classify successfully with finite arc length,
-    // or (b) return ZeroDisplacement — the one case where arc_length <= epsilon.
-    // What must NEVER happen: a panic or a non-finite distance_mm.
     let exact = classify_bezier(
         [0.0, 0.0, 0.0],
         0.0,

--- a/rust/motion-engine/src/config.rs
+++ b/rust/motion-engine/src/config.rs
@@ -330,7 +330,6 @@ impl AxisRegistry {
         &self.ordered
     }
 
-    /// `(follower_axis_index, followed_axis_indices)` per non-spatial axis.
     #[must_use]
     pub fn follower_index_map(&self) -> Vec<(usize, Vec<usize>)> {
         self.ordered
@@ -410,10 +409,6 @@ pub struct RuntimeCaps {
     pub accel: Option<f64>,
 }
 
-/// Mainline-style global motion limits read from `[printer]`: one velocity /
-/// accel / jerk for the XY plane plus separate Z caps. The streaming geometry
-/// pipeline projects these per move (Z caps bind only on Z-bearing moves), so
-/// an XY move never inherits the slower Z limit.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CartesianLimits {
     pub max_velocity: f64,
@@ -454,9 +449,6 @@ impl CartesianLimits {
         Ok(())
     }
 
-    /// The scalar path caps for a move with spatial deltas `(dx, dy, dz)`. The Z
-    /// caps project onto the path by the move's Z direction cosine, mirroring
-    /// mainline's `move.limit_speed(max_z_* / |z_unit|)`.
     #[must_use]
     pub fn for_move(&self, dx: f64, dy: f64, dz: f64) -> (f64, f64) {
         let d = (dx * dx + dy * dy + dz * dz).sqrt();
@@ -507,10 +499,6 @@ impl LimitSection {
     }
 }
 
-/// Square-corner velocity used when `[printer]` omits `square_corner_velocity`.
-/// The pipeline blends corners and caps their speed by curvature (`sqrt(a/κ)`),
-/// so this is not the primary corner limiter; it satisfies `VelocityLimits`'
-/// contract and is the floor applied to near-reversal junctions.
 pub const DEFAULT_SQUARE_CORNER_VELOCITY_MM_S: f64 = 5.0;
 
 impl PlannerConfig {
@@ -534,9 +522,6 @@ impl PlannerConfig {
         )
     }
 
-    /// Collapse the spatial limit sections (most-restrictive across them) plus
-    /// any runtime-caps override into the scalar path limits the geometry
-    /// pipeline consumes per move.
     pub fn path_velocity_limits(&self) -> Result<geometry::VelocityLimits, &'static str> {
         let mut max_v = f64::INFINITY;
         let mut max_a = f64::INFINITY;
@@ -564,9 +549,6 @@ impl PlannerConfig {
         geometry::VelocityLimits::try_new(max_v, max_a, DEFAULT_SQUARE_CORNER_VELOCITY_MM_S)
     }
 
-    /// Most-restrictive spatial jerk cap (falling back to `accel × default
-    /// multiple`, then a finite engine default) for the geometry velocity
-    /// planner's jerk-limited s-curve.
     #[must_use]
     pub fn path_velocity_config(&self) -> geometry::VelocityConfig {
         let mut max_j = f64::INFINITY;

--- a/rust/motion-engine/src/dispatch.rs
+++ b/rust/motion-engine/src/dispatch.rs
@@ -124,7 +124,6 @@ pub fn build_seed_sends(configs: &[McuAxisConfig], x: f64, y: f64, z: f64) -> Ve
         .collect()
 }
 
-// `runtime_seed_position` is serial-only; EtherCAT nodes are position-commanded with no serial transport.
 pub fn build_serial_seed_sends<S: ::std::hash::BuildHasher>(
     configs: &[McuAxisConfig],
     ethercat_mcu_ids: &HashSet<u32, S>,
@@ -132,9 +131,11 @@ pub fn build_serial_seed_sends<S: ::std::hash::BuildHasher>(
     y: f64,
     z: f64,
 ) -> Vec<SeedSend> {
+    let reachable_over_serial_transport =
+        |cfg: &&McuAxisConfig| !ethercat_mcu_ids.contains(&cfg.mcu_id);
     configs
         .iter()
-        .filter(|cfg| !ethercat_mcu_ids.contains(&cfg.mcu_id))
+        .filter(reachable_over_serial_transport)
         .map(|cfg| {
             let m = motor_frame(cfg, [x, y, z]);
             SeedSend {

--- a/rust/motion-engine/src/drain.rs
+++ b/rust/motion-engine/src/drain.rs
@@ -1,7 +1,3 @@
-//! `retired` is the MCU's raw cumulative counter (monotonic per boot); `sent`
-//! is per-stream. `reset()` snapshots `retired` into `baseline` so drained
-//! comparisons (`retired - baseline == sent`) survive multi-stream sessions.
-
 use std::collections::HashMap;
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
@@ -52,9 +48,10 @@ impl DrainSync {
     pub fn reset(&self) {
         let mut c = self.counts.lock().unwrap_or_else(|p| p.into_inner());
         c.sent.clear();
-        let snapshot: Vec<(AxisKey, u32)> = c.retired.iter().map(|(&k, &v)| (k, v)).collect();
-        for (k, v) in snapshot {
-            c.baseline.insert(k, v);
+        let retired_snapshot: Vec<(AxisKey, u32)> =
+            c.retired.iter().map(|(&k, &v)| (k, v)).collect();
+        for (key, retired_at_reset) in retired_snapshot {
+            c.baseline.insert(key, retired_at_reset);
         }
         drop(c);
         self.cv.notify_all();

--- a/rust/motion-engine/src/lib.rs
+++ b/rust/motion-engine/src/lib.rs
@@ -50,8 +50,6 @@ use pyo3::prelude::*;
 
 use bridge::PyMotionEngine;
 
-// Underscore-prefixed so the compiled extension (_motion_engine) does not
-// shadow the pure-Python wrapper klippy/motion_engine.py that imports it.
 #[pymodule]
 fn _motion_engine(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyMotionEngine>()?;

--- a/rust/motion-engine/src/lowering.rs
+++ b/rust/motion-engine/src/lowering.rs
@@ -7,17 +7,8 @@ use trajectory::ShapedSegment;
 const MIN_PIECE_DURATION_S: f64 = 1e-9;
 const MAX_SUBDIVISION_DEPTH: u32 = 22;
 
-/// Minimum duration of an emitted cubic piece. The MCU consumes pieces against
-/// a fixed step-sample clock (tens of µs); a piece shorter than several samples
-/// makes the MCU evaluate one cubic across a sample boundary and extrapolate it
-/// — corrupting the dispatched polynomial (Neptune steps-per-sample fault). The
-/// velocity profile can carry thousands of samples per move, so we fit *coarse*
-/// pieces to tolerance and never subdivide below this floor.
 const MIN_FIT_PIECE_S: f64 = 5e-4;
 
-/// Interior fractions sampled when testing a candidate cubic against the true
-/// trajectory over a span; a span passes only if every sampled axis is within
-/// `fit_tol_mm`.
 const RESIDUAL_PROBES: [f64; 3] = [0.25, 0.5, 0.75];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -99,11 +90,6 @@ fn build_phases(samples: &[VelSample]) -> Result<(Vec<Phase>, f64), LoweringErro
     Ok((phases, t_acc))
 }
 
-/// Power-basis cubic on `[u_start, u_end]` matching position and velocity at
-/// both ends (Hermite). `coeffs[k]` multiplies `(u − u_start)^k` — the
-/// representation `BezierPiece::evaluate` expects. A quadratic input (the line
-/// case, where position is exactly quadratic in time) yields `coeffs[3] == 0`
-/// and is reproduced exactly.
 fn hermite_cubic(u_start: f64, u_end: f64, p0: f64, v0: f64, p1: f64, v1: f64) -> BezierPiece<f64> {
     let h = u_end - u_start;
     if h <= 0.0 {
@@ -132,9 +118,6 @@ struct Sampler<'a> {
 }
 
 impl Sampler<'_> {
-    /// Absolute (position, velocity) for one registry axis at move-local time
-    /// `t`. Spatial axes ride the path; followers pay out `start + ratio·s`;
-    /// every other axis holds at its start position.
     fn axis_state(&self, axis: usize, t: f64) -> (f64, f64) {
         let (s, v) = locate(self.phases, t).s_v_at(t);
         if axis < 3 {
@@ -149,8 +132,6 @@ impl Sampler<'_> {
         }
     }
 
-    /// Worst-axis deviation of the candidate cubic over `[ta, tb]` from the true
-    /// trajectory, sampled at the interior probes.
     fn span_residual(&self, driven: &[usize], ta: f64, tb: f64) -> f64 {
         let mut worst = 0.0_f64;
         for &axis in driven {
@@ -174,10 +155,6 @@ fn locate(phases: &[Phase], t: f64) -> &Phase {
         .unwrap_or(&phases[phases.len() - 1])
 }
 
-/// Adaptively split `[ta, tb]` into spans each fittable by a single cubic within
-/// `tol_mm`, never going below `MIN_FIT_PIECE_S`. Appends the right edge of each
-/// accepted span to `out`. This fits *coarse* pieces that span many velocity
-/// samples — the MCU step clock cannot consume sub-sample pieces.
 fn refine_span(
     sampler: &Sampler<'_>,
     driven: &[usize],
@@ -200,12 +177,6 @@ fn refine_span(
     }
 }
 
-/// Lower a single planned move into a per-axis position-vs-time [`ShapedSegment`]
-/// in the planner's absolute time domain, starting at `t_start` and from the
-/// absolute registry positions `start_pos` (index = registry axis: 0..3
-/// spatial, then followers). The result feeds `enqueue_segment` unchanged. The
-/// trajectory is C1 (velocity-continuous across phases; acceleration may step),
-/// matching the velocity planner's own continuity.
 pub fn lower_move(
     gm: &Move,
     vm: &MoveVelocity,
@@ -237,12 +208,17 @@ pub fn lower_move(
     let mut driven: Vec<usize> = (0..3).collect();
     driven.extend(gm.segment.followers.iter().map(|f| f.axis_index));
 
-    // Coarse time grid shared by every axis: fit cubic pieces to tolerance over
-    // the whole move (spanning many velocity samples), never below the
-    // minimum-duration floor. One piece per velocity sample would emit thousands
-    // of sub-sample pieces the MCU cannot consume.
-    let mut bounds = vec![0.0];
-    refine_span(&sampler, &driven, fit_tol_mm, 0.0, total_t, 0, &mut bounds);
+    let mut coarse_fit_grid = vec![0.0];
+    refine_span(
+        &sampler,
+        &driven,
+        fit_tol_mm,
+        0.0,
+        total_t,
+        0,
+        &mut coarse_fit_grid,
+    );
+    let bounds = coarse_fit_grid;
 
     let mut axes_pieces: Vec<Vec<BezierPiece<f64>>> = vec![Vec::new(); n_axes];
     for w in bounds.windows(2) {

--- a/rust/motion-engine/src/lowering/tests.rs
+++ b/rust/motion-engine/src/lowering/tests.rs
@@ -7,12 +7,6 @@ use geometry::{
 use nurbs::bezier::extract_bezier_pieces;
 use nurbs::eval::eval;
 
-/// Regression for the Neptune steps-per-sample fault: the velocity profile can
-/// carry thousands of samples per move, but the MCU consumes pieces against a
-/// fixed ~tens-of-µs step clock. A piece shorter than several samples makes the
-/// MCU extrapolate one cubic across a sample boundary and blow up the step rate.
-/// Lowering must emit *coarse* pieces (bounded count, every piece ≥ the floor),
-/// not one per velocity sample.
 #[test]
 fn lowering_emits_coarse_pieces_above_the_sample_floor() {
     for (start, end) in [
@@ -39,9 +33,8 @@ fn lowering_emits_coarse_pieces_above_the_sample_floor() {
                 pieces.len()
             );
             for p in &pieces {
-                // A single whole-move piece may be shorter than the floor; only
-                // multi-piece fits must respect it (no sub-sample subdivision).
-                if pieces.len() > 1 {
+                let fit_was_subdivided = pieces.len() > 1;
+                if fit_was_subdivided {
                     assert!(
                         p.u_end - p.u_start >= MIN_FIT_PIECE_S - 1e-9,
                         "axis {axis}: piece {:.6}us below the floor",

--- a/rust/motion-engine/src/motion_node.rs
+++ b/rust/motion-engine/src/motion_node.rs
@@ -3,7 +3,6 @@ pub fn monotonic_ns() -> u64 {
         tv_sec: 0,
         tv_nsec: 0,
     };
-    // SAFETY: `ts` is a valid writable `timespec`; `CLOCK_MONOTONIC_RAW` is available on Linux/macOS.
     #[allow(unsafe_code)]
     unsafe {
         libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut ts);

--- a/rust/motion-engine/src/planner.rs
+++ b/rust/motion-engine/src/planner.rs
@@ -240,8 +240,6 @@ impl PlannerHandle {
             "planner.submit_move enter"
         );
 
-        // Advance before channel send so the atomic is fresh when submit_move returns.
-        // CAS guards against concurrent rectification from the planner thread.
         let nominal = m.nominal_duration();
         advance_last_move_time(&self.last_move_time_bits, nominal);
 
@@ -349,8 +347,6 @@ impl PlannerHandle {
             .map_err(|_| PlannerError::ChannelClosed)
     }
 
-    /// Must be called *before* `Router::set_clock_est_from_sample` to drain
-    /// held-back output under the old bias first.
     pub fn clock_sync_rearm(&self, new_bias: ClockBias) -> Result<(), PlannerError> {
         self.sender
             .send(PlannerMsg::ClockSyncRearm { new_bias })
@@ -422,8 +418,8 @@ fn fatal(e: &PlannerError) -> ! {
         error = %e,
         "planner encountered an unrecoverable error — aborting"
     );
-    // abort() skips the non_blocking appender's flush; let the worker drain.
-    std::thread::sleep(Duration::from_millis(100));
+    let log_appender_flush_drain = Duration::from_millis(100);
+    std::thread::sleep(log_appender_flush_drain);
     std::process::abort();
 }
 
@@ -584,9 +580,6 @@ fn run_loop(
 
         match msg {
             PlannerMsg::Move(m) => {
-                // `submit_move` already advanced `last_move_time_bits` by the nominal.
-                // Rectify if actual diverges: use CAS since submit_move is a concurrent writer.
-                // Rectify against t_appended delta (not dispatched): the decel tail is held back.
                 let nominal = m.nominal_duration();
                 let prior_t_appended = state.t_appended;
                 let prior_t_decel = state.t_decel_start;
@@ -605,12 +598,8 @@ fn run_loop(
                             &commit_fire_count,
                         );
                     }
-                    // Resume with the same dispatch cushion a fresh stream
-                    // gets: anchoring at bare `esc` leaves the upcoming
-                    // append_and_replan solve (observed 100-200 ms) to consume
-                    // the entire lead before seg0 is even emitted, landing
-                    // pieces in the MCU past.
-                    state.advance_idle(esc + LEAD);
+                    let resume_with_dispatch_cushion = esc + LEAD;
+                    state.advance_idle(resume_with_dispatch_cushion);
                 }
 
                 let replan_start = Instant::now();
@@ -715,9 +704,6 @@ fn run_loop(
                 {
                     let fields =
                         crate::binding_report::anytime_event_fields(&binding, &limit_names);
-                    // Fixed-decimal so the JSON layer stores e.g. "0.5970" instead of
-                    // serde's "2.03e-7" — comparable at a glance in the log UI and still
-                    // numerically filterable (VL parses numeric-looking strings).
                     let binding_ratio_str = format!("{:.4}", fields.binding_ratio);
                     let peak_util_str = format!("{:.4}", binding.peak_utilization);
                     let peak_util_family = match binding.peak_util_family {
@@ -771,9 +757,8 @@ fn run_loop(
                     }
                 }
 
-                // Capture sync_instant only on non-empty dispatch, not at append.
-                // Capturing at append would make elapsed_since_sync run ahead of the MCU playhead.
-                if sync_instant.is_none() && !drained.is_empty() {
+                let pieces_reached_mcu = !drained.is_empty();
+                if sync_instant.is_none() && pieces_reached_mcu {
                     sync_instant = Some(Instant::now());
                 }
 
@@ -853,9 +838,6 @@ fn run_loop(
             }
 
             PlannerMsg::ClockSyncRearm { new_bias: _ } => {
-                // Pre-swap barrier: flush held-back output under the old clock bias.
-                // Must run before Router::set_clock_est_from_sample — calling after
-                // would shape the drained tail under the new bias.
                 if state.t_dispatched < state.t_appended - 1e-12 {
                     run_commit_and_dispatch(
                         &mut state,

--- a/rust/motion-engine/src/planner/tests.rs
+++ b/rust/motion-engine/src/planner/tests.rs
@@ -626,11 +626,10 @@ fn move_after_idle_resumes_with_dispatch_lead() {
         "move 2 produced no dispatched segments"
     );
 
-    // flush() returns at wall time sync + m1_end + LEAD, then we idle a bit
-    // more; the resume must anchor at elapsed-since-sync at receipt PLUS a
-    // full dispatch lead, or the replan solve eats the cushion and seg0
-    // reaches the MCU already in the past (-308 PieceStartInPast on jog).
-    let min_expected = m1_max_t_end + LEAD + idle_extra + LEAD - 0.1;
+    let flush_anchor = m1_max_t_end + LEAD;
+    let resume_dispatch_lead = LEAD;
+    let solve_slack = 0.1;
+    let min_expected = flush_anchor + idle_extra + resume_dispatch_lead - solve_slack;
     assert!(
         m2_min_t_start >= min_expected,
         "move after idle anchored too early: started {m2_min_t_start:.3}, \

--- a/rust/motion-engine/src/position_query.rs
+++ b/rust/motion-engine/src/position_query.rs
@@ -4,9 +4,6 @@ use std::collections::HashMap;
 
 const AXIS_NAMES: [&str; 4] = ["x", "y", "z", "e"];
 
-/// `motors[slot]` / `vmotors[slot]` are motor-space mm / mm-s, `None` if that slot
-/// was not reported. `kin_tag` is the kinematics tag of the MCU owning the spatial
-/// axes. Returns cartesian per-axis (pos, vel); axes with no data are omitted.
 pub fn assemble_cartesian(
     motors: &[Option<f64>; MAX_AXES],
     vmotors: &[Option<f64>; MAX_AXES],

--- a/rust/motion-engine/src/position_query/tests.rs
+++ b/rust/motion-engine/src/position_query/tests.rs
@@ -24,13 +24,16 @@ fn cartesian_identity_passthrough() {
 
 #[test]
 fn corexy_inverse_mix() {
-    // motor A = x + y, motor B = x - y. For x=10, y=4: A=14, B=6.
+    let expected_x = 10.0;
+    let expected_y = 4.0;
+    let motor_a = expected_x + expected_y;
+    let motor_b = expected_x - expected_y;
     let mut m = [None; MAX_AXES];
     let v = [None; MAX_AXES];
-    m[0] = Some(14.0);
-    m[1] = Some(6.0);
+    m[0] = Some(motor_a);
+    m[1] = Some(motor_b);
     m[2] = Some(0.0);
     let out = assemble_cartesian(&m, &v, KINEMATICS_COREXY).unwrap();
-    assert!((out["x"].0 - 10.0).abs() < 1e-9);
-    assert!((out["y"].0 - 4.0).abs() < 1e-9);
+    assert!((out["x"].0 - expected_x).abs() < 1e-9);
+    assert!((out["y"].0 - expected_y).abs() < 1e-9);
 }

--- a/rust/motion-engine/src/pump.rs
+++ b/rust/motion-engine/src/pump.rs
@@ -59,27 +59,6 @@ pub enum Schedule {
     Idle,
 }
 
-/// Select the globally earliest-host-time piece across all queues, then emit
-/// the same-MCU prefix as one frame batch.
-///
-/// ## Invariants preserved
-///
-/// 1. **StallFull gates all MCUs.** When the globally-earliest piece belongs to
-///    a ring-full queue, no other queue may advance — cross-MCU issue-side
-///    coherence requires that a hardware-blocked MCU is never overtaken.
-///
-/// 2. **Cap-gated queues are skipped, not globally-gating.** When the
-///    globally-earliest piece has `releasable_cap_of == 0`, that queue is
-///    excluded from this round and the search continues among remaining
-///    queues in host-time order. A horizon-blocked head, by contrast,
-///    returns `StallAhead` immediately.
-///
-/// 3. **Ordering must use host time.** `start_time` values are raw MCU clock
-///    ticks in per-MCU clock domains (H7: ~520 MHz / own epoch; F446: ~180 MHz /
-///    own epoch). Comparing ticks across MCUs is meaningless; F446 values are
-///    numerically smaller and would always win, starving the H7.  The `f64`
-///    sidecar in each `(PieceEntry, f64)` pair carries the minting host time
-///    (`t0 + u_start`, seconds) and is the only valid cross-queue ordering key.
 #[must_use]
 pub fn schedule(
     queues: &BTreeMap<AxisKey, AxisQueue>,
@@ -95,9 +74,9 @@ pub fn schedule(
             .iter()
             .filter(|(k, q)| !q.pieces.is_empty() && !cap_skipped.contains(*k))
             .min_by(|(ka, qa), (kb, qb)| {
-                let ha = qa.pieces.front().unwrap().1;
-                let hb = qb.pieces.front().unwrap().1;
-                ha.total_cmp(&hb).then(ka.cmp(kb))
+                let host_a = qa.pieces.front().unwrap().1;
+                let host_b = qb.pieces.front().unwrap().1;
+                host_a.total_cmp(&host_b).then(ka.cmp(kb))
             });
         let (&k, q) = match candidate {
             None => {
@@ -212,9 +191,6 @@ pub struct DripArm {
 
 pub struct EnqueueMsg {
     pub key: AxisKey,
-    /// Each entry pairs the `PieceEntry` with its minting host time (`t0 + u_start`, seconds).
-    /// The host time is the ordering key used by `schedule()`; the raw `start_time` tick is
-    /// MCU-clock-domain-specific and incomparable across MCUs.
     pub pieces: Vec<(PieceEntry, f64)>,
     pub fresh_stream: bool,
     pub lead_secs: f64,
@@ -235,20 +211,9 @@ pub enum PumpMsg {
     Shutdown,
 }
 
-/// Error from [`PieceSink::send_frame`].
-///
-/// `Fatal` means the transport is permanently broken and the caller must not
-/// retry — the process should abort or restart.  `Transient` means the frame
-/// was not delivered but the transport may recover; the caller can back off and
-/// retry.
 #[derive(Debug)]
 pub enum SendError {
-    /// Unrecoverable transport failure (broken pipe, connection reset, peer
-    /// closed).  Callers that receive this must invoke their fatal-fault action
-    /// immediately; retrying will not help.
     Fatal(String),
-    /// Recoverable or non-transport error (MCU rejected the frame, ring full,
-    /// etc.).
     Transient(String),
 }
 
@@ -271,10 +236,6 @@ pub trait PieceSink: Send {
     ) -> Result<i32, SendError>;
 }
 
-/// Compute the tick-domain and host-domain gaps at a batch boundary.
-///
-/// Returns `(tick_jump_us, host_jump_us)` where negative values indicate overlap.
-/// The difference between the two isolates clock-projection error from planner-intent gaps.
 pub fn junction_jumps(
     first_start_ticks: u64,
     first_host: f64,
@@ -300,11 +261,6 @@ struct JunctionEnd {
 pub const JUNCTION_POSITION_LOG_MM: f32 = 0.0125;
 pub const JUNCTION_POSITION_FATAL_MM: f32 = 0.1;
 
-/// A position jump between the last dispatched piece and the next one is the
-/// host-side image of MCU fault -300/-310 (the step burst that killed the
-/// Trident two-jog test, 2026-06-10): the MCU will emit |Δpos|·steps_per_mm
-/// steps in one 25µs sample into a 32-deep queue. Dying here, before the push,
-/// preserves both endpoint values; the MCU fault preserves neither.
 fn check_junction_position_continuity(
     key: AxisKey,
     prev_end_pos: f32,
@@ -363,13 +319,6 @@ impl DripCohort {
     }
 }
 
-/// Run the piece pump loop.
-///
-/// `on_fatal_transport` is called (at most once) when [`SendError::Fatal`] is
-/// returned by the sink, indicating an unrecoverable transport failure.  The
-/// production call site passes an `abort()`-based action; tests inject a
-/// channel-send or a flag-set so they can assert detection without terminating
-/// the process.  After the callback returns the pump loop exits.
 #[allow(clippy::too_many_lines)]
 pub fn run_pump<S, F, C, A, O, D>(
     rx: Receiver<PumpMsg>,
@@ -434,8 +383,6 @@ pub fn run_pump<S, F, C, A, O, D>(
                     junction_ends.remove(&key);
                 }
                 if !pieces.is_empty() {
-                    // Clock not yet synced — skip junction bookkeeping; µs math is
-                    // meaningless without a real frequency and end_time needs it too.
                     if let Some((_ack_now, freq)) = mcu_clock_of(key.mcu_id) {
                         let (first_entry, first_host) = &pieces[0];
                         if first_entry.motor_mask == 0 {
@@ -514,7 +461,6 @@ pub fn run_pump<S, F, C, A, O, D>(
                 mcu_id,
                 retired_counts,
             }) => {
-                // retired_counts[i] is axis index i; same numbering as PushPieces.axis_idx in runtime_ffi.rs — do not reorder either side.
                 for (axis, &c) in retired_counts.iter().enumerate() {
                     let key = AxisKey {
                         mcu_id,
@@ -738,22 +684,10 @@ impl std::fmt::Debug for McuTransport {
 pub struct WireSink {
     pub transports: HashMap<u32, McuTransport>,
     pub timeout: Duration,
-    /// Live per-MCU clock frequency (Hz), queried from the router per frame.
-    /// `None` while the MCU clock is not yet synced. Single source of truth for
-    /// the `[transit-diag]` µs conversion — no second freq table.
     pub freq_of: Arc<dyn Fn(u32) -> Option<f64> + Send + Sync>,
 }
 
 impl WireSink {
-    /// Call `PushPieces` on the transport for the given axis.
-    ///
-    /// Returns `Err(SendError::Fatal(...))` for EtherCAT transport errors that
-    /// represent permanent connection loss (`Closed` or `Io`); all other
-    /// failures map to `Err(SendError::Transient(...))`.
-    ///
-    /// The reader thread owns all socket reads; `WouldBlock`/`TimedOut` never
-    /// surface here.  `TransportError::Timeout` (deadline exhausted on the
-    /// caller's `recv_timeout`) is transient — the session may still be alive.
     fn call_push_pieces(
         &self,
         key: AxisKey,
@@ -806,9 +740,6 @@ impl WireSink {
             }
             McuTransport::EtherCat(weak) => {
                 let conn = weak.upgrade().ok_or_else(|| {
-                    // The endpoint conn was released (last strong Arc dropped):
-                    // session is gone, treat as fatal so the pump exits rather
-                    // than spinning on a dead axis.
                     SendError::Fatal(format!(
                         "ethercat conn for mcu {} detached (released)",
                         key.mcu_id
@@ -877,9 +808,6 @@ impl PieceSink for WireSink {
             };
             let zero_st = host_front_start_time == 0;
             let past_arrival = arrival_lead_ticks < 0;
-            // Clock not yet synced -> the µs conversion is meaningless; render
-            // N/A. Alert gating uses arrival_lead_ticks (tick domain), so the
-            // ALERT still fires without a frequency.
             let arrival_lead_us = approx_freq_hz
                 .map(|f| format!("{:.1}", (arrival_lead_ticks as f64 / f) * 1e6))
                 .unwrap_or_else(|| "N/A".to_owned());

--- a/rust/motion-engine/src/pump/sched_tests.rs
+++ b/rust/motion-engine/src/pump/sched_tests.rs
@@ -146,16 +146,6 @@ fn no_horizon_none_uses_count_only_gate() {
     }
 }
 
-/// Regression: bench shape from 2026-06-04.
-///
-/// mcu1 (F446, 180 MHz) has a far-future piece whose tick value is numerically
-/// small (~4.8e12) but whose host time is large (beyond mcu1's horizon).
-/// mcu0 (H7, 520 MHz) has past-due pieces whose tick value is numerically large
-/// (~13.8e12) but whose host time is now-ish (within mcu0's horizon, room available).
-///
-/// Old code: `min_by` on raw ticks → mcu1's small ticks win → StallAhead(mcu1),
-/// H7 starved for up to 2+ seconds.
-/// New code: `min_by` on host time → mcu0's smaller host time wins → Send(mcu0).
 #[test]
 fn cross_mcu_host_time_ordering_bench_regression() {
     let f446_tick: u64 = 4_790_000_000_000;

--- a/rust/motion-engine/src/pump/wire_sink_tests.rs
+++ b/rust/motion-engine/src/pump/wire_sink_tests.rs
@@ -5,10 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 fn closed_conn() -> Arc<host_rt::mcu_serial_conn::McuSerialConn> {
-    let (client, _server) = UnixStream::pair().unwrap();
-    // `_server` (not `_`) is load-bearing: the peer must outlive from_stream
-    // (setsockopt EINVAL on Darwin against a dead peer). It drops at return,
-    // so every subsequent call observes Closed / broken-pipe.
+    let (client, _peer_kept_alive_for_from_stream) = UnixStream::pair().unwrap();
     Arc::new(host_rt::mcu_serial_conn::McuSerialConn::from_stream(client).expect("from_stream"))
 }
 
@@ -28,8 +25,6 @@ fn one_piece() -> Vec<runtime::piece_ring::PieceEntry> {
 
 #[test]
 fn closed_peer_yields_fatal_send_error() {
-    // Hold the strong Arc for the whole test so upgrade() succeeds and we
-    // exercise the real Closed/Io path, not the detached-conn Fatal arm.
     let conn = closed_conn();
     let sink = WireSink {
         transports: {
@@ -49,13 +44,11 @@ fn closed_peer_yields_fatal_send_error() {
 
 #[test]
 fn detached_ethercat_conn_yields_fatal_send_error() {
-    // The strong Arc is dropped before the call, so upgrade() fails and the
-    // released-conn path must classify as Fatal (pump exits, no spin).
-    let weak = Arc::downgrade(&closed_conn());
+    let weak_to_already_dropped_conn = Arc::downgrade(&closed_conn());
     let sink = WireSink {
         transports: {
             let mut m = HashMap::new();
-            m.insert(0, McuTransport::EtherCat(weak));
+            m.insert(0, McuTransport::EtherCat(weak_to_already_dropped_conn));
             m
         },
         timeout: Duration::from_millis(50),

--- a/rust/motion-engine/src/remote_trigger.rs
+++ b/rust/motion-engine/src/remote_trigger.rs
@@ -1,8 +1,3 @@
-//! Decision logic for the remote-trigger relay: a reactor interceptor on a
-//! probe MCU's RX thread translating terminal `trsync_state` reports into
-//! the engine's endstop-trip dispatch. Kept free of I/O for testability;
-//! the interceptor closure lives in engine.rs.
-
 #[derive(Debug, PartialEq, Eq)]
 pub enum RelayAction {
     Fire,
@@ -16,14 +11,9 @@ pub fn relay_decision(can_trigger: Option<u32>, already_fired: bool) -> RelayAct
     }
 }
 
-/// `trsync_state.clock` is a report-time clock, not a trip timestamp
-/// (`trsync.c:190`), and the host-commanded `trsync_trigger` path sends 0
-/// (`trsync.c:176`). Expand a nonzero report clock to 64 bits against the
-/// router's current clock estimate for the probe MCU; substitute that
-/// estimate outright for the zero case. The result is provisional-only —
-/// precise trigger timestamps come from the probe's own latched record.
 pub fn relay_trip_clock(clock32: u32, reference_clock64: u64) -> u64 {
-    if clock32 == 0 {
+    const HOST_COMMANDED_TRIGGER_CLOCK: u32 = 0;
+    if clock32 == HOST_COMMANDED_TRIGGER_CLOCK {
         return reference_clock64;
     }
     let delta = clock32.wrapping_sub(reference_clock64 as u32) as i32 as i64;

--- a/rust/motion-engine/src/remote_trigger/tests.rs
+++ b/rust/motion-engine/src/remote_trigger/tests.rs
@@ -22,9 +22,12 @@ fn malformed_report_without_can_trigger_is_ignored() {
 
 #[test]
 fn nonzero_report_clock_expands_against_reference() {
-    // reference 0x1_0000_1000, clock32 just below the low-32 reference:
-    // small negative delta, same epoch.
-    assert_eq!(relay_trip_clock(0x0000_0F00, 0x1_0000_1000), 0x1_0000_0F00);
+    let reference = 0x1_0000_1000;
+    let clock32_just_below_reference_low32 = 0x0000_0F00;
+    assert_eq!(
+        relay_trip_clock(clock32_just_below_reference_low32, reference),
+        0x1_0000_0F00
+    );
 }
 
 #[test]
@@ -34,13 +37,20 @@ fn clock32_ahead_of_reference_expands_forward() {
 
 #[test]
 fn expansion_handles_wrap_boundary() {
-    // reference just past a 32-bit wrap; clock32 from just before it.
-    assert_eq!(relay_trip_clock(0xFFFF_FF00, 0x2_0000_0010), 0x1_FFFF_FF00);
+    let reference_just_past_wrap = 0x2_0000_0010;
+    let clock32_just_before_wrap = 0xFFFF_FF00;
+    assert_eq!(
+        relay_trip_clock(clock32_just_before_wrap, reference_just_past_wrap),
+        0x1_FFFF_FF00
+    );
 }
 
 #[test]
 fn zero_clock_means_host_commanded_trigger_substitute_reference() {
-    // trsync_trigger path reports clock=0 (trsync.c:176); substitute the
-    // router's current estimate.
-    assert_eq!(relay_trip_clock(0, 0x1_0000_1000), 0x1_0000_1000);
+    let host_commanded_trigger_clock = 0;
+    let reference = 0x1_0000_1000;
+    assert_eq!(
+        relay_trip_clock(host_commanded_trigger_clock, reference),
+        reference
+    );
 }

--- a/rust/motion-engine/src/servo_sdo.rs
+++ b/rust/motion-engine/src/servo_sdo.rs
@@ -8,8 +8,6 @@ use mcu_protocol::messages::{
     MessageKind, SdoRead, SdoReadResponse, SdoWrite, SdoWriteResponse,
 };
 
-/// Mailbox round trips take milliseconds; 5 s also covers the probe +
-/// readback-verify a single SdoWrite performs endpoint-side.
 const SDO_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn send_sdo_read(

--- a/rust/motion-engine/src/servo_torque.rs
+++ b/rust/motion-engine/src/servo_torque.rs
@@ -8,8 +8,10 @@ use mcu_protocol::messages::{
     SetDriveLimitsResponse, SetTorque, SetTorqueResponse,
 };
 
-/// Worst-case enable: 3000 DC cycles of ladder (~3 s) plus margin.
-const SET_TORQUE_TIMEOUT: Duration = Duration::from_secs(8);
+const WORST_CASE_LADDER_ENABLE: Duration = Duration::from_secs(3);
+const SET_TORQUE_TIMEOUT_MARGIN: Duration = Duration::from_secs(5);
+const SET_TORQUE_TIMEOUT: Duration =
+    WORST_CASE_LADDER_ENABLE.saturating_add(SET_TORQUE_TIMEOUT_MARGIN);
 
 pub fn send_set_torque(
     conn: &McuSerialConn,

--- a/rust/motion-engine/src/servo_torque/tests.rs
+++ b/rust/motion-engine/src/servo_torque/tests.rs
@@ -71,12 +71,9 @@ fn surfaces_nonzero_result() {
 
 #[test]
 fn transport_error_is_an_err() {
-    let (client, server) = UnixStream::pair().unwrap();
-    // Construct before killing the peer: from_stream's socket setup needs a
-    // live peer (setsockopt EINVAL on Darwin otherwise). Death-after-construction
-    // is also the real failure mode this guards.
-    let conn = McuSerialConn::from_stream(client).expect("from_stream");
-    drop(server);
+    let (client, live_peer) = UnixStream::pair().unwrap();
+    let conn = McuSerialConn::from_stream(client).expect("from_stream needs the peer alive");
+    drop(live_peer);
     assert!(send_set_torque(&conn, true, 1).is_err());
 }
 

--- a/rust/motion-engine/src/stream.rs
+++ b/rust/motion-engine/src/stream.rs
@@ -14,14 +14,7 @@ pub struct StreamConfig {
     pub chain: ChainFitConfig,
     pub velocity: VelocityConfig,
     pub fit_tol_mm: f64,
-    /// Look-ahead margin held back from each non-forced commit. The trailing
-    /// `keep_secs` of planned trajectory stays uncommitted so committed
-    /// junction velocities were planned with enough downstream context and are
-    /// not pulled down by the buffer's pessimistic terminal-`v=0`.
     pub keep_secs: f64,
-    /// Path limits for planner-internal moves (homing). Stream moves submitted
-    /// through the bridge carry their own per-move limits; this is the fallback
-    /// the planner uses when it constructs a move itself.
     pub limits: VelocityLimits,
 }
 
@@ -60,19 +53,10 @@ impl From<LoweringError> for StreamError {
     }
 }
 
-/// Streaming look-ahead planner over the new geometry pipeline. Buffers
-/// submitted moves, re-plans the uncommitted window warm-started from the
-/// dispatched velocity, and commits prefixes at clean (non-blended) seams so
-/// the trajectory stays velocity-continuous across consecutive moves without
-/// re-emitting committed pieces. Commit timing (real-time cadence) is the
-/// caller's; this type owns the geometry/velocity state.
 pub struct StreamState {
     buffer: VecDeque<Move>,
-    /// Absolute velocity at the committed seam (entry of the buffer's first move).
     entry_v: f64,
-    /// Absolute registry position at the committed seam (index = registry axis).
     odometer: Vec<f64>,
-    /// Absolute planner time of the committed seam.
     t_committed: f64,
     config: StreamConfig,
 }
@@ -100,9 +84,6 @@ impl StreamState {
         self.buffer.push_back(m);
     }
 
-    /// Advance the committed time cursor by an idle gap (a dwell) without
-    /// emitting motion. Only valid when fully committed (buffer empty); the
-    /// seam velocity must already be at rest.
     pub fn advance_time(&mut self, dt: f64) {
         debug_assert!(
             self.buffer.is_empty(),
@@ -114,11 +95,6 @@ impl StreamState {
         }
     }
 
-    /// Re-anchor the committed time cursor to `target_t` (the live MCU playhead
-    /// plus lead) after the stream has gone idle and the machine has caught up.
-    /// Without this, a move submitted after an idle gap is planned at a stale
-    /// planner time and lands in the MCU's past. Only valid at rest with a
-    /// drained buffer; never moves the cursor backward.
     pub fn advance_idle(&mut self, target_t: f64) {
         debug_assert!(
             self.buffer.is_empty(),
@@ -130,14 +106,6 @@ impl StreamState {
         }
     }
 
-    /// Restart the committed timeline at the origin after the machine has gone
-    /// idle and the playhead has caught up. The next dispatched segment then
-    /// re-anchors against the live playhead at dispatch time — like a freshly
-    /// opened stream — instead of inheriting the prior run's stale anchor, which
-    /// would land the resumed move in the MCU's past. Position is preserved;
-    /// only the time cursor resets. The caller must also drop its wall-clock
-    /// sync so the playhead and committed clocks realign at the origin. Valid
-    /// only at rest with a drained buffer.
     pub fn restart_idle_timeline(&mut self) {
         debug_assert!(
             self.buffer.is_empty(),
@@ -175,10 +143,6 @@ impl StreamState {
         self.config.limits
     }
 
-    /// Plan the buffer and commit a prefix at the latest clean seam. `force`
-    /// (flush / dwell / idle drain / shutdown) commits the entire buffer to
-    /// rest. Returns the `ShapedSegment`s to dispatch, in order; empty when
-    /// nothing is committable yet.
     pub fn commit(&mut self, force: bool) -> Result<Vec<ShapedSegment>, StreamError> {
         if self.buffer.is_empty() {
             return Ok(Vec::new());

--- a/rust/motion-engine/src/stream/tests.rs
+++ b/rust/motion-engine/src/stream/tests.rs
@@ -36,16 +36,13 @@ fn collinear_jogs_commit_at_the_seam_without_stopping() {
     s.push(line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0));
 
     let committed = s.commit(false).unwrap();
-    // The collinear junction is a clean seam: the first jog commits, the second is kept.
     assert!(!committed.is_empty());
     assert_eq!(s.buffered(), 1);
-    // No stop between the jogs: the carried seam velocity is well above rest.
     assert!(
         s.entry_velocity() > 1.0,
         "seam velocity {} should be cruising, not stopped",
         s.entry_velocity()
     );
-    // Committed boundary position is the seam (x = 50).
     let last = committed.last().unwrap();
     assert!((eval(&last.axes[0], last.t_end) - 50.0).abs() < 1e-6);
 }
@@ -56,7 +53,6 @@ fn flush_commits_everything_to_rest() {
     s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0));
     s.push(line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0));
 
-    // keep_secs large => nothing commits without force.
     assert!(s.commit(false).unwrap().is_empty());
 
     let committed = s.commit(true).unwrap();
@@ -69,8 +65,6 @@ fn flush_commits_everything_to_rest() {
 
 #[test]
 fn blended_corner_is_never_split_by_a_commit() {
-    // A 90-degree corner is blended (clothoid); there is no clean seam, so a
-    // non-forced commit must emit nothing rather than split the blend.
     let mut s = StreamState::new(cfg(0.0), &[0.0, 0.0, 0.0], 0.0);
     s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0));
     s.push(line(2, [50.0, 0.0, 0.0], [50.0, 50.0, 0.0], 0.0));
@@ -81,7 +75,6 @@ fn blended_corner_is_never_split_by_a_commit() {
     );
     assert_eq!(s.buffered(), 2);
 
-    // Force still drains it to rest.
     assert!(!s.commit(true).unwrap().is_empty());
     assert!(s.is_empty());
 }
@@ -95,7 +88,6 @@ fn odometer_accumulates_extrusion_across_commits() {
     let committed = s.commit(true).unwrap();
     assert!(s.is_empty());
     let last = committed.last().unwrap();
-    // Extruder (axis 3) reached the cumulative delta 8.0 at the final boundary.
     assert!((eval(&last.axes[3], last.t_end) - 8.0).abs() < 1e-3);
 }
 
@@ -123,16 +115,15 @@ fn advance_idle_reanchors_committed_time_after_a_gap() {
     let first = s.commit(true).unwrap();
     let after_first = first.last().unwrap().t_end;
 
-    // Long idle gap: the machine has caught up well past the committed horizon.
-    s.advance_idle(after_first + 50.0);
+    let idle_gap_past_horizon_secs = 50.0;
+    s.advance_idle(after_first + idle_gap_past_horizon_secs);
     s.push(line(2, [30.0, 0.0, 0.0], [60.0, 0.0, 0.0], 0.0));
     let second = s.commit(true).unwrap();
     assert!(
-        second[0].t_start >= after_first + 50.0 - 1e-9,
+        second[0].t_start >= after_first + idle_gap_past_horizon_secs - 1e-9,
         "second move must start at the re-anchored time, got {}",
         second[0].t_start
     );
-    // never rewinds:
     s.advance_idle(0.0);
     assert!(s.t_committed() >= second.last().unwrap().t_end - 1e-9);
 }

--- a/rust/motion-engine/src/stream_planner.rs
+++ b/rust/motion-engine/src/stream_planner.rs
@@ -113,9 +113,6 @@ impl StreamPlannerHandle {
         }
     }
 
-    /// Non-blocking flush: returns a receiver that yields the play-out
-    /// completion deadline (`None` if the stream was idle). Mirrors the old
-    /// planner's `flush_start`/`wait_moves_poll` protocol.
     pub fn flush_start(
         &self,
     ) -> Result<crossbeam_channel::Receiver<Option<Instant>>, StreamPlannerError> {

--- a/rust/motion-engine/tests/logging_integration.rs
+++ b/rust/motion-engine/tests/logging_integration.rs
@@ -21,8 +21,8 @@ fn end_to_end_jsonl_has_schema_and_context() {
         "endstop trip on Z"
     );
 
-    // Allow the non-blocking worker to flush.
-    std::thread::sleep(std::time::Duration::from_millis(250));
+    let non_blocking_worker_flush = std::time::Duration::from_millis(250);
+    std::thread::sleep(non_blocking_worker_flush);
 
     let contents = std::fs::read_to_string(dir.join("host-rust.jsonl")).unwrap();
     let lines: Vec<serde_json::Value> = contents

--- a/rust/motion-engine/tests/mcu_log_reemit.rs
+++ b/rust/motion-engine/tests/mcu_log_reemit.rs
@@ -11,10 +11,7 @@ use host_rt::clock::RealClock;
 use host_rt::host_io::runtime_events::McuLogEvent;
 use host_rt::passthrough_queue::{McuHandle, PassthroughRouter};
 
-/// Serialise tests that call `context::set_context` so they don't race on the
-/// process-global `ArcSwap<SessionContext>`.  Integration tests run in the same
-/// binary (one process), so a per-file mutex is sufficient.
-static CTX_LOCK: Mutex<()> = Mutex::new(());
+static GLOBAL_CONTEXT_SERIALISER: Mutex<()> = Mutex::new(());
 
 fn tmp_jsonl(dir_suffix: &str, filename: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
@@ -50,7 +47,9 @@ fn make_empty_router(label: &str) -> (Arc<Mutex<PassthroughRouter>>, McuHandle) 
 
 #[test]
 fn re_emit_closure_produces_schema_conformant_line() {
-    let _ctx_guard = CTX_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _ctx_guard = GLOBAL_CONTEXT_SERIALISER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     context::set_context("k-test-session".to_string(), "print-42".to_string());
 
     let path = tmp_jsonl("reemit", "mcu-h7.jsonl");
@@ -114,7 +113,9 @@ fn re_emit_closure_produces_schema_conformant_line() {
 
 #[test]
 fn fallback_stamps_time_estimated_true_when_no_clock_sync_samples() {
-    let _ctx_guard = CTX_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _ctx_guard = GLOBAL_CONTEXT_SERIALISER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     context::set_context(
         "k-fallback-session".to_string(),
         "print-fallback".to_string(),
@@ -174,7 +175,9 @@ fn fallback_stamps_time_estimated_true_when_no_clock_sync_samples() {
 
 #[test]
 fn source_matches_label() {
-    let _ctx_guard = CTX_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _ctx_guard = GLOBAL_CONTEXT_SERIALISER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     context::set_context("k-label-test".to_string(), "print-label".to_string());
 
     for label in &["mcu-h7", "mcu-f4"] {

--- a/rust/motion-engine/tests/streaming_replan.rs
+++ b/rust/motion-engine/tests/streaming_replan.rs
@@ -1,8 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-// The crate is `motion-engine` (package) but exposes its rlib under the
-// name `_motion_engine` (because `[lib].name` must match the
-// `#[pymodule]` fn — see Cargo.toml).
 use _motion_engine::classify::classify_and_build;
 use _motion_engine::config::{
     AxisDecl, AxisRegistry, LimitSection, PlannerConfig, PostProcessorDecl, PostProcessorSet,
@@ -509,18 +506,6 @@ fn slow_jogs_decelerate_to_zero_between() {
          append",
     );
 
-    // Task 6 — time-based flush: `flush` sleeps until `sync_instant +
-    // t_appended + LEAD`, so the second move arrives after real wall-clock
-    // time has advanced past move 1's planner-time end. The placement rule
-    // (spec §A) then inserts a rest-hold (advance_idle) bridging the gap,
-    // meaning move 2's segments start at a higher planner-time than move 1's
-    // segments end. Temporal contiguity therefore holds **within** each
-    // move's segment batch but NOT across the cross-flush boundary.
-    //
-    // Position continuity at the cross-flush boundary still holds: move 1
-    // ends at X=1.0 mm and move 2 starts from X=1.0 mm (the rest-hold is
-    // zero velocity, same position). All other adjacent seams remain both
-    // temporally and positionally contiguous.
     const SEAM_BUDGET_MM: f64 = 5.0e-2;
     let cross_flush = count_after_first.saturating_sub(1);
     for i in 0..segs.len().saturating_sub(1) {

--- a/rust/nurbs/src/algebra.rs
+++ b/rust/nurbs/src/algebra.rs
@@ -32,26 +32,6 @@ pub fn add<T: Float>(
         .map_err(|_| AlgebraError::KnotMismatch)
 }
 
-/// ```rust
-/// # use nurbs::algebra::add_with_knot_union;
-/// # use nurbs::ScalarNurbs;
-/// // X: two Bézier pieces. Y: one piece.
-/// let x = ScalarNurbs::try_new(
-///     1,
-///     vec![0.0_f64, 0.0, 0.5, 1.0, 1.0],
-///     vec![0.0, 5.0, 10.0],
-/// ).unwrap();
-/// let y = ScalarNurbs::try_new(
-///     1,
-///     vec![0.0_f64, 0.0, 1.0, 1.0],
-///     vec![20.0, 20.0],
-/// ).unwrap();
-/// let sum = add_with_knot_union(&x, &y).unwrap();
-/// let v0 = nurbs::eval::eval(&sum.as_view(), 0.0_f64);
-/// let v1 = nurbs::eval::eval(&sum.as_view(), 1.0_f64);
-/// assert!((v0 - 20.0).abs() < 1e-12);
-/// assert!((v1 - 30.0).abs() < 1e-12);
-/// ```
 #[cfg(feature = "host")]
 pub fn add_with_knot_union<T: Float>(
     a: &crate::ScalarNurbs<T>,
@@ -176,16 +156,6 @@ pub fn fit_hermite_c1<const D: usize>(
     Ok(result)
 }
 
-/// Hermite C1 fit with optional 2nd-derivative pins at the global start and end.
-///
-/// Identical to [`fit_hermite_c1`] when both `d2_start` and `d2_end` are `None`.
-/// When a pin is `Some([a0, a1, …])`, the first (or last) output piece is constructed
-/// as degree-5 so that its 2nd derivative at the outer endpoint equals the pin exactly.
-/// Interior piece joints remain C1 only.
-///
-/// The minimum `target_degree` is 3 when no pins are supplied, or 5 when at least one
-/// pin is supplied (the extra two DOF are needed to accommodate the f'' constraint while
-/// keeping the two-endpoint C1 conditions).
 #[cfg(feature = "host")]
 pub fn fit_hermite_c1_clamped<const D: usize>(
     pieces: &[[crate::bezier::BezierPiece<f64>; D]],
@@ -418,9 +388,6 @@ fn hermite_fit_one_piece_clamped<const D: usize>(
     }
 }
 
-/// Degree-5 Hermite piece with both endpoint 2nd derivatives pinned.
-/// 6 constraints (f_lo, f'_lo, f''_lo, f_hi, f'_hi, f''_hi) exactly determine
-/// the 6 coefficients of a degree-5 polynomial.
 #[cfg(feature = "host")]
 #[allow(clippy::cast_possible_wrap)]
 fn hermite_construct_poly_both_clamped(
@@ -433,8 +400,6 @@ fn hermite_construct_poly_both_clamped(
     d2_lo: f64,
     d2_hi: f64,
 ) -> crate::bezier::BezierPiece<f64> {
-    // p(u) = c0 + c1*h + c2*h² + c3*h³ + c4*h⁴ + c5*h⁵,  h = u - u_lo
-    // p''(u_lo) = 2*c2  →  c2 = d2_lo/2
     let c0 = f_lo;
     let c1 = df_lo;
     let c2 = d2_lo * 0.5;
@@ -447,7 +412,6 @@ fn hermite_construct_poly_both_clamped(
         };
     }
 
-    // Residuals after subtracting fixed coefficients:
     let h2 = h * h;
     let h3 = h2 * h;
     let h4 = h3 * h;
@@ -457,23 +421,14 @@ fn hermite_construct_poly_both_clamped(
     let v_res = df_hi - c1 - 2.0 * c2 * h;
     let a_res = d2_hi - 2.0 * c2;
 
-    // 3×3 system for (q = c3*h³, r = c4*h⁴, s = c5*h⁵):
-    //   q    +  r   +  s   = P
-    //   3q   + 4r   + 5s   = V*H
-    //   6q   + 12r  + 20s  = A*H²
-    // det = 2 (computed below)
     let rhs0 = p_res;
     let rhs1 = v_res * h;
     let rhs2 = a_res * h2;
 
-    // Verified Cramer solution (det=2):
-    //   q = (20*P - 8*V*H + A*H²) / 2
-    //   r = (-30*P + 14*V*H - 2*A*H²) / 2
-    //   s = (12*P - 6*V*H + A*H²) / 2
-    let det = 2.0;
-    let q = (20.0 * rhs0 - 8.0 * rhs1 + rhs2) / det;
-    let r = (-30.0 * rhs0 + 14.0 * rhs1 - 2.0 * rhs2) / det;
-    let s = (12.0 * rhs0 - 6.0 * rhs1 + rhs2) / det;
+    let cramer_det = 2.0;
+    let q = (20.0 * rhs0 - 8.0 * rhs1 + rhs2) / cramer_det;
+    let r = (-30.0 * rhs0 + 14.0 * rhs1 - 2.0 * rhs2) / cramer_det;
+    let s = (12.0 * rhs0 - 6.0 * rhs1 + rhs2) / cramer_det;
 
     let c3 = q / h3;
     let c4 = r / h4;
@@ -486,9 +441,6 @@ fn hermite_construct_poly_both_clamped(
     }
 }
 
-/// Degree-`d` (>=5) Hermite piece with start 2nd-derivative pinned.
-/// c0, c1 fixed; c2 = d2_lo/2; c3 = free minimax DOF (= `c3_val`);
-/// c_{d-1} and c_d solved from C1 at the end.
 #[cfg(feature = "host")]
 #[allow(clippy::too_many_arguments, clippy::cast_possible_wrap)]
 fn hermite_construct_poly_start_clamped(
@@ -547,11 +499,6 @@ fn hermite_construct_poly_start_clamped(
     }
 }
 
-/// Degree-`d` (>=4) Hermite piece with end 2nd-derivative pinned.
-/// c0, c1 fixed from start; c2 is the free minimax DOF (= `c2_val`);
-/// c_{d-2}, c_{d-1}, c_d solved from f_hi, f'_hi, f''_hi.
-/// For d=4 the 3×3 system covers coefficients 2..4, and c2_val shifts the
-/// solution family (no separate free DOF for the minimax caller).
 #[cfg(feature = "host")]
 #[allow(clippy::too_many_arguments, clippy::cast_possible_wrap)]
 fn hermite_construct_poly_end_clamped(
@@ -578,26 +525,18 @@ fn hermite_construct_poly_end_clamped(
         };
     }
 
-    // c0 = f_lo, c1 = df_lo, c2 = c2_val (minimax free DOF)
-    // coeffs[3..d-3] = 0 (no higher free DOFs)
-    // Last three: c_{d-2}, c_{d-1}, c_d from 3 constraints at h:
-    //   f(h)   = f_hi
-    //   f'(h)  = df_hi
-    //   f''(h) = d2_hi
     let mut coeffs = vec![0.0f64; d + 1];
     coeffs[0] = f_lo;
     coeffs[1] = df_lo;
     coeffs[2] = c2_val;
-    // coeffs[3..d-2] already 0
 
-    // Subtract known-coefficient contributions from each residual
     let mut pos_residual = f_hi - f_lo - df_lo * h - c2_val * h * h;
     let mut vel_residual = df_hi - df_lo - 2.0 * c2_val * h;
     let mut acc_residual = d2_hi - 2.0 * c2_val;
 
-    let mut h_pow = h * h * h; // h^3
-    let mut h_pow_d = h * h; // h^2
-    let mut h_pow_dd = h; // h^1
+    let mut h_pow = h * h * h;
+    let mut h_pow_d = h * h;
+    let mut h_pow_dd = h;
     for k in 3..d.saturating_sub(2) {
         pos_residual -= coeffs[k] * h_pow;
         vel_residual -= (k as f64) * coeffs[k] * h_pow_d;
@@ -607,15 +546,6 @@ fn hermite_construct_poly_end_clamped(
         h_pow_dd *= h;
     }
 
-    // Solve 3×3 for (c_{d-2}, c_{d-1}, c_d) using d=5 pattern generalized:
-    // Let a = d-2, b = d-1, e = d.
-    // p(h)   = c_a*h^a + c_b*h^b + c_e*h^e = P
-    // p'(h)  = a*c_a*h^{a-1} + b*c_b*h^{b-1} + e*c_e*h^{e-1} = V
-    // p''(h) = a*(a-1)*c_a*h^{a-2} + b*(b-1)*c_b*h^{b-2} + e*(e-1)*c_e*h^{e-2} = A
-    // Substituting q=c_a*h^a, r=c_b*h^b, s=c_e*h^e:
-    // q + r + s = P
-    // a*q/h + b*r/h + e*s/h = V  →  a*q + b*r + e*s = V*h
-    // a*(a-1)*q/h² + ... = A    →  a*(a-1)*q + b*(b-1)*r + e*(e-1)*s = A*h²
     let a = (d - 2) as f64;
     let b = (d - 1) as f64;
     let e = d as f64;
@@ -1296,14 +1226,10 @@ fn integrate_product_piece<T: Float>(
     let d_w = w.degree();
     let out_degree = d_x + d_w + 1;
 
-    // s_lo(u) = max(x.u_start, u - w.u_end); s_hi(u) = min(x.u_end, u - w.u_start).
-    // Active branch is constant on [α, β] by construction; determine from midpoint.
     let u_mid = (alpha + beta) * T::from_f64(0.5);
-    let lo_branch_curve = u_mid - w.u_end > x.u_start; // true → s_lo(u) = u - w.u_end
-    let hi_branch_curve = u_mid - w.u_start < x.u_end; // true → s_hi(u) = u - w.u_start
+    let lo_branch_curve = u_mid - w.u_end > x.u_start;
+    let hi_branch_curve = u_mid - w.u_start < x.u_end;
 
-    // Work in shifted frame v = u − α, r = s − α to avoid catastrophic cancellation
-    // when α is large. Result is already in (u − α)^k basis; no re-shift needed.
     let x_abs_r = pascal_shift_to_absolute(&x.coeffs, x.u_start - alpha);
     let w_abs_z = pascal_shift_to_absolute(&w.coeffs, w.u_start);
 

--- a/rust/nurbs/src/algebra/tests.rs
+++ b/rust/nurbs/src/algebra/tests.rs
@@ -53,8 +53,6 @@ fn integrate_product_constant_input_constant_kernel_yields_linear_result() {
 
     let contribution = integrate_product_piece(&x, &w, 0.5, 1.0);
 
-    // y(u) = 6 * (1.5 − u) for u ∈ [0.5, 1.0].
-    // Pascal-shifted at u_start = 0.5: y = 6 − 6·(u − 0.5), so coeffs = [6.0, −6.0].
     assert!((contribution.coeffs[0] - 6.0).abs() < 1e-10);
     assert!((contribution.coeffs[1] - (-6.0)).abs() < 1e-10);
 }
@@ -241,11 +239,6 @@ fn single_poly_from_absolute_round_trips_via_evaluate() {
 
 #[test]
 fn multiply_regression_proptest_shrunk_failing_input() {
-    // Captured from algebra_proptest::multiply_multi_piece_eval_matches_pointwise_product
-    // pre-Fix-1 (Mørken-bounded knot removal). At u=0.1, b has C⁰ kink (m_b=1, d_b=1)
-    // and a has interior multiplicity-1 knot (m_a=1, d_a=3). Per Mørken Eq. (1):
-    // μ_target(0.1) = max(3+1, 1+1) = 4. Pre-Fix-1 the unbounded knot_remove_redundant
-    // peeled below 4, smearing the C⁰ kink and producing wrong eval at u=0.1.
     let a = crate::ScalarNurbs::<f64>::try_new(
         3,
         vec![0.0, 0.0, 0.0, 0.0, 0.1, 0.55, 1.0, 1.0, 1.0, 1.0],
@@ -259,8 +252,6 @@ fn multiply_regression_proptest_shrunk_failing_input() {
     )
     .unwrap();
     let c = multiply(&a, &b).unwrap();
-    // Pointwise product at u=0.1 should be ≈ 0.014107177131003477.
-    // Pre-fix `multiply` returned ≈ 0.007758947422051913.
     let exp = eval(&a.as_view(), 0.1) * eval(&b.as_view(), 0.1);
     let got = eval(&c.as_view(), 0.1);
     assert!(
@@ -291,17 +282,6 @@ fn multiply_quadratic_x_linear_gives_cubic() {
     }
 }
 
-// Note: this test deliberately does NOT assert μ_y = 0 at the boundary
-// cross-sums u ∈ {0.1, 0.9}. The spec's convolution-continuity rule
-// predicts μ_y = 0 there (no real continuity break), but in practice the
-// post-pass knot_remove_redundant (Tiller A5.8 with chord-error tol)
-// can only peel a knot when both polynomial pieces match as polynomial
-// expressions, not just as functions agreeing at the join. At a boundary
-// cross-sum the left and right pieces of y differ by (u − u_break)^k
-// terms that vanish at the join but not elsewhere, so Tiller refuses
-// removal even though geometrically the curve is C-infinity there. This
-// leaves extra multiplicity at boundary cross-sums; harmless (eval is
-// correct, downstream ops don't care) and not the bug class tested here.
 #[test]
 fn convolve_multi_piece_input_with_c0_kink_preserves_natural_multiplicity() {
     let x = crate::ScalarNurbs::<f64>::try_new(
@@ -329,14 +309,6 @@ fn convolve_multi_piece_input_with_c0_kink_preserves_natural_multiplicity() {
         "expected μ_y(0.4) = m_x = 2 (kink image), got {mult_at_04}; full interior = {interior:?}",
     );
 
-    // x_1(s) = (20/3) s + (200/9) s² on [0, 0.3];
-    // x_2(s) = 4 − 10 (s − 0.3) + (320/49) (s − 0.3)² on [0.3, 1.0].
-    //   y(0.2) = ∫_{0.1}^{0.3} x_1(s) ds
-    //          = (10/3)(0.09 − 0.01) + (200/27)(0.027 − 0.001)
-    //          = 0.8/3 + 5.2/27.
-    //   y(0.4) = ∫_{0.3}^{0.5} x_2(s) ds
-    //          = 4·0.2 − 5·(0.2)² + (320/147)·(0.2)³
-    //          = 0.6 + 2.56/147.
     let exp_02 = 0.8 / 3.0 + 5.2 / 27.0;
     let exp_04 = 0.6 + 2.56 / 147.0;
     let got_02 = eval(&y.as_view(), 0.2);
@@ -352,11 +324,6 @@ fn convolve_multi_piece_input_with_c0_kink_preserves_natural_multiplicity() {
         (got_04 - exp_04).abs(),
     );
 
-    //   y(0.5) = ∫_{0.4}^{0.6} x_2(s) ds
-    //          = ∫_{0.1}^{0.3} (4 − 10·v + (320/49)·v²) dv  (v = s − 0.3)
-    //          = 4·0.2 − 5·(0.09 − 0.01) + (320/147)·(0.027 − 0.001)
-    //          = 0.8 − 0.4 + (320·0.026)/147
-    //          = 0.4 + 8.32/147.
     let exp_05 = 0.4 + 8.32 / 147.0;
     let got_05 = eval(&y.as_view(), 0.5);
     assert!(
@@ -418,6 +385,19 @@ fn add_with_knot_union_mismatched_knots_union_path() {
             "union-path u={u}: expected {expected}, got {got}",
         );
     }
+}
+
+#[test]
+fn add_with_knot_union_doc_example() {
+    use crate::ScalarNurbs;
+    let x =
+        ScalarNurbs::try_new(1, vec![0.0_f64, 0.0, 0.5, 1.0, 1.0], vec![0.0, 5.0, 10.0]).unwrap();
+    let y = ScalarNurbs::try_new(1, vec![0.0_f64, 0.0, 1.0, 1.0], vec![20.0, 20.0]).unwrap();
+    let sum = add_with_knot_union(&x, &y).unwrap();
+    let v0 = crate::eval::eval(&sum.as_view(), 0.0_f64);
+    let v1 = crate::eval::eval(&sum.as_view(), 1.0_f64);
+    assert!((v0 - 20.0).abs() < 1e-12);
+    assert!((v1 - 30.0).abs() < 1e-12);
 }
 
 #[test]

--- a/rust/nurbs/src/arc_length.rs
+++ b/rust/nurbs/src/arc_length.rs
@@ -1,5 +1,3 @@
-// `unsafe_code` is workspace-denied; targeted exception for MCU hot-path arc-length
-// lookup — release builds must not call the panic symbol from inside binary search.
 #![allow(unsafe_code)]
 
 use crate::Float;
@@ -136,10 +134,6 @@ use crate::eval::{eval, vector_derivative, vector_eval};
 #[cfg(feature = "host")]
 use crate::{ArcLengthError, NurbsView, VectorNurbsView};
 
-// SAFETY invariant for param_from_arc_length and arc_length_from_param:
-// Table construction asserts len >= 2. Binary search maintains lo = 0, hi = last = len-1;
-// loop exits with hi - lo == 1, so lo ∈ [0, last-1] and lo+1 ≤ last < len.
-// All get_unchecked accesses are to indices in [0, last].
 #[inline]
 pub fn param_from_arc_length<T: Float>(table: &ArcLengthTableRef<'_, T>, s: T) -> T {
     debug_assert!(s >= T::ZERO);
@@ -150,12 +144,10 @@ pub fn param_from_arc_length<T: Float>(table: &ArcLengthTableRef<'_, T>, s: T) -
     let u_arr = table.u();
     debug_assert!(s_arr.len() >= 2);
     debug_assert_eq!(s_arr.len(), u_arr.len());
-    // SAFETY: len >= 2 → index 0 is valid.
     if s_clamped <= unsafe { *s_arr.get_unchecked(0) } {
         return unsafe { *u_arr.get_unchecked(0) };
     }
     let last = s_arr.len() - 1;
-    // SAFETY: last = len-1 < len.
     if s_clamped >= unsafe { *s_arr.get_unchecked(last) } {
         return unsafe { *u_arr.get_unchecked(last) };
     }
@@ -164,14 +156,13 @@ pub fn param_from_arc_length<T: Float>(table: &ArcLengthTableRef<'_, T>, s: T) -
     let mut hi = last;
     while hi - lo > 1 {
         let mid = usize::midpoint(lo, hi);
-        // SAFETY: mid ∈ (lo, hi) ⊆ [0, last] < len.
         if unsafe { *s_arr.get_unchecked(mid) } <= s_clamped {
             lo = mid;
         } else {
             hi = mid;
         }
     }
-    // SAFETY: loop invariant → lo ∈ [0, last-1], lo+1 ≤ last < len; u_arr same length.
+    debug_assert!(lo < last);
     let s_lo = unsafe { *s_arr.get_unchecked(lo) };
     let s_hi = unsafe { *s_arr.get_unchecked(lo + 1) };
     let u_lo = unsafe { *u_arr.get_unchecked(lo) };
@@ -193,12 +184,10 @@ pub fn arc_length_from_param<T: Float>(table: &ArcLengthTableRef<'_, T>, u: T) -
     let u_arr = table.u();
     debug_assert!(u_arr.len() >= 2);
     debug_assert_eq!(s_arr.len(), u_arr.len());
-    // SAFETY: len >= 2 → index 0 is valid.
     if u_clamped <= unsafe { *u_arr.get_unchecked(0) } {
         return unsafe { *s_arr.get_unchecked(0) };
     }
     let last = u_arr.len() - 1;
-    // SAFETY: last = len-1 < len.
     if u_clamped >= unsafe { *u_arr.get_unchecked(last) } {
         return unsafe { *s_arr.get_unchecked(last) };
     }
@@ -207,14 +196,13 @@ pub fn arc_length_from_param<T: Float>(table: &ArcLengthTableRef<'_, T>, u: T) -
     let mut hi = last;
     while hi - lo > 1 {
         let mid = usize::midpoint(lo, hi);
-        // SAFETY: mid ∈ (lo, hi) ⊆ [0, last] < len.
         if unsafe { *u_arr.get_unchecked(mid) } <= u_clamped {
             lo = mid;
         } else {
             hi = mid;
         }
     }
-    // SAFETY: loop invariant → lo ∈ [0, last-1], lo+1 ≤ last < len.
+    debug_assert!(lo < last);
     let u_lo = unsafe { *u_arr.get_unchecked(lo) };
     let u_hi = unsafe { *u_arr.get_unchecked(lo + 1) };
     let s_lo = unsafe { *s_arr.get_unchecked(lo) };
@@ -349,10 +337,6 @@ impl<'a> ArcLengthTableRef<'a, f32> {
             });
         }
 
-        // SAFETY: alignment of `buf` to `align_of::<f32>()` is checked above; the
-        // header is 8 bytes (multiple of 4) so `s_ptr` and `u_ptr` remain 4-byte
-        // aligned. The total length covers `2 * sample_count * size_of::<f32>()`
-        // bytes after the header. Lifetime `'a` is inherited from `buf`.
         #[allow(unsafe_code)]
         let (s, u) = unsafe {
             let s_ptr = buf.as_ptr().add(ARC_LENGTH_HEADER_BYTES).cast::<f32>();

--- a/rust/nurbs/src/arc_length/tests.rs
+++ b/rust/nurbs/src/arc_length/tests.rs
@@ -22,7 +22,6 @@ fn owned_as_view_round_trips() {
 #[cfg(feature = "host")]
 #[test]
 fn integrate_constant_returns_length_times_constant() {
-    // ∫_0^1 of f(u)=2 should be 2.
     let result = integrate_arc_length(|_u: f64| 2.0_f64, 0.0, 1.0, 5);
     assert!((result - 2.0).abs() < 1e-12);
 }
@@ -30,7 +29,6 @@ fn integrate_constant_returns_length_times_constant() {
 #[cfg(feature = "host")]
 #[test]
 fn integrate_linear_matches_closed_form() {
-    // ∫_0^1 of f(u)=u should be 0.5.
     let result = integrate_arc_length(|u: f64| u, 0.0, 1.0, 5);
     assert!((result - 0.5).abs() < 1e-12);
 }
@@ -38,7 +36,6 @@ fn integrate_linear_matches_closed_form() {
 #[cfg(feature = "host")]
 #[test]
 fn integrate_quadratic_matches_closed_form() {
-    // ∫_0^1 of f(u)=u^2 should be 1/3. 5-point Gauss-Legendre is exact for degree <= 9.
     let result = integrate_arc_length(|u: f64| u * u, 0.0, 1.0, 5);
     assert!((result - 1.0 / 3.0).abs() < 1e-12);
 }
@@ -71,8 +68,8 @@ fn param_from_arc_length_at_endpoints() {
 #[test]
 fn param_from_arc_length_interpolates_linearly() {
     let table = ArcLengthTableRef::new(&[0.0_f64, 0.5, 1.0], &[0.0, 0.6, 1.0]);
-    // s = 0.25 lies between (0.0 -> 0.0) and (0.5 -> 0.6); linear interp gives 0.3.
-    assert!((param_from_arc_length(&table, 0.25_f64) - 0.3).abs() < 1e-12);
+    let expected_interp = 0.3;
+    assert!((param_from_arc_length(&table, 0.25_f64) - expected_interp).abs() < 1e-12);
 }
 
 #[allow(clippy::float_cmp)]
@@ -107,8 +104,6 @@ fn build_vector_table_for_3d_linear_curve() {
 
 #[test]
 fn try_from_wire_parses_small_table() {
-    // Layout: u8 version, u8 reserved, u16 sample_count, u32 reserved2,
-    //         T[sample_count] s, T[sample_count] u
     let mut buf = Vec::new();
     buf.extend_from_slice(&[1u8, 0]); // version, reserved
     buf.extend_from_slice(&3u16.to_ne_bytes()); // sample_count
@@ -133,8 +128,7 @@ struct AlignedBytes {
 
 impl AlignedBytes {
     fn as_slice(&self) -> &[u8] {
-        // SAFETY: `Vec<u32>` is 4-byte aligned and `len <= backing.len() * 4`.
-        // `u32` has no padding and any bit pattern is a valid `u8` byte.
+        debug_assert!(self.len <= self.backing.len() * core::mem::size_of::<u32>());
         #[allow(unsafe_code)]
         unsafe {
             core::slice::from_raw_parts(self.backing.as_ptr().cast::<u8>(), self.len)
@@ -145,8 +139,7 @@ impl AlignedBytes {
 fn test_align(data: &[u8], _align: usize) -> AlignedBytes {
     let n = data.len().div_ceil(4);
     let mut backing: Vec<u32> = vec![0; n];
-    // SAFETY: `backing` owns `n*4` bytes 4-byte aligned; `data.len() <= n*4`.
-    // `u32` has no padding so writing arbitrary bytes is well-defined.
+    debug_assert!(data.len() <= n * core::mem::size_of::<u32>());
     #[allow(unsafe_code)]
     let bytes: &mut [u8] =
         unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), n * 4) };

--- a/rust/nurbs/src/bezier.rs
+++ b/rust/nurbs/src/bezier.rs
@@ -1,7 +1,5 @@
 use crate::{AlgebraError, Float, ScalarNurbs};
 
-/// One Bézier piece as a polynomial in the Pascal-shifted monomial basis:
-/// `p(u) = Σ_{k=0..d} coeffs[k] * (u - u_start)^k`
 #[derive(Debug, Clone, PartialEq)]
 pub struct BezierPiece<T: Float> {
     pub u_start: T,
@@ -187,7 +185,6 @@ impl BezierPiece<f64> {
             let x = -b / (2.0 * a);
             return if x.is_finite() { vec![x] } else { Vec::new() };
         }
-        // Numerically stable form — avoids catastrophic cancellation.
         let sqrt_disc = disc.sqrt();
         let q = -0.5 * (b + b.signum() * sqrt_disc);
         let x1 = q / a;
@@ -504,8 +501,11 @@ pub fn split_piece_at<T: Float>(
     (left, right)
 }
 
-// Safe for n ≤ 50; crate MAX_DEGREE = 20, convolve worst case n = 40.
 pub(crate) fn binomial(n: usize, k: usize) -> u64 {
+    debug_assert!(
+        n <= 50,
+        "binomial intermediate products overflow u64 above n = 50"
+    );
     if k > n {
         return 0;
     }

--- a/rust/nurbs/src/eval.rs
+++ b/rust/nurbs/src/eval.rs
@@ -10,11 +10,9 @@ pub(crate) use crate::knot::find_knot_span;
 pub(crate) fn find_knot_span<T: Float>(knots: &[T], p: usize, n: usize, u: T) -> usize {
     debug_assert!(knots.len() == n + p + 1);
     debug_assert!(n >= 1);
-    // SAFETY: n < n+p+1 = knots.len() (p is usize so >= 0, n >= 1)
     if u >= unsafe { *knots.get_unchecked(n) } {
         return n - 1;
     }
-    // SAFETY: p < n+p+1 = knots.len() (n >= 1)
     if u <= unsafe { *knots.get_unchecked(p) } {
         return p;
     }
@@ -22,13 +20,10 @@ pub(crate) fn find_knot_span<T: Float>(knots: &[T], p: usize, n: usize, u: T) ->
     let mut high = n;
     let mut mid = (low + high) / 2;
     while {
-        // SAFETY: mid ∈ [low,high] ⊆ [p,n] < n+p+1 = knots.len();
-        //         mid+1 ≤ high+1 ≤ n+1 ≤ n+p+1 = knots.len() (p >= 0).
         let km = unsafe { *knots.get_unchecked(mid) };
         let km1 = unsafe { *knots.get_unchecked(mid + 1) };
         u < km || u >= km1
     } {
-        // SAFETY: same bounds — recompute on next iteration.
         let km = unsafe { *knots.get_unchecked(mid) };
         if u < km {
             high = mid;
@@ -40,18 +35,6 @@ pub(crate) fn find_knot_span<T: Float>(knots: &[T], p: usize, n: usize, u: T) ->
     mid
 }
 
-/// de Boor's algorithm at parameter `u` over `cps` with degree `p`.
-/// Reference: Piegl & Tiller "The NURBS Book" Algorithm A4.1 (de Boor).
-///
-/// # Index-safety invariant
-///
-/// `find_knot_span` returns `k ∈ [p, n-1]` (algorithm A2.1 postcondition).
-///
-/// For `j ∈ 0..=p`: `k - p + j ∈ [0, k] ⊆ [0, n-1]` — valid index into
-/// `cps` (len `n`) and into `knots` (len `n + p + 1`).
-///
-/// For the recurrence with `r ∈ 1..=p`, `j ∈ r..=p`:
-/// `k + 1 + j - r ≤ k + p ≤ (n-1) + p = n + p - 1 < n + p + 1` — valid.
 #[inline]
 pub(crate) fn de_boor_inner<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) -> T {
     debug_assert!((degree as usize) <= MAX_DEGREE);
@@ -59,22 +42,16 @@ pub(crate) fn de_boor_inner<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) 
     let n = cps.len();
     let k = find_knot_span(knots, p, n, u);
 
-    // SAFETY: k ∈ [p, n-1] from find_knot_span, so k-p+j ∈ [0, n-1] for j ∈ 0..=p.
     debug_assert!(k >= p && k < n, "find_knot_span invariant: k ∈ [p, n-1]");
     debug_assert!(knots.len() == n + p + 1, "knots len == n + p + 1");
 
     let mut d = [T::ZERO; WORKSPACE_SIZE];
     for j in 0..=p {
-        // SAFETY: k - p + j ∈ [0, k] ⊆ [0, n-1] < cps.len()
-        // SAFETY: j ≤ p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
         unsafe { *d.get_unchecked_mut(j) = *cps.get_unchecked(k - p + j) };
     }
 
     for r in 1..=p {
         for j in (r..=p).rev() {
-            // SAFETY: k - p + j ∈ [0, n-1] < knots.len();
-            //         k + 1 + j - r ≤ k + p ≤ n + p - 1 < knots.len() = n + p + 1.
-            // SAFETY: j ≤ p ≤ MAX_DEGREE < WORKSPACE_SIZE; j-1 ≥ r-1 ≥ 0.
             let knot_lo = unsafe { *knots.get_unchecked(k - p + j) };
             let knot_hi = unsafe { *knots.get_unchecked(k + 1 + j - r) };
             let denom = knot_hi - knot_lo;
@@ -89,7 +66,6 @@ pub(crate) fn de_boor_inner<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) 
         }
     }
 
-    // SAFETY: p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
     unsafe { *d.get_unchecked(p) }
 }
 
@@ -110,13 +86,10 @@ pub fn vector_eval<T: Float, V: VectorNurbsView<T, N>, const N: usize>(curve: &V
 
     let mut d_axes: [[T; WORKSPACE_SIZE]; N] = [[T::ZERO; WORKSPACE_SIZE]; N];
 
-    // SAFETY: k ∈ [p, n-1] from find_knot_span (same invariant as de_boor_inner).
     debug_assert!(k >= p && k < n, "find_knot_span invariant: k ∈ [p, n-1]");
     debug_assert!(knots.len() == n + p + 1, "knots len == n + p + 1");
 
     for j in 0..=p {
-        // SAFETY: k - p + j ∈ [0, n-1] < cps.len()
-        // SAFETY: j ≤ p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
         let cp = unsafe { cps.get_unchecked(k - p + j) };
         for axis in 0..N {
             unsafe { *d_axes[axis].get_unchecked_mut(j) = cp[axis] };
@@ -125,8 +98,6 @@ pub fn vector_eval<T: Float, V: VectorNurbsView<T, N>, const N: usize>(curve: &V
 
     for r in 1..=p {
         for j in (r..=p).rev() {
-            // SAFETY: same knots-index invariant as de_boor_inner.
-            // SAFETY: j ≤ p ≤ MAX_DEGREE < WORKSPACE_SIZE; j-1 ≥ r-1 ≥ 0.
             let knot_lo = unsafe { *knots.get_unchecked(k - p + j) };
             let knot_hi = unsafe { *knots.get_unchecked(k + 1 + j - r) };
             let denom = knot_hi - knot_lo;
@@ -145,18 +116,11 @@ pub fn vector_eval<T: Float, V: VectorNurbsView<T, N>, const N: usize>(curve: &V
 
     let mut result = [T::ZERO; N];
     for axis in 0..N {
-        // SAFETY: p ≤ MAX_DEGREE < WORKSPACE_SIZE
         result[axis] = unsafe { *d_axes[axis].get_unchecked(p) };
     }
     result
 }
 
-/// Evaluate `P(u)` and `dP/du` simultaneously. Runs de Boor and its derivative
-/// recurrence in parallel to avoid a second pass.
-///
-/// Derivative recurrence: differentiate `d^(r)_j = (1-α)*d^(r-1)_{j-1} + α*d^(r-1)_j` w.r.t. `u`:
-///   `∂_u d^(r)_j = (1-α)*∂_u d^(r-1)_{j-1} + α*∂_u d^(r-1)_j + (d^(r-1)_j - d^(r-1)_{j-1})/denom`.
-/// Initial `∂_u d^(0)_j = 0`. After full recurrence, `dd[p] = P'(u)`.
 #[inline]
 pub fn eval_polynomial_with_derivative<T: Float>(
     cps: &[T],
@@ -171,7 +135,6 @@ pub fn eval_polynomial_with_derivative<T: Float>(
         let p = 0;
         let n = cps.len();
         let k = find_knot_span(knots, p, n, u);
-        // SAFETY: find_knot_span returns k ∈ [0, n-1] for p=0.
         debug_assert!(k < n);
         return (unsafe { *cps.get_unchecked(k) }, T::ZERO);
     }
@@ -180,23 +143,17 @@ pub fn eval_polynomial_with_derivative<T: Float>(
     let n = cps.len();
     let k = find_knot_span(knots, p, n, u);
 
-    // SAFETY: k ∈ [p, n-1] from find_knot_span; k-p+j ∈ [0,n-1] for j ∈ 0..=p;
-    //         k+1+j-r ≤ k+p ≤ n+p-1 < knots.len() = n+p+1.
     debug_assert!(k >= p && k < n, "find_knot_span invariant: k ∈ [p, n-1]");
     debug_assert!(knots.len() == n + p + 1, "knots len == n + p + 1");
 
     let mut d = [T::ZERO; WORKSPACE_SIZE];
     let mut dd = [T::ZERO; WORKSPACE_SIZE];
     for j in 0..=p {
-        // SAFETY: k - p + j ∈ [0, n-1] < cps.len()
-        // SAFETY: j ≤ p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
         unsafe { *d.get_unchecked_mut(j) = *cps.get_unchecked(k - p + j) };
     }
 
     for r in 1..=p {
         for j in (r..=p).rev() {
-            // SAFETY: same knots-index invariant as de_boor_inner.
-            // SAFETY: j ≤ p ≤ MAX_DEGREE < WORKSPACE_SIZE; j-1 ≥ r-1 ≥ 0.
             let lo = unsafe { *knots.get_unchecked(k - p + j) };
             let hi = unsafe { *knots.get_unchecked(k + 1 + j - r) };
             let denom = hi - lo;
@@ -223,24 +180,16 @@ pub fn eval_polynomial_with_derivative<T: Float>(
         }
     }
 
-    // SAFETY: p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
     unsafe { (*d.get_unchecked(p), *dd.get_unchecked(p)) }
 }
 
-// Same index-safety proof as the MCU `find_knot_span` copy:
-//   knots[n]     : n < n+p+1 (p is usize, n >= 1)
-//   knots[p]     : p < n+p+1 (n >= 1)
-//   knots[mid]   : mid ∈ [low,high] ⊆ [p,n] < n+p+1
-//   knots[mid+1] : mid+1 ≤ n+1 ≤ n+p+1 (p >= 0)
 #[inline]
 fn find_knot_span_f32_with_f64_u(knots: &[f32], p: usize, n: usize, u: f64) -> usize {
     debug_assert!(knots.len() == n + p + 1);
     debug_assert!(n >= 1);
-    // SAFETY: n < n+p+1 = knots.len()
     if u >= f64::from(unsafe { *knots.get_unchecked(n) }) {
         return n - 1;
     }
-    // SAFETY: p < n+p+1 = knots.len()
     if u <= f64::from(unsafe { *knots.get_unchecked(p) }) {
         return p;
     }
@@ -248,7 +197,6 @@ fn find_knot_span_f32_with_f64_u(knots: &[f32], p: usize, n: usize, u: f64) -> u
     let mut high = n;
     let mut mid = (low + high) / 2;
     while {
-        // SAFETY: mid ∈ [low,high] ⊆ [p,n] < n+p+1; mid+1 ≤ n+1 ≤ n+p+1.
         let km = f64::from(unsafe { *knots.get_unchecked(mid) });
         let km1 = f64::from(unsafe { *knots.get_unchecked(mid + 1) });
         u < km || u >= km1
@@ -264,9 +212,6 @@ fn find_knot_span_f32_with_f64_u(knots: &[f32], p: usize, n: usize, u: f64) -> u
     mid
 }
 
-/// Same as `eval_polynomial_with_derivative` but also tracks the second
-/// derivative. The `ddd` update rule is the difference-of-`dd` recurrence —
-/// algebraically the second derivative of the same polynomial.
 #[inline]
 pub fn eval_polynomial_f32_with_pos_vel_accel_f64(
     cps: &[f32],
@@ -283,14 +228,11 @@ pub fn eval_polynomial_f32_with_pos_vel_accel_f64(
 
     if degree == 0 {
         let k = find_knot_span_f32_with_f64_u(knots, p, n, u_f64);
-        // SAFETY: find_knot_span returns k ∈ [0, n-1] for p=0.
         debug_assert!(k < n);
         return (f64::from(unsafe { *cps.get_unchecked(k) }), 0.0, 0.0);
     }
     if degree == 1 {
-        // Linear: second derivative is identically zero on each span.
         let k = find_knot_span_f32_with_f64_u(knots, p, n, u_f64);
-        // SAFETY: k ∈ [1, n-1] for p=1; k-1 ∈ [0, n-2]; k+1 ≤ n < knots.len().
         debug_assert!(k >= 1 && k < n);
         let a = f64::from(unsafe { *cps.get_unchecked(k - 1) });
         let b = f64::from(unsafe { *cps.get_unchecked(k) });
@@ -308,8 +250,6 @@ pub fn eval_polynomial_f32_with_pos_vel_accel_f64(
 
     let k = find_knot_span_f32_with_f64_u(knots, p, n, u_f64);
 
-    // SAFETY: k ∈ [p, n-1] from find_knot_span; k-p+j ∈ [0,n-1] for j ∈ 0..=p;
-    //         k+1+j-r ≤ k+p ≤ n+p-1 < knots.len() = n+p+1.
     debug_assert!(k >= p && k < n, "find_knot_span invariant");
     debug_assert!(knots.len() == n + p + 1, "knots len == n + p + 1");
 
@@ -317,15 +257,11 @@ pub fn eval_polynomial_f32_with_pos_vel_accel_f64(
     let mut dd = [0.0_f64; WORKSPACE_SIZE];
     let mut ddd = [0.0_f64; WORKSPACE_SIZE];
     for j in 0..=p {
-        // SAFETY: k - p + j ∈ [0, n-1] < cps.len()
-        // SAFETY: j ≤ p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
         unsafe { *d.get_unchecked_mut(j) = f64::from(*cps.get_unchecked(k - p + j)) };
     }
 
     for r in 1..=p {
         for j in (r..=p).rev() {
-            // SAFETY: same knots-index invariant as de_boor_inner.
-            // SAFETY: j ≤ p ≤ MAX_DEGREE < WORKSPACE_SIZE; j-1 ≥ r-1 ≥ 0.
             let lo = f64::from(unsafe { *knots.get_unchecked(k - p + j) });
             let hi = f64::from(unsafe { *knots.get_unchecked(k + 1 + j - r) });
             let denom = hi - lo;
@@ -358,7 +294,6 @@ pub fn eval_polynomial_f32_with_pos_vel_accel_f64(
         }
     }
 
-    // SAFETY: p ≤ MAX_DEGREE = WORKSPACE_SIZE - 1 < WORKSPACE_SIZE
     unsafe {
         (
             *d.get_unchecked(p),
@@ -368,8 +303,6 @@ pub fn eval_polynomial_f32_with_pos_vel_accel_f64(
     }
 }
 
-/// Evaluate at `u` from raw slices without going through `ScalarNurbsRef::try_new`.
-/// Caller must ensure `knots.len() == cps.len() + degree + 1` (validated upstream).
 #[inline]
 pub fn eval_polynomial<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) -> T {
     debug_assert!((degree as usize) <= MAX_DEGREE);
@@ -394,11 +327,6 @@ pub fn eval_derivative<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) -> T 
 
     let k = find_knot_span(lowered_knots, new_p, new_n, u);
 
-    // SAFETY: k ∈ [new_p, new_n-1] from find_knot_span;
-    //         i = k - new_p + j ∈ [0, k] ⊆ [0, new_n-1] = [0, n-2].
-    //         cps[i+1] has i+1 ≤ new_n-1+1 = n-1 < cps.len().
-    //         knots[i+p+1] has i+p+1 ≤ (n-2)+p+1 = n+p-1 < knots.len() = n+p+1.
-    //         lowered_knots has length n+p-1; k+1+j-r ≤ k+new_p ≤ n-2+p-1 = n+p-3 < n+p-1.
     debug_assert!(
         k >= new_p && k < new_n,
         "find_knot_span invariant on lowered knots"
@@ -408,12 +336,9 @@ pub fn eval_derivative<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) -> T 
     let p_t = T::from_f64(f64::from(degree));
     for j in 0..=new_p {
         let i = k - new_p + j;
-        // SAFETY: i ∈ [0, n-2]; i+1 ∈ [1, n-1] < cps.len(); i+p+1 ≤ n+p-1 < knots.len().
-        // SAFETY: j ≤ new_p ≤ p-1 ≤ MAX_DEGREE-1 < WORKSPACE_SIZE
         let denom = unsafe { *knots.get_unchecked(i + p + 1) - *knots.get_unchecked(i + 1) };
         unsafe {
             *d.get_unchecked_mut(j) = if denom > T::ZERO {
-                // SAFETY: i ∈ [0, n-2]; i+1 ∈ [1, n-1] < cps.len()
                 p_t * (*cps.get_unchecked(i + 1) - *cps.get_unchecked(i)) / denom
             } else {
                 T::ZERO
@@ -423,8 +348,6 @@ pub fn eval_derivative<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) -> T 
 
     for r in 1..=new_p {
         for j in (r..=new_p).rev() {
-            // SAFETY: lowered_knots indices are in-bounds by the invariant above.
-            // SAFETY: j ≤ new_p < WORKSPACE_SIZE; j-1 ≥ r-1 ≥ 0.
             let knot_lo = unsafe { *lowered_knots.get_unchecked(k - new_p + j) };
             let knot_hi = unsafe { *lowered_knots.get_unchecked(k + 1 + j - r) };
             let denom = knot_hi - knot_lo;
@@ -439,7 +362,6 @@ pub fn eval_derivative<T: Float>(cps: &[T], knots: &[T], degree: u8, u: T) -> T 
         }
     }
 
-    // SAFETY: new_p = p - 1 ≤ MAX_DEGREE - 1 < WORKSPACE_SIZE
     unsafe { *d.get_unchecked(new_p) }
 }
 
@@ -505,9 +427,6 @@ pub fn vector_derivative<T: Float, const N: usize>(
         .expect("degree-lowered NURBS satisfies invariants by construction")
 }
 
-/// Compute curvature κ(u) = ||r' × r''|| / ||r'||³ for a 3D path NURBS.
-/// Speed-cubed denominator is clamped at `MIN_PARAMETRIC_SPEED` to avoid
-/// divide-by-zero at cusps.
 #[cfg(feature = "host")]
 pub fn curvature_from_derivs<T: Float, const N: usize>(
     first_deriv: &crate::VectorNurbs<T, N>,

--- a/rust/nurbs/src/eval/tests.rs
+++ b/rust/nurbs/src/eval/tests.rs
@@ -264,17 +264,15 @@ fn pos_vel_accel_on_cubic_polynomial() {
 
 #[test]
 fn pos_vel_accel_on_linear_polynomial_returns_zero_accel() {
-    // f(u) = u, degree-1 Bézier cps=[0,1], knots=[0,0,1,1].
-    // Note: 0.3_f32 widens to ~0.30000001192 in f64, so position tolerance
-    // accommodates the f32→f64 round-trip on u (~1.2e-8). Velocity and
-    // acceleration are exact (rational arithmetic on exact knots/cps).
     let cps = vec![0.0_f32, 1.0];
     let knots = vec![0.0_f32, 0.0, 1.0, 1.0];
+    let f32_round_trip_tol = 1e-6;
+    let exact_arithmetic_tol = 1e-9;
     let (p, v, a) = eval_polynomial_f32_with_pos_vel_accel_f64(&cps, &knots, 1, 0.3);
-    assert!((p - 0.3).abs() < 1e-6, "pos={}", p);
-    assert!((v - 1.0_f64).abs() < 1e-9, "vel={}", v);
+    assert!((p - 0.3).abs() < f32_round_trip_tol, "pos={}", p);
+    assert!((v - 1.0_f64).abs() < exact_arithmetic_tol, "vel={}", v);
     assert!(
-        a.abs() < 1e-9,
+        a.abs() < exact_arithmetic_tol,
         "linear curve must have zero second derivative; got {}",
         a
     );

--- a/rust/nurbs/src/float.rs
+++ b/rust/nurbs/src/float.rs
@@ -14,7 +14,6 @@ pub trait Float:
     const ONE: Self;
 
     fn from_f64(x: f64) -> Self;
-    // mul_add is load-bearing on M7: emits a single VFMA.F32 instruction in release.
     fn mul_add(self, a: Self, b: Self) -> Self;
 
     fn sqrt(self) -> Self;
@@ -35,7 +34,6 @@ impl Float for f32 {
 
     #[inline]
     fn mul_add(self, a: Self, b: Self) -> Self {
-        // no_std: f32::mul_add recurses via trait; use libm::fmaf instead.
         #[cfg(feature = "host")]
         {
             f32::mul_add(self, a, b)

--- a/rust/nurbs/src/knot.rs
+++ b/rust/nurbs/src/knot.rs
@@ -46,7 +46,6 @@ impl<T: Float> KnotVector<T> {
     }
 }
 
-// Piegl & Tiller Algorithm A2.1.
 pub fn find_knot_span<T: Float>(knots: &[T], p: usize, n: usize, u: T) -> usize {
     debug_assert!(knots.len() == n + p + 1);
     if u >= knots[n] {
@@ -275,7 +274,6 @@ fn refine_knot_vect_curve<T: Float>(knots: &[T], cps: &[T], p: usize, x: &[T]) -
     (new_knots, new_cps)
 }
 
-// Tiller knot removal: Piegl & Tiller Algorithm A5.8.
 pub fn remove_knot<T: Float>(
     curve: &ScalarNurbs<T>,
     u: T,

--- a/rust/nurbs/src/knot/tests.rs
+++ b/rust/nurbs/src/knot/tests.rs
@@ -131,13 +131,6 @@ fn remove_knot_undoes_insertion_for_cubic_with_irregular_cps() {
 
 #[test]
 fn remove_knot_two_round_trips_for_cubic_with_irregular_cps() {
-    // Degree-4 curve with no interior knots, irregular non-symmetric CPs.
-    // Insert at u=0.4 twice to lift multiplicity to 2, then attempt to
-    // remove both. With p=4 and s=2, iteration t=1 of remove_knot exits its
-    // inner loop with j == i (i.e. j < i + t strictly), exercising the
-    // convergence-branch predicate. With the buggy `j + t < i` predicate
-    // this routes to the else branch, reads outside the temp window, and
-    // either panics or returns count=1 with displaced cps.
     let curve = ScalarNurbs::<f64>::try_new(
         4,
         vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0],
@@ -281,9 +274,6 @@ fn refined_to_full_multiplicity_matches_reference_on_mixed_multiplicity_curve() 
 
 #[test]
 fn insert_knot_multifold_at_existing_preserves_evaluation_for_failing_case() {
-    // From the algebra_proptest shrunk failure: cubic with interior knot at 0.1
-    // (multiplicity 1), inserted twice — Boehm A5.3 multi-fold + existing path
-    // produced wrong control points pre-fix.
     use crate::eval::eval;
     let curve = ScalarNurbs::<f64>::try_new(
         3,

--- a/rust/nurbs/src/lib.rs
+++ b/rust/nurbs/src/lib.rs
@@ -66,9 +66,6 @@ pub const MAX_DEGREE: usize = 20;
 
 pub const WORKSPACE_SIZE: usize = MAX_DEGREE + 1;
 
-/// Numerical floor for parametric speed |dP/du|, weight denominators, and
-/// curvature-divisor cubed-norms. Exposed as f64 so callers and `Float::from_f64`
-/// see a single source of truth.
 pub const MIN_PARAMETRIC_SPEED: f64 = 1e-9;
 
 const _: () = assert!(WORKSPACE_SIZE == MAX_DEGREE + 1);

--- a/rust/nurbs/src/scalar.rs
+++ b/rust/nurbs/src/scalar.rs
@@ -210,8 +210,8 @@ impl<'a> ScalarNurbsRef<'a, f32> {
             });
         }
 
-        // SAFETY: alignment checked above; lengths checked above; T = f32 has
-        // no invalid bit patterns for any 4-byte sequence.
+        debug_assert!((buf.as_ptr() as usize) % core::mem::align_of::<f32>() == 0);
+        debug_assert!(buf.len() >= total);
         #[allow(unsafe_code)]
         let (knots, cps) = unsafe {
             let knots_ptr = buf.as_ptr().add(SCALAR_HEADER_BYTES).cast::<f32>();

--- a/rust/nurbs/src/scalar/tests.rs
+++ b/rust/nurbs/src/scalar/tests.rs
@@ -84,9 +84,6 @@ fn ref_try_new_accepts_valid_data() {
 
 #[test]
 fn try_from_wire_parses_unweighted_linear() {
-    // Layout: u8 version, u8 degree, u8 has_weights, u8 reserved,
-    //         u16 knot_count, u16 cp_count, then knots + cps (both as f32).
-    // Linear curve: degree=1, knots=[0,0,1,1], cps=[0.0, 1.0]
     let mut buf = Vec::new();
     buf.extend_from_slice(&[1, 1, 0, 0]); // version, degree, has_weights, reserved
     buf.extend_from_slice(&4u16.to_ne_bytes()); // knot_count
@@ -108,11 +105,10 @@ fn try_from_wire_parses_unweighted_linear() {
 fn try_from_wire_rejects_misaligned_buffer() {
     let mut data = [0u8; 32 + 1];
     data[0] = 1;
-    // Stack-array layout in release can land on an address where `&buf[1..]`
-    // happens to be 4-aligned. Anchor on a 4-aligned base via align_buf, then
-    // slice from offset 1 so misalignment for f32 is guaranteed.
     let aligned = align_buf(&data, 4);
-    let result = ScalarNurbsRef::<f32>::try_from_wire(&aligned.as_slice()[1..]);
+    let guaranteed_misaligned = &aligned.as_slice()[1..];
+    debug_assert_ne!(guaranteed_misaligned.as_ptr().align_offset(4), 0);
+    let result = ScalarNurbsRef::<f32>::try_from_wire(guaranteed_misaligned);
     assert!(matches!(result, Err(crate::WireError::Misaligned)));
 }
 
@@ -153,11 +149,6 @@ fn try_from_wire_rejects_has_weights_flag() {
     assert!(matches!(result, Err(crate::WireError::WeightsUnsupported)));
 }
 
-/// Owns a 4-byte-aligned byte buffer for wire-format tests. The backing
-/// storage is a `Vec<u32>` (alignment 4); we expose its bytes via `as_slice`.
-/// Using a wrapper avoids the layout-mismatch UB that would arise from
-/// transmuting `Vec<u32>` → `Vec<u8>` and letting the latter free with the
-/// wrong alignment.
 struct AlignedBytes {
     backing: Vec<u32>,
     len: usize,
@@ -165,8 +156,8 @@ struct AlignedBytes {
 
 impl AlignedBytes {
     fn as_slice(&self) -> &[u8] {
-        // SAFETY: `Vec<u32>` is 4-byte aligned and `len <= backing.len() * 4`.
-        // `u32` has no padding and any bit pattern is a valid `u8` byte.
+        debug_assert!(self.len <= self.backing.len() * 4);
+        debug_assert_eq!(self.backing.as_ptr().align_offset(4), 0);
         #[allow(unsafe_code)]
         unsafe {
             core::slice::from_raw_parts(self.backing.as_ptr().cast::<u8>(), self.len)
@@ -179,9 +170,7 @@ fn align_buf(data: &[u8], align: usize) -> AlignedBytes {
         4 => {
             let n = data.len().div_ceil(4);
             let mut backing: Vec<u32> = vec![0; n];
-            // SAFETY: `backing` owns `n * 4` bytes with 4-byte alignment;
-            // we write exactly `data.len() <= n * 4` bytes via the
-            // `&mut [u8]` view, then release it before returning.
+            debug_assert!(data.len() <= n * 4);
             #[allow(unsafe_code)]
             let bytes: &mut [u8] = unsafe {
                 core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), n * 4)

--- a/rust/nurbs/src/vector.rs
+++ b/rust/nurbs/src/vector.rs
@@ -164,8 +164,12 @@ impl<'a, const N: usize> VectorNurbsRef<'a, f32, N> {
             });
         }
 
-        // SAFETY: alignment checked; lengths checked; f32 has no invalid bit patterns;
-        // [f32; N] has same layout as N consecutive f32 values (no inter-element padding).
+        debug_assert_eq!((buf.as_ptr() as usize) % core::mem::align_of::<f32>(), 0);
+        debug_assert!(buf.len() >= total);
+        debug_assert_eq!(
+            core::mem::size_of::<[f32; N]>(),
+            N * core::mem::size_of::<f32>()
+        );
         #[allow(unsafe_code)]
         let (knots, cps) = unsafe {
             let knots_ptr = buf.as_ptr().add(VECTOR_HEADER_BYTES).cast::<f32>();

--- a/rust/nurbs/src/vector/tests.rs
+++ b/rust/nurbs/src/vector/tests.rs
@@ -44,8 +44,6 @@ fn as_view_provides_borrowed_access() {
 
 #[test]
 fn try_from_wire_parses_3d_unweighted_linear() {
-    // Layout: u8 version, u8 degree, u8 has_weights, u8 axes_n,
-    //         u16 knot_count, u16 cp_count, then knots + cps (interleaved).
     let mut buf = Vec::new();
     buf.extend_from_slice(&[1, 1, 0, 3]); // version, degree, has_weights, axes_n
     buf.extend_from_slice(&4u16.to_ne_bytes()); // knot_count
@@ -65,8 +63,6 @@ fn try_from_wire_parses_3d_unweighted_linear() {
 
 #[test]
 fn try_from_wire_rejects_has_weights_flag() {
-    // Legacy rational header (has_weights=1) must be rejected loudly, not
-    // parsed with a misaligned payload assumption.
     let mut buf = Vec::new();
     buf.extend_from_slice(&[1, 1, 1, 3]); // version, degree, has_weights=1, axes_n
     buf.extend_from_slice(&4u16.to_ne_bytes());
@@ -83,7 +79,6 @@ fn try_from_wire_rejects_axis_mismatch() {
     buf.extend_from_slice(&[1, 1, 0, 4]);
     buf.extend_from_slice(&4u16.to_ne_bytes());
     buf.extend_from_slice(&2u16.to_ne_bytes());
-    // pad to enough bytes so we get past the axis check
     buf.resize(64, 0);
     let aligned = test_align_buf(&buf, 4);
     let result = VectorNurbsRef::<f32, 3>::try_from_wire(aligned.as_slice());
@@ -103,7 +98,8 @@ struct AlignedBytes {
 
 impl AlignedBytes {
     fn as_slice(&self) -> &[u8] {
-        // SAFETY: `Vec<u32>` is 4-byte aligned; len <= backing.len()*4.
+        debug_assert!(self.backing.as_ptr() as usize % core::mem::align_of::<u32>() == 0);
+        debug_assert!(self.len <= self.backing.len() * 4);
         #[allow(unsafe_code)]
         unsafe {
             core::slice::from_raw_parts(self.backing.as_ptr().cast::<u8>(), self.len)
@@ -114,7 +110,7 @@ impl AlignedBytes {
 fn test_align_buf(data: &[u8], _align: usize) -> AlignedBytes {
     let n = data.len().div_ceil(4);
     let mut backing: Vec<u32> = vec![0; n];
-    // SAFETY: backing owns n*4 bytes 4-byte aligned; we write data.len() <= n*4.
+    debug_assert!(data.len() <= n * 4);
     #[allow(unsafe_code)]
     let bytes: &mut [u8] =
         unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), n * 4) };

--- a/rust/nurbs/src/wire.rs
+++ b/rust/nurbs/src/wire.rs
@@ -1,6 +1,12 @@
 pub const FORMAT_VERSION_V1: u8 = 0x01;
 
-// 8-byte headers align subsequent T[..] for both f32 and f64.
+const MAX_SCALAR_ALIGN_BYTES: usize = core::mem::align_of::<f64>();
 pub const SCALAR_HEADER_BYTES: usize = 8;
 pub const VECTOR_HEADER_BYTES: usize = 8;
 pub const ARC_LENGTH_HEADER_BYTES: usize = 8;
+
+const _: () = {
+    assert!(SCALAR_HEADER_BYTES % MAX_SCALAR_ALIGN_BYTES == 0);
+    assert!(VECTOR_HEADER_BYTES % MAX_SCALAR_ALIGN_BYTES == 0);
+    assert!(ARC_LENGTH_HEADER_BYTES % MAX_SCALAR_ALIGN_BYTES == 0);
+};

--- a/rust/nurbs/tests/algebra_oracle.rs
+++ b/rust/nurbs/tests/algebra_oracle.rs
@@ -1,7 +1,3 @@
-//! Cross-check our algebra ops against a sympy-generated oracle corpus.
-//! Corpus file: `tests/data/algebra_corpus.json` (regenerated via the
-//! Python script in `tests/scripts/`).
-
 #![cfg(feature = "host")]
 
 use serde_json::Value;

--- a/rust/nurbs/tests/algebra_proptest.rs
+++ b/rust/nurbs/tests/algebra_proptest.rs
@@ -20,8 +20,6 @@ fn arb_simple_polynomial_curve() -> impl Strategy<Value = nurbs::ScalarNurbs<f64
 }
 
 fn arb_multi_piece_curve() -> impl Strategy<Value = nurbs::ScalarNurbs<f64>> {
-    // Generates curves with 1-2 interior knots, well-separated (>0.1 apart) to
-    // avoid coincident-knot collisions during proptest shrinking.
     (1u8..=4, 1usize..=2).prop_flat_map(|(p, num_interior)| {
         let pad = p as usize + 1;
         let n = p as usize + 1 + num_interior;
@@ -52,11 +50,6 @@ fn arb_single_poly_kernel() -> impl Strategy<Value = nurbs::algebra::PiecewisePo
 
 fn arb_curve_with_existing_interior_multiplicity()
 -> impl Strategy<Value = (nurbs::ScalarNurbs<f64>, f64, usize, usize)> {
-    // Generates (curve, u_knot, p, existing_mult_at_u) with TWO interior knots:
-    // the target knot at `existing_mult_at_u >= 1` plus one other. Without the
-    // second knot the local CP polygon is constrained by uniform surrounding knots
-    // and the A5.3 bug produces the right eval by accident. Constraint
-    // `existing <= p - 2` ensures r_max >= 2, the regime that triggered A5.3.
     (3u8..=4, 0.1..0.45_f64, 0.55..0.9_f64, prop::bool::ANY).prop_flat_map(|(p, ka, kb, swap)| {
         let (u_knot, other_knot) = if swap { (ka, kb) } else { (kb, ka) };
         let existing_strategy: BoxedStrategy<usize> = (1usize..=(p as usize - 2)).boxed();
@@ -229,8 +222,6 @@ proptest! {
 }
 
 proptest! {
-    // Knot values propagate bit-exact through insertion / Bezier extraction in
-    // our pipeline; the exact equality check is intentional structural verification.
     #[test]
     #[allow(clippy::float_cmp)]
     fn multiply_product_has_morken_multiplicities_at_kinks(

--- a/rust/nurbs/tests/compose_vector_piece.rs
+++ b/rust/nurbs/tests/compose_vector_piece.rs
@@ -21,7 +21,6 @@ fn identity_composition_returns_outer() {
         u_end: 1.0,
         coeffs: vec![5.0, 0.0, 0.0, 0.0], // p(s) = 5
     };
-    // identity(t) = t in Pascal-shifted basis on [0, 1] is [0, 1].
     let inner = BezierPiece::<f64> {
         u_start: 0.0,
         u_end: 1.0,
@@ -60,7 +59,6 @@ fn linear_inner_is_parameter_rescaling() {
         u_end: 1.0,
         coeffs: vec![0.0, 1.0, 0.0, 1.0], // p(s) = s + s³
     };
-    // inner(t) = 0.5 * t = t/2: maps [0, 1] → [0, 0.5].
     let inner = BezierPiece::<f64> {
         u_start: 0.0,
         u_end: 1.0,
@@ -87,13 +85,11 @@ fn linear_inner_is_parameter_rescaling() {
 
 #[test]
 fn cubic_outer_quadratic_inner_yields_degree_6() {
-    // outer(s) = 1 + s + s² + s³ on s ∈ [0, 1].
     let outer = BezierPiece::<f64> {
         u_start: 0.0,
         u_end: 1.0,
         coeffs: vec![1.0, 1.0, 1.0, 1.0],
     };
-    // inner(t) = t² on t ∈ [0, 1] (Pascal-shifted around 0): coeffs = [0, 0, 1].
     let inner = BezierPiece::<f64> {
         u_start: 0.0,
         u_end: 1.0,
@@ -109,7 +105,6 @@ fn cubic_outer_quadratic_inner_yields_degree_6() {
         composed[0].degree()
     );
 
-    // Sample values must match outer(inner(t)) = 1 + t² + t⁴ + t⁶.
     for i in 0..=100 {
         let t = i as f64 / 100.0;
         let composed_val = composed[0].evaluate(t);

--- a/rust/nurbs/tests/fit_hermite.rs
+++ b/rust/nurbs/tests/fit_hermite.rs
@@ -309,20 +309,12 @@ fn hermite_fit_degree6_input_reduces_to_degree4() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tests for fit_hermite_c1_clamped (C2 boundary pins)
-// ---------------------------------------------------------------------------
-
-/// Evaluate the 2nd derivative of a BezierPiece at a point.
 fn d2_at(piece: &BezierPiece<f64>, u: f64) -> f64 {
     piece.differentiate().differentiate().evaluate(u)
 }
 
 #[test]
 fn clamped_fit_pins_both_boundary_second_derivatives() {
-    // Source: f(t) = t³ on [0, 2]. Pascal-shifted at 0: coeffs = [0,0,0,1].
-    // We pin d2_start=6 and d2_end=10 (deliberately not the analytic values).
-    // The fitted polynomial must honour exactly these pins at its outer endpoints.
     let pieces: Vec<[BezierPiece<f64>; 1]> = vec![[BezierPiece {
         u_start: 0.0,
         u_end: 2.0,
@@ -332,8 +324,6 @@ fn clamped_fit_pins_both_boundary_second_derivatives() {
     let d2_start_pin = 6.0_f64;
     let d2_end_pin = 10.0_f64;
 
-    // Tolerance is 2.0: with deliberately non-analytic pins the residual will be
-    // significant, but we only need to assert the pins are honoured exactly.
     let result =
         fit_hermite_c1_clamped::<1>(&pieces, 2.0, 5, Some([d2_start_pin]), Some([d2_end_pin]))
             .unwrap();
@@ -356,8 +346,6 @@ fn clamped_fit_pins_both_boundary_second_derivatives() {
 
 #[test]
 fn clamped_fit_position_residual_within_tolerance() {
-    // Source: f(t) = t² + 0.5*t on [0, 3], split into 3 unit pieces.
-    // f''(0) = 2, f''(3) = 2.
     let pieces: Vec<[BezierPiece<f64>; 1]> = (0..3)
         .map(|i| {
             let s = i as f64;
@@ -397,8 +385,6 @@ fn clamped_fit_position_residual_within_tolerance() {
 
 #[test]
 fn clamped_fit_preserves_c1_at_interior_knots() {
-    // 4 quadratic pieces; pin d2_start and d2_end.
-    // Interior piece joints must remain C1.
     let pieces: Vec<[BezierPiece<f64>; 1]> = (0..4)
         .map(|i| {
             let s = i as f64;
@@ -410,8 +396,6 @@ fn clamped_fit_preserves_c1_at_interior_knots() {
         })
         .collect();
 
-    // Tolerance 0.5: pin d2_end=10 is far from the analytic 2, introducing
-    // inherent position deviation that a tight tolerance would reject.
     let result =
         fit_hermite_c1_clamped::<1>(&pieces, 0.5, 5, Some([2.0_f64]), Some([10.0_f64])).unwrap();
 
@@ -437,7 +421,6 @@ fn clamped_fit_preserves_c1_at_interior_knots() {
 
 #[test]
 fn clamped_fit_none_pins_matches_c1() {
-    // With both pins = None, clamped fit must reproduce fit_hermite_c1 values.
     let pieces: Vec<[BezierPiece<f64>; 1]> = (0..4)
         .map(|i| {
             let s = i as f64;
@@ -466,8 +449,6 @@ fn clamped_fit_none_pins_matches_c1() {
 
 #[test]
 fn clamped_fit_2d_pins_both_axes() {
-    // 2D: x(t) = t², y(t) = 2t on [0, 2].
-    // x''(0) = 2, x''(2) = 2; y''(0) = 0, y''(2) = 0.
     let pieces: Vec<[BezierPiece<f64>; 2]> = vec![[
         BezierPiece {
             u_start: 0.0,
@@ -517,47 +498,23 @@ fn clamped_fit_2d_pins_both_axes() {
     );
 }
 
-/// Adversarial: non-polynomial input (sine approximation as degree-6 pieces)
-/// with ASYMMETRIC d2_start != d2_end.
-///
-/// Verifies:
-/// 1. The pinned 2nd derivatives are exact to 1e-6 (not approximate).
-/// 2. C0 and C1 are preserved at interior knots.
-/// 3. Position residual stays within tolerance everywhere.
-/// 4. The test does NOT use a polynomial input — the sine Taylor approximation
-///    has non-trivial residual, so the fitter has genuine work to do.
 #[test]
 fn adversarial_nonpolynomial_asymmetric_pins() {
-    // Use the degree-6 Taylor approximation of sin(t) on [0, 2*pi] split into
-    // 8 equal pieces. The approximation is NOT exact (truncation error grows
-    // near pi/2), so the fitter must actually subdivide and cannot trivially
-    // reproduce the source. The 2nd derivative pins are chosen to be the analytic
-    // sin''(t) = -sin(t) at the global endpoints but rounded to produce a
-    // genuinely asymmetric pair.
     let n = 8;
     let two_pi = std::f64::consts::TAU;
-    // sin Taylor at 0: [0, 1, 0, -1/6, 0, 1/120, 0, -1/5040]
-    // degree-6 Taylor (drop t^7 term):
-    let _sin_abs = [0.0_f64, 1.0, 0.0, -1.0 / 6.0, 0.0, 1.0 / 120.0, 0.0];
 
     let pieces: Vec<[BezierPiece<f64>; 1]> = (0..n)
         .map(|i| {
             let u0 = i as f64 * two_pi / n as f64;
             let u1 = (i + 1) as f64 * two_pi / n as f64;
-            // Re-expand sin Taylor around u0 using shift. For each piece we use
-            // a cubic Hermite interpolant matching sin/cos at both endpoints — this
-            // is C1-continuous across pieces and NOT a polynomial of sin, so the
-            // fitter has nontrivial residual to deal with.
             let h = u1 - u0;
             let f0 = u0.sin();
             let df0 = u0.cos();
             let f1 = u1.sin();
             let df1 = u1.cos();
-            // cubic Hermite: c0=f0, c1=df0, solve 2x2 for c2,c3
-            let det = h * h * h * h; // h^4
+            let det = h * h * h * h;
             let c2 = (3.0 * h * h * (f1 - f0 - df0 * h) - h * h * h * (df1 - df0)) / det;
             let c3 = (h * h * (df1 - df0) - 2.0 * h * (f1 - f0 - df0 * h)) / det;
-            // Pad to degree-6 with zeros so degree is uniform across pieces.
             [BezierPiece {
                 u_start: u0,
                 u_end: u1,
@@ -566,19 +523,14 @@ fn adversarial_nonpolynomial_asymmetric_pins() {
         })
         .collect();
 
-    // Analytic: sin''(0) = -sin(0) = 0; sin''(2*pi) = -sin(2*pi) ≈ 0.
-    // Use deliberately different-from-analytic values to make d2_start != d2_end.
-    // Pins are deliberately non-analytic but small enough that the resulting
-    // polynomial stays within position tolerance on short pieces.
-    let d2_start_pin = 0.5_f64; // not the analytic 0 at t=0
-    let d2_end_pin = -0.8_f64; // different sign and magnitude, also not analytic 0
+    let d2_start_pin = 0.5_f64;
+    let d2_end_pin = -0.8_f64;
 
-    let tol = 0.15; // generous: residual from non-polynomial input + pin deviation
+    let tol = 0.15;
     let result =
         fit_hermite_c1_clamped::<1>(&pieces, tol, 5, Some([d2_start_pin]), Some([d2_end_pin]))
             .expect("adversarial clamped fit must succeed");
 
-    // 1. Pins are exact at outer endpoints.
     let first = &result[0][0];
     let last = result[0].last().unwrap();
     let got_start = d2_at(first, first.u_start);
@@ -592,7 +544,6 @@ fn adversarial_nonpolynomial_asymmetric_pins() {
         "ADVERSARIAL: d2 at global end: expected {d2_end_pin}, got {got_end}"
     );
 
-    // 2. C0 and C1 at all interior knots.
     for window in result[0].windows(2) {
         let left = &window[0];
         let right = &window[1];
@@ -616,7 +567,6 @@ fn adversarial_nonpolynomial_asymmetric_pins() {
         );
     }
 
-    // 3. Position residual within tolerance at dense sample points.
     for fitted_piece in &result[0] {
         let n_samples = 40;
         let step = (fitted_piece.u_end - fitted_piece.u_start) / n_samples as f64;
@@ -638,7 +588,6 @@ fn adversarial_nonpolynomial_asymmetric_pins() {
         }
     }
 
-    // 4. Confirm that pins are genuinely asymmetric (not both zero or equal).
     assert!(
         d2_start_pin.abs() > 0.1 && d2_end_pin.abs() > 0.1,
         "pins are non-trivial by construction"
@@ -648,7 +597,6 @@ fn adversarial_nonpolynomial_asymmetric_pins() {
         "pins are asymmetric by construction"
     );
 
-    // 5. Degree check: first and last pieces must be degree-5 (the pinned boundary pieces).
     assert_eq!(
         first.coeffs.len(),
         6,
@@ -662,10 +610,7 @@ fn adversarial_nonpolynomial_asymmetric_pins() {
         last.coeffs.len()
     );
 
-    // Bonus: the start-pin check should NOT hold for the NON-pinned fit (proving we're testing something real).
     let unpinned = fit_hermite_c1_clamped::<1>(&pieces, tol, 4, None, None).unwrap();
     let unpinned_start_d2 = d2_at(&unpinned[0][0], unpinned[0][0].u_start);
-    // The unpinned fit is free to choose its own c2; it's unlikely to land at 3.0.
-    // We don't assert a strict divergence, but print it for visibility.
-    let _ = unpinned_start_d2; // used as proof-of-concept
+    let _ = unpinned_start_d2;
 }

--- a/rust/nurbs/tests/geomdl_oracle.rs
+++ b/rust/nurbs/tests/geomdl_oracle.rs
@@ -1,7 +1,3 @@
-//! Cross-check our eval against NURBS-Python (geomdl) on a fixed corpus.
-//! Corpus file: `tests/data/geomdl_corpus.json` (regenerated via the
-//! Python script in `tests/scripts/`).
-
 #![cfg(feature = "host")]
 
 use serde_json::Value;

--- a/rust/nurbs/tests/klipper_convolve_crosscheck.rs
+++ b/rust/nurbs/tests/klipper_convolve_crosscheck.rs
@@ -1,8 +1,3 @@
-//! Note on file location: the plan called for `rust/tests/`, but the workspace
-//! `Cargo.toml` is workspace-only (no `[lib]`/`[[bin]]`), so there is no
-//! workspace-level test crate. This integration test lives in `rust/nurbs/tests/`
-//! instead.
-
 #![cfg(feature = "host")]
 
 use serde_json::Value;

--- a/rust/temporal/src/deadline.rs
+++ b/rust/temporal/src/deadline.rs
@@ -6,10 +6,6 @@ thread_local! {
     static DEADLINE_TRUNCATED: Cell<bool> = const { Cell::new(false) };
 }
 
-/// RAII guard restoring the previous deadline on drop. The solve deadline is an
-/// absolute `Instant` so it survives the multi-stage temporal call chain without
-/// any layer re-subtracting elapsed time. `None` means unbounded — the default
-/// outside the live planner, so every existing test keeps today's behavior.
 #[must_use = "the deadline is cleared when this guard is dropped"]
 pub struct DeadlineGuard {
     previous: Option<Instant>,
@@ -21,44 +17,29 @@ impl Drop for DeadlineGuard {
     }
 }
 
-/// Installs an absolute solve deadline on the current thread for the lifetime of
-/// the returned guard. Fan-out workers in `parallel.rs` run on scoped threads
-/// that do not inherit this thread-local, so the planner sets the deadline on
-/// the worker entry as well via [`with_deadline`]; for the single-threaded path
-/// the guard alone suffices.
 pub fn scope(deadline: Option<Instant>) -> DeadlineGuard {
     let previous = SOLVE_DEADLINE.with(|d| d.replace(deadline));
     DeadlineGuard { previous }
 }
 
-/// The absolute deadline installed on this thread, if any.
 #[must_use]
 pub fn current() -> Option<Instant> {
     SOLVE_DEADLINE.with(Cell::get)
 }
 
-/// True when a deadline is installed and has already passed.
 #[must_use]
 pub fn expired() -> bool {
     matches!(current(), Some(d) if Instant::now() >= d)
 }
 
-/// Resets the per-thread truncation flag. Called at the start of every single
-/// segment solve so the flag reflects only that solve. A solve runs start-to-
-/// finish on one worker thread, so this thread-local is the correct scope —
-/// it never crosses threads or leaks between concurrently-running tests.
 pub fn clear_truncation() {
     DEADLINE_TRUNCATED.with(|t| t.set(false));
 }
 
-/// Records that the active solve stopped refining because the deadline expired,
-/// so the shipped profile may be more conservative than the time-unbounded
-/// optimum. Distinct from a slow-but-converged solve, which never marks.
 pub fn mark_truncated() {
     DEADLINE_TRUNCATED.with(|t| t.set(true));
 }
 
-/// Whether the current segment solve was cut short by the deadline.
 #[must_use]
 pub fn truncated() -> bool {
     DEADLINE_TRUNCATED.with(Cell::get)

--- a/rust/temporal/src/lib.rs
+++ b/rust/temporal/src/lib.rs
@@ -133,8 +133,5 @@ pub struct TopProfile {
     pub grid_scheme: GridScheme,
     pub total_time: f64,
     pub binding: BindingSummary,
-    /// True when this profile's solve stopped refining because the real-time
-    /// deadline expired, so it may sit further below the kinematic limit than
-    /// a time-unbounded solve would. A slow-but-converged solve is `false`.
     pub deadline_truncated: bool,
 }

--- a/rust/temporal/src/multi/chain/tests.rs
+++ b/rust/temporal/src/multi/chain/tests.rs
@@ -30,7 +30,6 @@ fn partition_single_segment_no_junctions() {
 
 #[test]
 fn slice_duplicates_junction_sample_and_splits_time() {
-    // 2-segment chain profile: ranges (0,2) and (2,4), 5 samples, uniform v=10.
     let ranges = vec![(0usize, 2usize), (2, 4)];
     let samples: Vec<GridSample> = (0..5)
         .map(|i| GridSample {

--- a/rust/temporal/src/multi/grid.rs
+++ b/rust/temporal/src/multi/grid.rs
@@ -22,31 +22,6 @@ pub(crate) fn compute_n(strategy: &GridStrategy, curve: &VectorNurbs<f64, 3>) ->
     }
 }
 
-/// Adjust per-segment node counts so that at every junction the boundary
-/// interval ratio stays within `MAX_JUNCTION_SPACING_RATIO`. Each entry in
-/// `ns` corresponds to the matching entry in `curves`; the two slices must be
-/// the same length and represent consecutive segments in one chain.
-///
-/// Strategy (single forward pass, then single backward pass):
-///
-/// For each junction (i, i+1) the boundary spacing is `h = L/(n-1)` where L
-/// is the control-polygon length.  When `h[i]/h[i+1] > MAX`:
-/// 1. Increase `n[i]` toward `max_n` to reduce `h[i]`.
-/// 2. If `max_n` is insufficient, reduce `n[i+1]` (floor toward 2) to raise
-///    `h[i+1]` until the ratio is within bound.
-///
-/// This never increases n beyond `max_n` and never decreases n below 2, so
-/// the resulting grids are always valid inputs to `sample_arclength_grid`.
-/// `Fixed` grids are left unchanged.
-///
-/// Returns a mask of segments to absorb — contributing no grid nodes to the
-/// chain — because their spacing deficit is length-determined: even with the
-/// segment at n=2 (one interval spanning its whole arclength) and its
-/// neighbor refined to `max_n`, the junction ratio exceeds
-/// `MAX_JUNCTION_SPACING_RATIO`. Runs on the natural (pre-reconcile) node
-/// counts; reconciliation afterwards must skip absorbed segments, otherwise
-/// it inflates a neighbor's n chasing a segment that will not exist in the
-/// grid. At least one segment always stays non-absorbed.
 pub(crate) fn classify_absorbed(
     ns: &[usize],
     curves: &[&VectorNurbs<f64, 3>],
@@ -164,11 +139,6 @@ pub(crate) fn reconcile_junction_n(
     }
 }
 
-/// Control-polygon length (sum of `‖cp[i+1] − cp[i]‖`).
-///
-/// For non-rational degree-1 NURBS this equals arclength exactly; for
-/// higher-degree or rational curves it is a strict upper bound — used only
-/// as a heuristic for grid-density.
 fn control_polygon_length_mm(curve: &VectorNurbs<f64, 3>) -> f64 {
     let cps = curve.control_points();
     cps.windows(2)

--- a/rust/temporal/src/multi/joining.rs
+++ b/rust/temporal/src/multi/joining.rs
@@ -127,10 +127,6 @@ fn max_kernel_half_support(chain: &ChainGrid) -> f64 {
         .fold(0.0, f64::max)
 }
 
-/// The shaper window spans chain junctions (full stops): the neighbor chain's
-/// ramp contributes to shaped speed near the boundary. After joining has
-/// converged, re-solve each windowed chain with its neighbors' boundary-window
-/// velocity samples as constants, iterated until total times settle.
 pub(crate) fn exchange_follower_tails(
     chain_grids: &mut [ChainGrid],
     states: &mut [ChainState],

--- a/rust/temporal/src/multi/junction.rs
+++ b/rust/temporal/src/multi/junction.rs
@@ -1,21 +1,8 @@
 use nurbs::VectorNurbs;
 use nurbs::eval::{vector_derivative, vector_eval};
 
-/// Two adjacent curves count as collinear when the forward unit tangent at the
-/// left curve's end and at the right curve's start disagree by at most this
-/// angle. Purely a numerical collinearity epsilon — anything sharper is a
-/// full-stop junction the blender did not round away.
 const THETA_COLLINEAR_RAD: f64 = 1e-3;
 
-/// `true` when the path is tangent-continuous (G1) across the junction between
-/// two adjacent curves, within `THETA_COLLINEAR_RAD`. A degenerate (zero)
-/// tangent on either side is never collinear — an undefined direction cannot be
-/// parallel to anything — which is also what isolates zero-displacement
-/// (virtual-path) segments into their own chains.
-///
-/// This is the sole junction predicate: a non-collinear junction is exactly a
-/// chain boundary / full stop. The batch solver partitions chains on it and the
-/// streaming planner snaps its re-solve window to it.
 #[must_use]
 pub fn are_collinear(left: &VectorNurbs<f64, 3>, right: &VectorNurbs<f64, 3>) -> bool {
     let t_left = forward_unit_tangent_at_end(left);

--- a/rust/temporal/src/multi/mod.rs
+++ b/rust/temporal/src/multi/mod.rs
@@ -18,23 +18,16 @@ pub struct SegmentInput<'a> {
     pub curve: &'a VectorNurbs<f64, 3>,
     pub limits: Limits,
     pub followers: &'a [crate::FollowerDemand],
-    /// `Some(length)` marks a follower-only move planned on a virtual path of
-    /// this arclength; `curve` has zero displacement and the follower rows do
-    /// all the limiting.
     pub virtual_path: Option<f64>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct BatchInput<'a> {
     pub segments: &'a [SegmentInput<'a>],
-    /// Input-shaper kernels + pre-batch follower history; `None` = no shaper
-    /// folding anywhere in the batch.
     pub shaping: Option<&'a BatchShaping>,
     pub grid_strategy: GridStrategy,
     pub worker_threads: usize,
     pub initial_velocity: f64,
-    /// Path accel at the batch start. Pinned in the SOCP only when `initial_velocity > 0`;
-    /// at a rest start it MUST be 0.0 (asserted) and the rest envelope governs.
     pub initial_accel: f64,
     pub terminal_velocity: f64,
 }
@@ -238,7 +231,6 @@ pub fn plan_batch(input: BatchInput<'_>) -> Result<BatchOutput, BatchError> {
 
     joining::exchange_follower_tails(&mut chain_grids, &mut states, input.worker_threads)?;
 
-    // Slice each chain profile into per-segment profiles and flatten.
     let profiles: Vec<TopProfile> = states
         .into_iter()
         .zip(chain_grids.iter())

--- a/rust/temporal/src/multi/parallel/tests.rs
+++ b/rust/temporal/src/multi/parallel/tests.rs
@@ -23,14 +23,12 @@ fn straight_chain() -> ChainGrid {
     ChainGrid::from_segment_grids(vec![grid], vec![limits()])
 }
 
-/// 1 mm straight segment — far too short to decelerate from 500 mm/s to rest
-/// under a_max = 5 000 mm/s² (stopping distance ≈ 25 mm), so every SOCP call
-/// is infeasible and the solver returns a garbage-primal profile.
 fn short_straight_chain() -> ChainGrid {
+    const TOO_SHORT_FOR_500MMS_DECEL_MM: f64 = 1.0;
     let curve = VectorNurbs::<f64, 3>::try_new(
         1,
         vec![0.0, 0.0, 1.0, 1.0],
-        vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        vec![[0.0, 0.0, 0.0], [TOO_SHORT_FOR_500MMS_DECEL_MM, 0.0, 0.0]],
     )
     .unwrap();
     let grid = sample_arclength_grid(&curve, 20).unwrap();
@@ -85,16 +83,6 @@ fn pinned_both_endpoints_returns_failed_status_unmodified() {
     );
 }
 
-/// Regression test for the boundary-clobber bug: when chain 0's SOCP is
-/// infeasible (segment too short to carry the pinned v_start), the solver
-/// returns a garbage-primal profile whose first sample has v ≈ 0.  The old
-/// code unconditionally synced states[0].v_start to that garbage value.  On
-/// the immediately-following re-solve (dirty stays true after infeasible),
-/// schedule_chain_with_tolerance rejected v_start ≈ 0 + a_start = Some(...)
-/// with InvalidEndpointAccel, crashing the planner.
-///
-/// The fix guards the sync: chain 0's v_start is a pinned batch boundary and
-/// must never be overwritten regardless of the solve outcome.
 #[test]
 fn pinned_v_start_not_overwritten_by_infeasible_chain0_solve() {
     const PINNED_V_START: f64 = 500.0;
@@ -109,8 +97,6 @@ fn pinned_v_start_not_overwritten_by_infeasible_chain0_solve() {
         dirty: true,
     }];
 
-    // First solve: infeasible because 1 mm cannot carry 500 mm/s.  The old
-    // code would overwrite v_start with the garbage primal's first sample.
     fan_out_solves(&[chain.clone()], &mut states, 1)
         .expect("fan_out_solves must not return BatchError on infeasible profile");
 
@@ -121,10 +107,6 @@ fn pinned_v_start_not_overwritten_by_infeasible_chain0_solve() {
         states[0].v_start, PINNED_V_START,
     );
 
-    // After an infeasible solve dirty stays true, so a second call re-solves.
-    // With the bug, v_start was now ≈ 0 while a_start = Some(...), which
-    // triggers InvalidEndpointAccel("a_start requires v_start > 0 ...") and
-    // propagates as BatchError::Segment.
     fan_out_solves(&[chain], &mut states, 1)
         .expect("second fan_out_solves must not return InvalidEndpointAccel after the first");
 }

--- a/rust/temporal/src/multi/tests.rs
+++ b/rust/temporal/src/multi/tests.rs
@@ -99,20 +99,12 @@ fn smooth_junction_has_no_accel_impulse() {
     let a_end_left = out.profiles[0].samples.last().unwrap().a;
     let a_start_right = out.profiles[1].samples[0].a;
 
-    // Pre-fix: independent FD endpoints, V-profile makes them differ by
-    // O(a_max) — expect this assert to fail with step ≈ 1e3..1e4.
-    // Post-fix: structural check only — slicing duplicates the single shared
-    // junction variable into both profiles, so step == 0 by construction.
-    // The PHYSICAL test is the contract-(b) jerk assertion below.
     let step = (a_end_left - a_start_right).abs();
     assert!(
         step < 1.0,
         "junction accel step {step:.1} mm/s² — boundary accels are decoupled"
     );
 
-    // Contract (b): the junction-spanning discrete jerk obeys j_max. Build
-    // the spanning second difference from the two slices (junction sample
-    // duplicated, so left[n-2], junction, right[1]).
     let left = &out.profiles[0].samples;
     let right = &out.profiles[1].samples;
     let (bl, bj, br) = (left[left.len() - 2].b, left[left.len() - 1].b, right[1].b);

--- a/rust/temporal/src/topp/chain.rs
+++ b/rust/temporal/src/topp/chain.rs
@@ -34,8 +34,6 @@ pub struct PointGeom {
     pub c_triple_prime: [f64; 3],
 }
 
-/// Right-side geometry/limits of a shared junction point. The primary
-/// per-point arrays carry the left side.
 #[derive(Debug, Clone, Copy)]
 pub struct JunctionDual {
     pub idx: usize,
@@ -45,31 +43,17 @@ pub struct JunctionDual {
 
 #[derive(Debug, Clone)]
 pub struct ChainGrid {
-    /// Cumulative arclength along the chain, len M.
     pub s: Vec<f64>,
     pub geom: Vec<PointGeom>,
-    /// Per-interval spacing, len M−1. Uniform within a segment, changes at
-    /// junction indices.
     pub h_intervals: Vec<f64>,
-    /// Index into `limits` per point (junction points → left segment).
     pub limits_idx: Vec<usize>,
     pub limits: Vec<Limits>,
     pub junctions: Vec<JunctionDual>,
-    /// Inclusive (start, end) point-index range per segment; consecutive
-    /// ranges share their boundary index.
     pub segment_ranges: Vec<(usize, usize)>,
-    /// Interior geometry samples for each chain interval `[i, i+1]`, len M−1.
-    /// Each sample's θ ∈ (0,1).
     pub inter_geom: Vec<Vec<InterSample>>,
-    /// Follower demands per segment, indexed like `limits`.
     pub followers: Vec<Vec<FollowerDemand>>,
-    /// Input-shaper kernels per spatial axis; `None` = passthrough.
     pub axis_kernels: [Option<PiecewisePolynomialKernel<f64>>; 3],
-    /// Realized per-axis velocity immediately before this chain, for the
-    /// shaper window's left edge.
     pub follower_history: Option<FollowerHistory>,
-    /// Per-axis velocity immediately after this chain (the right neighbor's
-    /// ramp), for the shaper window's right edge.
     pub follower_terminal: Option<FollowerHistory>,
 }
 
@@ -126,12 +110,6 @@ impl ChainGrid {
         Ok(())
     }
 
-    /// Concatenate per-segment grids into one chain. Adjacent grids must be
-    /// geometrically continuous (the caller guarantees tangent continuity —
-    /// that's what made them one chain). Segments marked in `absorbed` have
-    /// their arclength folded into a single degenerate interval shared with
-    /// the preceding segment; they contribute no interior grid nodes. Panics
-    /// on empty input: an empty chain is a caller bug.
     pub fn from_segment_grids_with_absorbed(
         grids: Vec<ArclengthGrid>,
         limits: Vec<Limits>,
@@ -221,9 +199,6 @@ impl ChainGrid {
         }
     }
 
-    /// Chain for a follower-only move: zero spatial geometry, arclength =
-    /// the largest follower displacement, follower rows + feedrate cap do
-    /// all the limiting (spec §2's fallback line).
     pub fn virtual_path(
         length: f64,
         n: usize,

--- a/rust/temporal/src/topp/chain/tests_support.rs
+++ b/rust/temporal/src/topp/chain/tests_support.rs
@@ -11,9 +11,6 @@ pub(crate) fn line_50mm() -> VectorNurbs<f64, 3> {
     line([0.0; 3], [50.0, 0.0, 0.0])
 }
 
-/// 40 mm + 60 mm collinear lines with different v_max per side
-/// (300 / 150 mm/s); 11 + 13 grid points → junction at index 10,
-/// h = 4 mm left, 5 mm right.
 pub(crate) fn two_segment_chain_with_junction() -> ChainGrid {
     let ga =
         crate::topp::path::sample_arclength_grid(&line([0.0; 3], [40.0, 0.0, 0.0]), 11).unwrap();

--- a/rust/temporal/src/topp/constraints.rs
+++ b/rust/temporal/src/topp/constraints.rs
@@ -24,12 +24,8 @@ pub struct ConstraintBundle {
     pub h_intervals: Vec<f64>,
     pub j_path_at: Vec<f64>,
 
-    /// Precomputed column-sparse form of the base constraint matrix.
-    /// Sign convention: `A_clarabel = -A_k`, so `base_csc_nzval[col][k] = -a_rows[row][col]`.
-    /// Length of both outer vecs equals `n_vars`.
     pub base_csc_rowval: Vec<Vec<usize>>,
     pub base_csc_nzval: Vec<Vec<f64>>,
-    /// Number of base (non-cut, non-TR) constraint rows; equals `a_rows.len()`.
     pub base_n_rows: usize,
 }
 
@@ -60,14 +56,6 @@ pub const KAPPA_FLOOR: f64 = 1e-12;
 
 pub const B_MAX_CENT_CAP: f64 = 1e8;
 
-/// Ceiling on the *scaled* `b = v²` cap (`b_cap`) used to bound the centripetal
-/// and velocity constraint rows. `B_MAX_CENT_CAP` is a fixed mm-unit stand-in
-/// for the unbounded centripetal cap on straight segments; dividing it by σ²
-/// inflates it to 1e10+ scaled units on slow machines (tiny σ), and that huge
-/// constraint RHS wrecks Clarabel's equilibration into false infeasibility. The
-/// solver scale normalizes the peak reachable b to ≈`V_TARGET_UNITS_PER_S`², so
-/// clamping `b_cap` here bounds the cap-row dynamic range to a constant
-/// independent of machine speed. A no-op at identity and normal-machine scales.
 pub(crate) const B_CAP_SCALED_CEILING: f64 = 1e8;
 
 pub(crate) const COMP_FLOOR: f64 = 1e-12;

--- a/rust/temporal/src/topp/constraints/tests.rs
+++ b/rust/temporal/src/topp/constraints/tests.rs
@@ -95,10 +95,6 @@ fn boundary_above_mvc_returns_boundary_outcome() {
 
 #[test]
 fn start_above_per_axis_velocity_cap_is_boundary_infeasible() {
-    // Straight line (kappa = 0): centripetal MVC is effectively unbounded, so
-    // only the per-axis velocity cap binds. A v_start a hair above v_max (the
-    // streaming-replan ripple that crashed the bridge) must be caught here, not
-    // handed to the SOCP to emit a frozen garbage profile.
     let grid = dummy_straight_grid(10, 100.0);
     let limits = Limits::axis_boxes(
         [200.0, 300.0, 15.0],
@@ -236,10 +232,6 @@ fn n_eq_2_minimum_grid_no_interior_points() {
     assert!(bundle.objective.iter().all(|c| c.abs() < 1e-12));
 }
 
-// -------------------------------------------------------------------------
-// Test 5: rest_boundary_b_cap — formula continuity and scaling
-// -------------------------------------------------------------------------
-
 #[test]
 fn env_b_continuity_at_s1_and_scaling() {
     use super::rest_boundary_b_cap;
@@ -249,7 +241,6 @@ fn env_b_continuity_at_s1_and_scaling() {
     let s1 = a * a * a / (6.0 * j * j);
     let v1_sq = (a * a / (2.0 * j)).powi(2);
 
-    // Continuity: both branches return the same value at d = s1.
     let left = rest_boundary_b_cap(s1 * (1.0 - 1e-9), a, j);
     let right = rest_boundary_b_cap(s1 * (1.0 + 1e-9), a, j);
     assert!(
@@ -257,7 +248,6 @@ fn env_b_continuity_at_s1_and_scaling() {
         "discontinuity at s1: left={left}, right={right}"
     );
 
-    // v² ∝ d^(4/3) in the jerk phase: env_b(4d)/env_b(d) = 4^(4/3).
     let d_small = s1 * 0.1;
     let ratio = rest_boundary_b_cap(4.0 * d_small, a, j) / rest_boundary_b_cap(d_small, a, j);
     let expected_ratio = 4.0_f64.powf(4.0 / 3.0);
@@ -266,7 +256,6 @@ fn env_b_continuity_at_s1_and_scaling() {
         "jerk-phase scaling: ratio={ratio}, expected {expected_ratio}"
     );
 
-    // Accel-phase value at d = s1 + Δ matches closed-form v1² + 2AΔ.
     let delta = 10.0_f64;
     let cap = rest_boundary_b_cap(s1 + delta, a, j);
     let expected = v1_sq + 2.0 * a * delta;
@@ -275,10 +264,6 @@ fn env_b_continuity_at_s1_and_scaling() {
         "accel-phase value: cap={cap}, expected={expected}"
     );
 }
-
-// -------------------------------------------------------------------------
-// Test 6: straight-line grid, zero endpoints → envelope rows emitted
-// -------------------------------------------------------------------------
 
 #[test]
 fn zero_endpoints_emit_envelope_rows() {
@@ -298,8 +283,6 @@ fn zero_endpoints_emit_envelope_rows() {
         BuildOutcome::Boundary(_) => panic!("zero endpoints should be feasible"),
     };
 
-    // Block (e2) must contribute at least one nonneg row (envelope rows exist
-    // for d values below b_cap).
     let nonneg_rows: usize = bundle
         .cones
         .iter()
@@ -307,23 +290,16 @@ fn zero_endpoints_emit_envelope_rows() {
         .map(|(_, n)| *n)
         .sum();
 
-    // Old nonneg count for zero-endpoint N=10 X-line without (e2):
-    //   (c) 10, (d) 20, (e) 10, (f) 16, (g) 16 = 72.
-    // Block (e2) adds > 0 rows (both endpoints at rest).
+    let nonneg_rows_without_envelope = 72;
     assert!(
-        nonneg_rows > 72,
+        nonneg_rows > nonneg_rows_without_envelope,
         "expected envelope rows to be added, nonneg={nonneg_rows}"
     );
 
-    // Dimension consistency holds.
     let total_cone_dim: usize = bundle.cones.iter().map(|(_, d)| d).sum();
     assert_eq!(bundle.a_rows.len(), total_cone_dim);
     assert_eq!(bundle.b_rhs.len(), total_cone_dim);
 }
-
-// -------------------------------------------------------------------------
-// Test 7: junction velocities (v > 0) → zero envelope rows
-// -------------------------------------------------------------------------
 
 #[test]
 fn nonzero_endpoints_emit_no_envelope_rows() {
@@ -343,24 +319,18 @@ fn nonzero_endpoints_emit_no_envelope_rows() {
         BuildOutcome::Boundary(_) => panic!("should be feasible for v=100 on straight X-line"),
     };
 
-    // No (e2) rows: neither endpoint is at rest.
-    // Old nonneg count for this config (no e2): 10+20+10+16+16 = 72.
     let nonneg_rows: usize = bundle
         .cones
         .iter()
         .filter(|(c, _)| matches!(c, Cone::Nonneg))
         .map(|(_, n)| *n)
         .sum();
-    assert_eq!(nonneg_rows, 72, "no envelope rows for nonzero endpoints");
+    let nonneg_rows_without_envelope = 72;
+    assert_eq!(
+        nonneg_rows, nonneg_rows_without_envelope,
+        "no envelope rows for nonzero endpoints"
+    );
 }
-
-// -------------------------------------------------------------------------
-// Test 8: diagonal X=Y line yields A_env ≈ √2 · a_max (projected cap)
-// -------------------------------------------------------------------------
-
-// -------------------------------------------------------------------------
-// Task 5 tests: junction dual rows
-// -------------------------------------------------------------------------
 
 #[test]
 fn junction_point_gets_dual_velocity_rows() {
@@ -377,9 +347,6 @@ fn junction_point_gets_dual_velocity_rows() {
         BuildOutcome::Ok(b) => b,
         other => panic!("{other:?}"),
     };
-    // Count rows whose ONLY nonzero is −1 at the junction b-column (off_b+10)
-    // with rhs in {300², 150²}: the left-side (block c) and right-side (dual)
-    // velocity caps must both be present.
     let jidx = chain.junctions[0].idx;
     let mut rhs_seen = vec![];
     for (row, rhs) in bundle.a_rows.iter().zip(&bundle.b_rhs) {
@@ -424,9 +391,6 @@ fn a_start_pin_at_rest_panics() {
 
 #[test]
 fn a_start_tube_replaces_hard_pin() {
-    // With a_start=Some and v_start>0, block (a) emits only the 2 boundary
-    // equalities (no third pin row), and the tube rows appear as Nonneg rows
-    // that bound b_1 from above and below.
     let chain = two_segment_chain_with_junction();
     let v_start = 50.0_f64;
     let a0 = -2_000.0_f64;
@@ -443,11 +407,8 @@ fn a_start_tube_replaces_hard_pin() {
         other => panic!("{other:?}"),
     };
 
-    // Zero cone must be exactly 2 rows (no hard pin).
     assert_eq!(bundle.cones[0], (Cone::Zero, 2));
 
-    // The tube emits at least one Nonneg row touching b_1 (off_b+1 = 1).
-    // Upper rows have coefficient -1 on b_1; lower rows have +1.
     let has_upper_at_b1 = bundle
         .a_rows
         .iter()
@@ -464,7 +425,6 @@ fn diagonal_line_a_env_is_projected() {
     let length = 100.0_f64;
     let sqrt2 = std::f64::consts::SQRT_2;
 
-    // Diagonal X=Y: tangent = [1/√2, 1/√2, 0].
     let s: Vec<f64> = (0..n).map(|i| length * i as f64 / (n - 1) as f64).collect();
     let c_prime = vec![[1.0 / sqrt2, 1.0 / sqrt2, 0.0]; n];
     let grid = ArclengthGrid {
@@ -499,36 +459,22 @@ fn diagonal_line_a_env_is_projected() {
         BuildOutcome::Boundary(_) => panic!("should be feasible"),
     };
 
-    // a_env from build is internal; verify via envelope cap magnitudes.
-    // For the diagonal, projected a_tan = min(a_max[0]/(1/√2), a_max[1]/(1/√2))
-    //                                   = a_max · √2.
-    // The first envelope row (i=1, d = s[1]-s[0]) should correspond to a_env ≈ √2·a_max.
     let a_env_expected = 5_000.0 * sqrt2;
     let j_env_expected = 100_000.0 * sqrt2;
-    let d1 = grid.total_length / (n - 1) as f64; // = 25.0
+    let d1 = grid.total_length / (n - 1) as f64;
     let cap_expected = super::rest_boundary_b_cap(d1, a_env_expected, j_env_expected);
 
-    // Find the first (e2) row in the bundle: it is the row immediately after
-    // block (e)'s N rows, with coefficient -1.0 on b_1 (off_b+1 = 1).
-    // A_env = √2·5000 ≈ 7071, J_env = √2·100000 ≈ 141421.
-    // s1 = A³/(6J²) ≈ 7071³/(6·141421²) ≈ 2.08 mm, d1=25mm >> s1.
-    // cap_expected = v1² + 2·A_env·(d1 - s1).
-    let _ = bundle; // bundle used only to verify Ok; formula verified analytically
+    let _ = bundle;
     assert!(
         (cap_expected - (500.0_f64 * sqrt2).powi(2)).abs() / (500.0_f64 * sqrt2).powi(2) < 1.0,
         "projected cap for diagonal should be in v_max range: cap={cap_expected}"
     );
-    // More precisely: cap must be strictly larger than the axis-min cap.
     let cap_axis_min = super::rest_boundary_b_cap(d1, 5_000.0, 100_000.0);
     assert!(
         cap_expected > cap_axis_min,
         "diagonal projected cap {cap_expected} must exceed axis-min cap {cap_axis_min}"
     );
 }
-
-// -------------------------------------------------------------------------
-// Task 5 accel-dual coverage: curved junction with distinct a_max per side
-// -------------------------------------------------------------------------
 
 fn two_segment_chain_curved_junction() -> crate::topp::chain::ChainGrid {
     use crate::topp::chain::ChainGrid;
@@ -594,13 +540,6 @@ fn junction_dual_accel_rows_use_right_limits() {
     );
 }
 
-// -------------------------------------------------------------------------
-// Jerk-reachability tube: forward-simulation oracle + closed-form tests
-// -------------------------------------------------------------------------
-
-/// Ground-truth reachability by small-step forward integration. sign=+1 →
-/// accelerate hardest (upper), sign=-1 → decelerate hardest (lower). Returns
-/// v² at the first time s(t) ≥ s_target. Floors v at 0 for the decel branch.
 fn simulate_reachable_b(s_target: f64, v0: f64, a0: f64, a_max: f64, j_max: f64, sign: f64) -> f64 {
     let dt = 1e-6;
     let (mut s, mut v, mut a) = (0.0_f64, v0, a0);

--- a/rust/temporal/src/topp/follower.rs
+++ b/rust/temporal/src/topp/follower.rs
@@ -390,9 +390,6 @@ pub(crate) fn build_follower_windows(chain: &ChainGrid, b_bar: &[f64]) -> Follow
     }
 }
 
-/// Window weights depend only on pairwise time differences within one kernel
-/// support, so drift is measured on those differences, not on accumulated
-/// absolute time.
 pub(crate) fn refreeze_drift(windows: &FollowerWindows, b_new: &[f64], chain: &ChainGrid) -> f64 {
     let t_new = frozen_time_map(b_new, &chain.h_intervals);
     let t_old = &windows.t_map;

--- a/rust/temporal/src/topp/follower/tests.rs
+++ b/rust/temporal/src/topp/follower/tests.rs
@@ -595,12 +595,6 @@ fn binding_summary_reports_velocity_pin() {
         }],
     );
 
-    // The reported worst binding spans all families (velocity/accel/jerk/PA):
-    // it answers "which limit is this move riding, and how close." A velocity-
-    // capped cruise rides its cap, so the worst sits at ratio ~1.0 — it may be
-    // tagged jerk rather than velocity, because jerk floats up into its accepted
-    // slack (EPS_FEAS_JERK) at the accel ramps, marginally above velocity's 1.0.
-    // Either way the move is at its limit (gap ~0); that is the contract.
     let worst = profile
         .binding
         .worst
@@ -619,9 +613,6 @@ fn binding_summary_reports_velocity_pin() {
         worst.ratio
     );
 
-    // The velocity pin itself must still be detected in the per-grid tally — the
-    // cruise plateau binds on velocity even if a ramp jerk edges out the single
-    // worst sample.
     let velocity_count: u32 = profile
         .binding
         .histogram

--- a/rust/temporal/src/topp/path.rs
+++ b/rust/temporal/src/topp/path.rs
@@ -26,23 +26,13 @@ impl InterSample {
 
 #[derive(Debug, Clone)]
 pub struct ArclengthGrid {
-    /// `s_i ∈ [0, L]`, length N.
     pub s: Vec<f64>,
-    /// `u_i = u(s_i)`, length N.
     pub u: Vec<f64>,
-    /// `C(u_i)`, length N.
     pub c: Vec<[f64; 3]>,
-    /// `dC/ds` at `s_i`, length N. Unit-magnitude up to numerical floor.
     pub c_prime: Vec<[f64; 3]>,
-    /// `d²C/ds²` at `s_i`, length N.
     pub c_double_prime: Vec<[f64; 3]>,
-    /// `d³C/ds³` at `s_i`, length N.
     pub c_triple_prime: Vec<[f64; 3]>,
-    /// Total arclength, mm.
     pub total_length: f64,
-    /// Interior geometry samples for each interval `[i, i+1]`, length N−1.
-    /// Each sample's θ ∈ (0,1) is the fractional position within the
-    /// interval (`s = s_i + θ·h`).
     pub inter_geom: Vec<Vec<InterSample>>,
 }
 

--- a/rust/temporal/src/topp/scaling.rs
+++ b/rust/temporal/src/topp/scaling.rs
@@ -2,10 +2,6 @@ use crate::Limits;
 use crate::topp::path::ArclengthGrid;
 use crate::topp::solver::SolverResult;
 
-/// Clarabel's QDLDL factorization loses enough precision to stall
-/// (InsufficientProgress, false certificates) when b = v² reaches ~1e6 in raw
-/// mm units; mapping the dominant v_max to ~10 units/s puts every machine
-/// config in the empirically best-conditioned regime (b ≈ 1e2).
 const V_TARGET_UNITS_PER_S: f64 = 10.0;
 
 pub struct SolverScale {
@@ -109,14 +105,6 @@ impl SolverScale {
             return Self::identity();
         }
 
-        // Scale to the path velocity the trajectory can actually *reach*, not the
-        // raw velocity ceiling. The reachable peak is the high point of the MVC
-        // envelope (velocity ∧ centripetal caps) capped by acceleration-from-rest
-        // reachability over the path length. Scaling by v_ceiling alone over-scales
-        // accel/jerk/centripetal-bound moves by many orders of magnitude — a 1e9
-        // velocity cap with 1e-2 accel collapses b = v² to ~1e-17 scaled units,
-        // far below Clarabel's precision, surfacing as garbage residuals or false
-        // infeasibility.
         let mut peak_mvc_b = 0.0_f64;
         let mut a_tan_max = 0.0_f64;
         for (i, g) in chain.geom.iter().enumerate() {
@@ -207,9 +195,6 @@ impl SolverScale {
     }
 }
 
-/// Accumulate the reachable-velocity envelope at one path point into the
-/// running peak `b = v²` (velocity ∧ centripetal caps) and the running max
-/// tangential-acceleration cap used for accel-from-rest reachability.
 fn scan_reachable_b(
     limits: &Limits,
     geom: &crate::topp::chain::PointGeom,

--- a/rust/temporal/src/topp/scaling/tests.rs
+++ b/rust/temporal/src/topp/scaling/tests.rs
@@ -55,7 +55,6 @@ fn grid_scaling_fields_have_correct_power_of_sigma() {
     let grid = tiny_grid(raw_s, raw_kappa);
     let scaled = scale.scale_grid(&grid);
 
-    // s ÷ σ
     for (raw, sc) in grid.s.iter().zip(scaled.s.iter()) {
         assert!(
             (sc - raw / sigma).abs() < 1e-12,
@@ -65,12 +64,10 @@ fn grid_scaling_fields_have_correct_power_of_sigma() {
         );
     }
 
-    // u unchanged
     for (raw, sc) in grid.u.iter().zip(scaled.u.iter()) {
         assert!((sc - raw).abs() < 1e-12, "u field should be unchanged");
     }
 
-    // c ÷ σ
     for (raw, sc) in grid.c.iter().zip(scaled.c.iter()) {
         for ax in 0..3 {
             assert!(
@@ -82,7 +79,6 @@ fn grid_scaling_fields_have_correct_power_of_sigma() {
         }
     }
 
-    // c_prime unchanged (dimensionless dC/ds)
     for (raw, sc) in grid.c_prime.iter().zip(scaled.c_prime.iter()) {
         for ax in 0..3 {
             assert!(
@@ -92,7 +88,6 @@ fn grid_scaling_fields_have_correct_power_of_sigma() {
         }
     }
 
-    // c_double_prime ×σ
     for (raw, sc) in grid.c_double_prime.iter().zip(scaled.c_double_prime.iter()) {
         for ax in 0..3 {
             let expected = raw[ax] * sigma;
@@ -105,7 +100,6 @@ fn grid_scaling_fields_have_correct_power_of_sigma() {
         }
     }
 
-    // c_triple_prime ×σ²
     for (raw, sc) in grid.c_triple_prime.iter().zip(scaled.c_triple_prime.iter()) {
         for ax in 0..3 {
             let expected = raw[ax] * sigma * sigma;
@@ -118,7 +112,6 @@ fn grid_scaling_fields_have_correct_power_of_sigma() {
         }
     }
 
-    // total_length ÷ σ
     assert!(
         (scaled.total_length - raw_s / sigma).abs() < 1e-12,
         "total_length: expected {}, got {}",

--- a/rust/temporal/src/topp/solver.rs
+++ b/rust/temporal/src/topp/solver.rs
@@ -1,46 +1,3 @@
-//! Clarabel SOCP construction + solve. INTERNAL — Clarabel types do not
-//! escape this module.
-//!
-//! Clarabel solves: `Ax + s = b`, `s ∈ K`
-//!
-//! The kalico `ConstraintBundle` uses: `A_k * x + b_rhs ∈ K`.
-//! These are equal when `A_clarabel = -A_k` and `b_clarabel = b_rhs`:
-//!   `s = b_rhs - (-A_k)*x = A_k*x + b_rhs` ∈ K  ✓
-//!
-//! This negation is applied uniformly to every row of A regardless of cone type.
-//!
-//! # Cone mapping (kalico → Clarabel 0.11)
-//!
-//! | kalico `Cone`            | Clarabel `SupportedConeT`  |
-//! |--------------------------|---------------------------|
-//! | `Zero`                   | `ZeroConeT(dim)`           |
-//! | `Nonneg`                 | `NonnegativeConeT(dim)`    |
-//! | `SecondOrder`            | `SecondOrderConeT(dim)`    |
-//! | `RotatedSecondOrder`     | (not emitted by `build()`) |
-//!
-//! `RotatedSecondOrderConeT` does not exist in Clarabel 0.11. `constraints::build_chain()`
-//! never emits `Cone::RotatedSecondOrder`; jerk constraints use the norm-form
-//! identity `z² ≤ u·v ↔ ||(2z, u-v)|| ≤ u+v` (standard SOC). The variant exists
-//! for exhaustiveness but `solve()` returns `SolverSetupError` if a bundle contains it.
-//!
-//! # Clarabel `SolverStatus` → kalico `SolverStatus`
-//!
-//! | Clarabel                         | kalico                             |
-//! |----------------------------------|------------------------------------|
-//! | `Solved`                         | `SolverStatus::Solved`             |
-//! | `AlmostSolved`                   | `SolverStatus::SolvedInexact{..}`  |
-//! | `PrimalInfeasible`               | `SolverStatus::Infeasible`         |
-//! | `DualInfeasible`                 | `SolverStatus::Infeasible`         |
-//! | `AlmostPrimalInfeasible`         | `SolverStatus::Infeasible`         |
-//! | `AlmostDualInfeasible`           | `SolverStatus::Infeasible`         |
-//! | `MaxIterations`                  | `SolverStatus::MaxIter{..}`        |
-//! | `MaxTime`                        | `SolverStatus::MaxIter{..}`        |
-//! | `NumericalError`                 | `SolverStatus::Infeasible`         |
-//! | `InsufficientProgress`           | `SolverStatus::MaxIter{..}`        |
-//! | `CallbackTerminated`             | `SolverStatus::Infeasible`         |
-//! | `Unsolved`                       | `SolverStatus::Infeasible`         |
-
-// clippy::doc_markdown fires on unicode-math and CamelCase names in docs here.
 #![allow(clippy::doc_markdown)]
 
 use clarabel::algebra::CscMatrix;
@@ -52,37 +9,18 @@ use clarabel::solver::{
 use crate::topp::constraints::{Cone, ConstraintBundle};
 use crate::topp::scaling::SolverScale;
 
-// ---------------------------------------------------------------------------
-// Per-thread Clarabel call counters — always compiled, near-zero overhead.
-// One Cell<u32> increment per Clarabel call (~1 ns); negligible versus the
-// SOCP solve time (~1-50 ms).  Integration tests read these via the public
-// `counters` module; production code ignores the counts.
-// ---------------------------------------------------------------------------
 use std::cell::Cell;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-/// Snapshot of Clarabel invocation counts for one top-level schedule call.
-/// Reset with `counters::reset()` before a solve; read with
-/// `counters::snapshot()` after.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SolveCounters {
-    /// Total `DefaultSolver::new` + `.solve()` invocations.
     pub clarabel_calls_total: u32,
-    /// Calls with no trust region: base SOCP solve + path-jerk SLP outer iters.
     pub clarabel_calls_path_jerk: u32,
-    /// SLP9 calls with a trust region box (inner backtrack probes).
     pub clarabel_calls_slp9_tr: u32,
-    /// SLP9 calls without a trust region (no-TR fallback after failed backtrack).
     pub clarabel_calls_slp9_no_tr: u32,
-    /// 1 when `run_slp9_loop` triggers the uniform-damp restoration path.
     pub slp9_restoration_fired: u32,
-    /// 1 when `ToleranceMode::Auto` fires the tight (1e-8) second pass.
     pub auto_second_pass_fired: u32,
-    /// Number of `schedule_chain_*` invocations (one per chain solve, including
-    /// the velocity-clamp re-solves inside the parallel joining loop).
     pub chains_scheduled: u32,
-    /// Sum of `ChainGrid::n_points()` over every `schedule_chain_*` invocation.
-    /// This is the total number of discretization nodes the solver touched.
     pub grid_points_scheduled: u64,
 }
 
@@ -99,8 +37,6 @@ thread_local! {
     })};
 }
 
-/// Public counter accessors.  Integration tests and benchmarks call
-/// `counters::reset()` before a solve and `counters::snapshot()` after.
 pub mod counters {
     use super::{
         COUNTERS, Cell, G_CHAINS_SCHEDULED, G_CLARABEL_PATH_JERK, G_CLARABEL_SLP9_NO_TR,
@@ -121,9 +57,6 @@ pub mod counters {
         COUNTERS.with(Cell::get)
     }
 
-    /// Process-global aggregate across every worker thread that ran a chain
-    /// since the last [`reset`]. Use this — not [`snapshot`] — when the solve
-    /// fans out across threads (it always does via `multi::parallel`).
     pub fn snapshot_global() -> SolveCounters {
         let thread_local = COUNTERS.with(Cell::get);
         SolveCounters {
@@ -188,13 +121,6 @@ pub mod counters {
     }
 }
 
-// Sentinel: true while execution is inside an SLP9 outer loop.
-// Process-global mirror of the per-call counters. The schedule fans out across
-// worker threads (`thread::scope` in `multi::parallel`), so the thread-local
-// `COUNTERS` only ever see the work done on the thread that happened to run a
-// given chain. The globals aggregate across all worker threads so a caller on
-// the orchestrating thread can read total per-append solver WORK. Reset before
-// a top-level solve, snapshot after; cross-thread visibility is the point.
 static G_CLARABEL_TOTAL: AtomicU32 = AtomicU32::new(0);
 static G_CLARABEL_PATH_JERK: AtomicU32 = AtomicU32::new(0);
 static G_CLARABEL_SLP9_TR: AtomicU32 = AtomicU32::new(0);
@@ -206,8 +132,6 @@ thread_local! {
     static IN_SLP9_PHASE: Cell<bool> = const { Cell::new(false) };
 }
 
-// RAII guard that sets `IN_SLP9_PHASE = true` on construction and restores
-// the previous value on drop — safe even if `run_slp9_loop` nests.
 struct Slp9PhaseGuard {
     prev: bool,
 }
@@ -228,7 +152,6 @@ impl Drop for Slp9PhaseGuard {
 
 #[derive(Debug, Clone)]
 pub(crate) enum SlpCut {
-    /// Weight-based path-jerk cut. Rows scaled by `h̄²` to stay O(1).
     PathJerkWeights {
         i: usize,
         b_bar: f64,
@@ -244,15 +167,11 @@ pub(crate) enum SlpCut {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AxisJerkCut {
-    /// Grid index this cut is anchored at. The anchor is `idx[anchor_pos]`.
     pub i: usize,
     #[allow(dead_code)]
     pub axis: usize,
-    /// Column indices for the three stencil b-variables (from `stencil::stencil_at`).
     pub idx: [usize; 3],
-    /// b″ weights matching `idx` order (from `stencil::b_dd_weights(hl, hr)`).
     pub w: [f64; 3],
-    /// Iterate `b̄` values in stencil order `[b̄_{idx[0]}, b̄_{idx[1]}, b̄_{idx[2]}]`.
     pub b_bars: [f64; 3],
     pub a_bar_i: f64,
     pub cp: f64,
@@ -261,18 +180,11 @@ pub(crate) struct AxisJerkCut {
     pub j_lim_inflated: f64,
 }
 
-/// Gradient of `j_axis` at iterate `(b̄, ā)` w.r.t. stencil b-values and `a_i`.
-/// Used by the cut appender and exposed for numerical identity tests.
 pub struct AxisJerkGradient {
-    /// Gradient w.r.t. `b̄` in stencil order `[∂/∂b̄_{idx[0]}, ..., ∂/∂b̄_{idx[2]}]`.
     pub b: [f64; 3],
-    /// Gradient w.r.t. `ā_i`.
     pub a: f64,
 }
 
-/// Test-support export: computes the linearization coefficients (= gradient of
-/// `j_axis`) for an interior (anchor_pos=1) stencil with the given non-uniform
-/// spacings and `b_floor = 0`.
 pub fn axis_jerk_gradient_for_test(
     b_bars: &[f64; 3],
     a_bar: f64,
@@ -347,7 +259,6 @@ fn map_clarabel_cones(
     Ok(out)
 }
 
-/// Exhaustive match against Clarabel 0.11.1; a new variant will fail to compile.
 fn map_status(status: ClarabelStatus, residual: f64) -> SolverStatus {
     match status {
         ClarabelStatus::Solved => SolverStatus::Solved,
@@ -365,8 +276,6 @@ fn map_status(status: ClarabelStatus, residual: f64) -> SolverStatus {
     }
 }
 
-/// Variable layout (pinned in `constraints.rs`): `x[0..n_grid]` → `b_i`,
-/// `x[n_grid..2*n_grid]` → `a_i`.
 fn extract_solution(x: &[f64], n_grid: usize, status: SolverStatus) -> SolverResult {
     let b: Vec<f64> = x[..n_grid].to_vec();
     let a: Vec<f64> = x[n_grid..2 * n_grid].to_vec();
@@ -378,21 +287,6 @@ pub(crate) fn solve(bundle: &ConstraintBundle) -> Result<SolverResult, SolverSet
     solve_with_cuts(bundle, &[], 1e-8, &SolverScale::identity())
 }
 
-/// Append one per-axis Cartesian jerk SLP cut as two `Nonneg` rows.
-///
-/// Unified first-order Taylor linearization of `j_axis = c'''·b^(3/2) + 3·c''·a·√b + c'·s⃛`
-/// at iterate `(b̄, ā)`. Uses weight-based formula (3b): `b̄″ = w·b̄` (dot over stencil triple),
-/// `S = √(max(b̄_anchor, b_floor))`, `anchor_pos = idx.iter().position(|&x| x == i)`.
-///
-/// ```text
-///   coeff on b at idx[k], k ≠ anchor_pos:   c'·S·w[k]/2
-///   coeff on b at anchor:  (3/2)·c'''·S + 3·c''·ā/(2S) + c'·(w[anchor]·S/2 + b̄″/(4S))
-///   coeff on a_i:          3·c''·S
-///   K:  −(1/2)·c'''·S3 − (3/2)·c''·ā·S − c'·b̄″·S/4
-/// ```
-///
-/// Identity verified (uniform w reproduces legacy 3-case formulas exactly) by
-/// `tests/step9_cut_identity.rs`.
 #[allow(clippy::too_many_arguments)]
 fn append_axis_jerk_cut_to_clarabel(
     cut: &AxisJerkCut,
@@ -409,7 +303,6 @@ fn append_axis_jerk_cut_to_clarabel(
     let cppp = cut.cppp;
     let j = cut.j_lim_inflated;
 
-    // Variable layout (pinned in constraints.rs): b at 0..n_grid, a at n_grid..2*n_grid.
     let off_b = 0usize;
     let off_a = n_grid;
 
@@ -450,19 +343,12 @@ fn append_axis_jerk_cut_to_clarabel(
 
     let anchor_b_col = off_b + i;
 
-    // Row-∞-norm scaling: cp·√b/h² grows as O(N²) with grid refinement,
-    // reaching 1.9e6 on fixture_4 (146-cut case) vs a-column coefficients ~10.
-    // A 40 000:1 in-row spread causes QDLDL to return infeasible/maxiter on
-    // every trust-region subproblem and stalls the SLP. Dividing every
-    // coefficient and both RHS values by row_scale is a feasible-set-exact
-    // transformation for Nonneg rows (positive scalar on a ≥ 0 constraint).
     let row_scale = entries_extra
         .iter()
         .map(|&(_, a)| a.abs())
         .fold(alpha_b_anchor.abs(), f64::max);
 
     if row_scale == 0.0 {
-        // All coefficients are zero: vacuous constraint, skip both rows.
         return;
     }
 
@@ -500,25 +386,14 @@ fn push_nz(rowval: &mut [Vec<usize>], nzval: &mut [Vec<f64>], col: usize, row: u
     }
 }
 
-/// L∞ trust region on `(b, a)` around iterate `(b̄, ā)`.
-///
-/// Box rows enforce
-/// `b̄_i·(1−ρ_b) ≤ b_i ≤ b̄_i·(1+ρ_b)` and
-/// `ā_i ± ρ_a·max(|ā_i|, A_TR_FLOOR)` for all interior grid points.
-/// Boundary `b` rows are skipped — block (a) pins them exactly.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TrustRegion {
     pub rho_b: f64,
     pub rho_a: f64,
 }
 
-/// Floor on |ā_i| for the a-trust-region radius: prevents near-zero iterates
-/// from producing a zero-width TR that pins `a` in place. ≈ a_max.
 const A_TR_FLOOR: f64 = 5_000.0;
 
-/// Floor on `b̄_i` for the b-trust-region radius. Prevents near-zero iterates
-/// from producing a near-zero TR Clarabel can't satisfy against centripetal
-/// caps. (50 mm/s)² = 2500.
 const B_TR_FLOOR: f64 = 2_500.0;
 
 fn solve_with_cuts(
@@ -554,8 +429,6 @@ fn solve_with_cuts_and_trust_region(
     if cut_rows > 0 {
         cones_clarabel.push(NonnegativeConeT(cut_rows));
     }
-    // Trust-region rows: 2 per interior b_i (boundary b pinned by block (a)),
-    // 2 per a_i.
     let tr_rows = if trust_region.is_some() {
         if n_grid >= 2 {
             2 * (n_grid - 2) + 2 * n_grid
@@ -733,20 +606,6 @@ fn solve_with_cuts_and_trust_region(
     let p_zero = build_p_zero(n_vars);
     let q: &[f64] = &bundle.objective;
 
-    // verbose=false: diagnostics via kalico telemetry.
-    // max_iter=1000: SLP-cut SOCPs condition more tightly than the base SOCP;
-    //   200 iters produces InsufficientProgress on the CL-2024 counterexample
-    //   (a no-TR / path-jerk SLP case).
-    // max_iter=200 for trust-region subproblems: TR boxes strictly shrink the
-    //   feasible set so feasible TR solves converge faster; a TR subproblem
-    //   hitting MaxIter is discarded by run_slp9_loop's cand_ratio check and
-    //   the no-TR fallback provides an unconditional escape path. This caps
-    //   wasted IPM iterations on infeasible TR probes without affecting the
-    //   CL-2024 case (which is a no-TR solve).
-    // reduced_tol_*=1e-3: lets Clarabel report AlmostSolved; dropping these
-    //   restores Clarabel defaults and silently changes AlmostSolved semantics.
-    // direct_solve_method="qdldl", max_threads=1: determinism pin — single-
-    //   threaded QDLDL keeps the joining-loop early-bail deterministic.
     let max_iter: u32 = if trust_region.is_some() { 200 } else { 1000 };
     #[allow(clippy::similar_names)]
     let settings = DefaultSettings::<f64> {
@@ -776,24 +635,14 @@ fn solve_with_cuts_and_trust_region(
     Ok(extract_solution(&soln.x, n_grid, status))
 }
 
-/// Hard cap; Lee 2024 reports ~5–30 iterations in practice.
 const SLP_MAX_OUTER_ITERS: u32 = 50;
 
-/// Looser than `verify::EPS_FEAS`: the SLP predicate uses a raw FD estimate
-/// of `b''(s)`, which is noisy near constraint-switch kinks (~1–2% spurious
-/// violations). Real violations are ~143% on the CL-2024 counterexample.
 const SLP_EPS_FEAS: f64 = 5e-2;
 
-/// Avoids `1/√0` in the path-jerk linearization.
 const SLP_B_FLOOR: f64 = 1.0;
 
-/// Below this `b̄` a violator does not receive a cut. `α = J·h²/b̄^{3/2}`
-/// diverges as b̄ → 0, producing steep rows that wreck the inner SOCP's
-/// conditioning. ≈ (10 mm/s)².
 const SLP_B_CUT_FLOOR: f64 = 100.0;
 
-/// Warm-up before divergence rule fires; iterates routinely bounce for several
-/// iterations before settling (Lee 2024: 5–30 typical).
 const SLP_WARMUP_ITERS: u32 = 8;
 
 const SLP_MIN_IMPROVEMENT: f64 = 0.01;
@@ -801,8 +650,6 @@ const SLP_NO_IMPROVEMENT_WINDOW: usize = 10;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum SlpOutcome {
-    /// No violators within `SLP_EPS_FEAS`. `outer_iters = 0` means the
-    /// base SOCP was already feasible.
     Converged {
         outer_iters: u32,
     },
@@ -828,17 +675,6 @@ fn max_ratio(vs: &[JerkViolator]) -> f64 {
     vs.iter().map(|v| v.ratio).fold(0.0_f64, f64::max)
 }
 
-/// Append one path-jerk SLP cut using weight-based b″ for non-uniform grids.
-///
-/// Row (sign-paired) scaled by `h̄²` so row magnitudes match the legacy uniform
-/// row and remain O(1) regardless of grid refinement:
-///   `3J·h̄²/√b̄ − α·h̄²·b_i − h̄²·Σ_k w_k·b_{idx[k]} ≥ 0`
-/// where `α = J/b̄^{3/2}`.
-///
-/// For uniform spacing h̄=h the weights `w_k = b_dd_weights(h,h)` give
-/// `h²·w_k = [1, -2, 1]`, reproducing the legacy `append_path_jerk_cut_to_clarabel`
-/// row exactly. For non-uniform junctions this is a feasible-set-identical
-/// positive scaling (`h̄² > 0`).
 #[allow(clippy::too_many_arguments)]
 fn append_path_jerk_cut_weights(
     i: usize,
@@ -861,19 +697,11 @@ fn append_path_jerk_cut_weights(
     let alpha = j_path * h2 / (b_bar * sqrt_b);
     let rhs = 3.0 * j_path * h2 / sqrt_b;
 
-    // anchor_pos: which element of idx is i (for adding alpha to the right column).
     let anchor_pos = idx
         .iter()
         .position(|&x| x == i)
         .expect("i must appear in idx");
 
-    // Sign-convention: A_clarabel = -A_k.
-    // The two Nonneg rows are:
-    //   (+): rhs - alpha·b_i - h²·b_dd ≥ 0
-    //   (−): rhs - alpha·b_i + h²·b_dd ≥ 0
-    // In Clarabel form A_clarabel·x + rhs ≥ 0:
-    //   non-anchor k: A_clarabel[idx[k]] = ∓h²·w[k]  (- for Row+, + for Row-)
-    //   anchor:       A_clarabel[idx[anchor]] = ∓h²·w[anchor] − alpha
     for &neg_b_dd in &[true, false] {
         let row = *n_rows;
         let sign_b_dd: f64 = if neg_b_dd { -1.0 } else { 1.0 };
@@ -891,7 +719,6 @@ fn append_path_jerk_cut_weights(
     let _ = n_grid;
 }
 
-/// Path-jerk violators using per-point `b_dd_weights` for non-uniform spacing.
 pub(crate) fn find_jerk_violators_chain(
     b: &[f64],
     h_intervals: &[f64],
@@ -918,8 +745,6 @@ pub(crate) fn find_jerk_violators_chain(
     out
 }
 
-/// Per-axis ratio scan for a chain grid. Includes a second pass over junction
-/// duals so both geometries at shared junction points are evaluated.
 pub(crate) fn max_axis_ratio_chain(
     result: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
@@ -1027,10 +852,6 @@ const SLP9_TARGET_MARGIN: f64 = 1e-3;
 const SLP9_CUT_PLACEMENT_FRACTION: f64 = 0.9;
 const SLP9_DAMP_TARGET_RATIO: f64 = 0.9;
 
-/// Cut builder for a chain grid. Uses per-point stencil weights from
-/// `chain.h_intervals`. Junction dual points receive extra cuts (dual geometry
-/// and limits evaluated at the same stencil triple). Cuts are placed for all
-/// violators above `target_floor` and tightened to `target_ratio`.
 pub(crate) fn build_axis_jerk_cuts_chain(
     result: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
@@ -1078,7 +899,6 @@ pub(crate) fn build_axis_jerk_cuts_chain(
                 j_lim_inflated: j_lim,
             }));
         }
-        // Junction dual: same stencil triple, right-side geometry and limits.
         for jct in chain.junctions.iter().filter(|jct| jct.idx == i) {
             let jlim = &chain.limits[jct.limits_idx];
             let jgeom = &jct.geom;
@@ -1116,11 +936,6 @@ pub(crate) fn build_axis_jerk_cuts_chain(
     cuts
 }
 
-/// Path-jerk SLP outer loop for chain grids (non-uniform spacing).
-///
-/// Clone of `slp_solve` control flow; calls `find_jerk_violators_chain` and
-/// emits weight-based path-jerk cuts via `append_path_jerk_cut_weights`.
-/// Wired into the schedule entry in Task 8.
 pub(crate) fn slp_solve_chain(
     bundle: &ConstraintBundle,
     tol: f64,
@@ -1421,9 +1236,6 @@ fn run_slp9_loop(
     ))
 }
 
-/// Uniform time dilation of the iterate: `b ← λ²·b`, `a ← λ²·a`. Every
-/// constraint-family ratio decreases monotonically as λ → 0, so this can always
-/// restore a feasible point while staying on the `b' = 2a` motion manifold.
 fn damp_profile_uniform(result: &SolverResult, lambda: f64) -> SolverResult {
     let l2 = lambda * lambda;
     SolverResult {
@@ -1453,12 +1265,6 @@ fn uniform_damp_for_feasibility(
     (damped, ratio)
 }
 
-/// Cheap O(N) feasible seed for the recovery descent when the direct
-/// feasibility descent stalled. Uniform time dilation (`b ← λ²b, a ← λ²a`)
-/// reduces every constraint ratio monotonically and stays on the `b' = 2a`
-/// motion manifold (zero Clarabel calls). Returns `None` when even full
-/// dilation cannot reach `ratio ≤ 1.0` — the curve is genuinely infeasible and
-/// must not be laundered into success.
 fn seed_feasible_point(
     result: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
@@ -1470,21 +1276,6 @@ fn seed_feasible_point(
     (uniform_ratio <= 1.0).then_some(uniform)
 }
 
-/// Always-available feasibility floor for the anytime path. Uniformly
-/// time-dilates an MVC-respecting base iterate until every constraint-family
-/// ratio sits at or below the kinematic limit, with zero Clarabel solves.
-///
-/// `base` must already satisfy the velocity / accel / centripetal cones (the
-/// path-jerk SLP iterate does — it only ever adds jerk cuts, never relaxing the
-/// SOCP cones), so `damp_profile_uniform` lowers `b,a` monotonically and drives
-/// jerk down as `λ³`, the fastest-shrinking family. Returns `None` only when
-/// even full dilation cannot reach `ratio ≤ 1` — a genuine infeasibility that
-/// must never be laundered into a feasible-looking profile.
-///
-/// The damped seed starts slower than the committed boundary (`b[0]` is scaled),
-/// which is strictly safe: slower start, lower accel/jerk demand. The streaming
-/// boundary logic clamps the dispatched front downward only, so a slower floor
-/// start never violates the committed past.
 fn feasibility_floor(
     base: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
@@ -1518,10 +1309,6 @@ fn profile_time(result: &SolverResult, h_intervals: &[f64]) -> f64 {
         .sum()
 }
 
-/// The SLP9 loop only ever reduces constraint violation; descending from the
-/// follower-free iterate it stops at first feasibility, which can sit a few
-/// percent below the local optimum. Re-maximize speed under full-cap cuts
-/// rebuilt at each accepted iterate while staying feasible.
 fn build_polish_cuts(
     current: &SolverResult,
     chain: &crate::topp::chain::ChainGrid,
@@ -1603,16 +1390,6 @@ fn polish_axis_jerk(
     Ok(current)
 }
 
-/// Recovers a feasible, manifold-consistent profile from a uniformly-damped
-/// seed when the direct feasibility descent stalled. The uniform-damp seed is
-/// feasible but off the `b' = 2a` motion manifold and carries a scaled entry
-/// `b[0]`; a short trust-region-boxed cutting-plane projection re-pins
-/// `b[0] = v_start²` and lands on a feasible on-manifold profile (the only kind
-/// valid as an output trajectory) in a handful of Clarabel solves — not a full
-/// `run_slp9_loop` re-descent, which would re-stall and burn the whole budget.
-/// A final time-maximizing polish nudges the projected profile toward the local
-/// time-optimum while staying feasible. Returns the recovered profile and its
-/// axis-jerk ratio; the seed is the feasibility floor.
 fn recover_speed_from_seed(
     bundle: &ConstraintBundle,
     chain: &crate::topp::chain::ChainGrid,
@@ -1663,17 +1440,6 @@ fn recover_speed_from_seed(
     Ok((polished, polished_ratio))
 }
 
-/// Anytime exit reconciliation. When the SLP stopped early on a deadline and
-/// the best iterate it holds is not yet feasible, substitute the feasibility
-/// floor (feasible by construction). Leaves a genuine, non-time-budget failure
-/// untouched so it still maps to a non-success status and fails loud:
-///
-/// - already feasible → unchanged (the ample-deadline / normal path is bit-identical).
-/// - infeasible, deadline NOT expired → unchanged (genuine SLP failure, fail loud).
-/// - infeasible, deadline expired, floor exists → ship the floor as `Diverged`,
-///   which `map_status` maps to a feasible `SolvedInexact` success.
-/// - infeasible, deadline expired, floor `None` → unchanged (genuine
-///   infeasibility — never laundered into a feasible-looking profile).
 fn ship_feasible_or_floor(
     result: SolverResult,
     outcome: SlpOutcome,

--- a/rust/temporal/src/topp/solver/tests.rs
+++ b/rust/temporal/src/topp/solver/tests.rs
@@ -4,13 +4,6 @@ use crate::topp::chain::ChainGrid;
 use crate::topp::constraints::{BuildOutcome, EndpointConditions, build_chain};
 use crate::topp::path::{ArclengthGrid, InterSample};
 
-/// Verify that `append_axis_jerk_cut_to_clarabel` emits ∞-norm-normalized rows.
-///
-/// With cp=1.0, b_bars=[6.0; 3], h=1e-3 the stencil coefficients include
-/// cp·√b/h² ≈ 2.449e6 — a scale that historically wrecked QDLDL conditioning.
-/// After the fix every pushed coefficient must be ≤ 1.0 in absolute value (the
-/// row has been divided through by its ∞-norm), and the RHS values must equal
-/// the unscaled values divided by that same scale.
 #[test]
 fn axis_jerk_cut_row_norm_is_one() {
     let n_grid = 5_usize;
@@ -20,8 +13,6 @@ fn axis_jerk_cut_row_norm_is_one() {
     let h = 1e-3_f64;
     let b_val = 6.0_f64;
     let cp = 1.0_f64;
-    // cpp and cppp set to zero so the dominant term is cp·√b/h², which is
-    // the O(N²) coefficient that caused conditioning failures.
     let h_uniform = h;
     let w = crate::topp::stencil::b_dd_weights(h_uniform, h_uniform);
     let cut = AxisJerkCut {
@@ -37,14 +28,6 @@ fn axis_jerk_cut_row_norm_is_one() {
         j_lim_inflated: 1_000.0,
     };
 
-    // Compute the expected unscaled row_scale.  Interior stencil with cpp=cppp=0,
-    // a_bar=0, d2=0:
-    //   alpha_b_im1 = cp·√b / (2h²)
-    //   alpha_b_ip1 = cp·√b / (2h²)
-    //   alpha_b_i   = -cp·√b / h² + 0  (d2 = 0)
-    //   alpha_a_i   = 0
-    // So |alpha_b_i| = cp·√b/h² and the two side coefficients are half that.
-    // row_scale = cp·√b/h².
     let s = b_val.sqrt();
     let expected_scale = cp * s / (h * h);
     assert!(
@@ -71,7 +54,6 @@ fn axis_jerk_cut_row_norm_is_one() {
     assert_eq!(n_rows, 2, "expected two rows (± pair)");
     assert_eq!(b_rhs.len(), 2);
 
-    // Collect all non-zero coefficient magnitudes across both rows.
     let max_coeff: f64 = nzval
         .iter()
         .flat_map(|col| col.iter().copied())
@@ -83,8 +65,6 @@ fn axis_jerk_cut_row_norm_is_one() {
         "∞-norm of emitted rows should be 1.0, got {max_coeff}"
     );
 
-    // RHS pair: the cut has k_const = 0 (cpp=cppp=0, d2=0, a_bar=0), so
-    // rhs_pos = j / row_scale and rhs_neg = j / row_scale — both equal.
     let j = cut.j_lim_inflated;
     let expected_rhs = j / expected_scale;
     assert!(
@@ -98,7 +78,6 @@ fn axis_jerk_cut_row_norm_is_one() {
         b_rhs[1]
     );
 
-    // The ± rows must have identical coefficient magnitudes (symmetry preserved).
     let coeff_pos: Vec<f64> = nzval
         .iter()
         .enumerate()
@@ -133,7 +112,6 @@ fn axis_jerk_cut_row_norm_is_one() {
         );
     }
 
-    // off_a column (alpha_a_i = 0) must not appear in the output.
     assert!(
         rowval[off_a + cut.i].is_empty(),
         "a_i column should be absent when cpp = 0"
@@ -142,18 +120,13 @@ fn axis_jerk_cut_row_norm_is_one() {
 
 #[test]
 fn find_jerk_violators_chain_ratio_has_no_spurious_h_factor() {
-    // Uniform grid with h=0.5. b_dd_weights returns [1/h², -2/h², 1/h²], so
-    // b_dd = (b0 - 2*b1 + b2) / h² directly — no extra h² should appear in
-    // the ratio denominator.
-    //
-    // Construction: target ratio = 1.10 (safely above the 1+SLP_EPS_FEAS=1.05 gate).
-    //   ratio = |b_dd| * sqrt(b1) / (2*J)
-    //   want 1.10 = |b_dd| * sqrt(400) / (2*100) → |b_dd| = 1.10*200/20 = 11.0
-    //   b_dd = (b0 - 2*400 + b2)/h² with h=0.5 → (b0-800+b2)/0.25 = 11.0
-    //   symmetric: b0=b2=400 + 11.0*0.25/2 = 400 + 1.375 = 401.375
     let h = 0.5_f64;
     let j_path = 100.0_f64;
-    let b = vec![401.375_f64, 400.0, 401.375];
+    let target_ratio = 1.10_f64;
+    let b_mid = 400.0_f64;
+    let b_dd = target_ratio * 2.0 * j_path / b_mid.sqrt();
+    let b_side = b_mid + b_dd * (h * h) / 2.0;
+    let b = vec![b_side, b_mid, b_side];
     let h_intervals = vec![h, h];
     let violators = find_jerk_violators_chain(&b, &h_intervals, &[j_path; 3]);
     assert_eq!(
@@ -163,8 +136,8 @@ fn find_jerk_violators_chain_ratio_has_no_spurious_h_factor() {
     );
     let got_ratio = violators[0].ratio;
     assert!(
-        (got_ratio - 1.10).abs() < 1e-3,
-        "ratio {got_ratio} should be ≈1.10; a spurious h² divisor would give {:.4} instead",
+        (got_ratio - target_ratio).abs() < 1e-3,
+        "ratio {got_ratio} should be ≈{target_ratio}; a spurious h² divisor would give {:.4} instead",
         got_ratio / (h * h),
     );
 }
@@ -274,9 +247,6 @@ fn straight_line_solves_to_nontrivial_profile() {
     );
 }
 
-/// `uniform_damp_for_feasibility` must return a uniform time dilation that
-/// brings the axis-jerk ratio of the damped result to ≤ `SLP9_DAMP_TARGET_RATIO`,
-/// staying on the `b' = 2a` motion manifold (both `b` and `a` scaled by λ²).
 #[test]
 fn uniform_damp_achieves_target_on_manifold() {
     let n = 7_usize;
@@ -358,16 +328,6 @@ fn uniform_damp_achieves_target_on_manifold() {
     }
 }
 
-/// `build_axis_jerk_cuts_chain` must place maintenance cuts (j_lim = j_max) for
-/// non-violating points whose jerk ratio is above `SLP9_EPS_FEAS`, and tightening
-/// cuts (j_lim < j_max) only for points above the tightening threshold.
-///
-/// Two X-axis points are constructed:
-///   - i=1 (maintenance): ratio ≈ 0.20 — above SLP9_EPS_FEAS(0.05) but below
-///     `SLP9_CUT_PLACEMENT_FRACTION * target_ratio` — must get j_lim = j_max.
-///   - i=2 (tightening): ratio ≈ 1.30 — above the tightening threshold — must
-///     get j_lim = j_max * target_ratio.
-///   - i=3 (no cut): ratio ≈ 0.01 — below SLP9_EPS_FEAS — must produce no cut.
 #[test]
 fn build_axis_jerk_cuts_chain_places_maintenance_cuts() {
     let n = 5_usize;
@@ -477,13 +437,6 @@ fn build_axis_jerk_cuts_chain_places_maintenance_cuts() {
     );
 }
 
-/// Regression: `slp_solve_chain` must return `Converged`, not `MaxIters`, when
-/// all interior b values are below `SLP_B_CUT_FLOOR` (no cuts placeable).
-///
-/// `j_max = [1,1,1]` ensures the FD-estimated path-jerk ratio exceeds 1.05 on
-/// the initial SOCP solution while the 0.03 mm move keeps peak b far below
-/// `SLP_B_CUT_FLOOR = 100.0`, making `added == 0` guaranteed. The old code
-/// returned `MaxIters`; the fix returns `Converged`.
 #[test]
 fn slp_solve_chain_zero_cuts_placeable_is_converged_not_max_iters() {
     let grid = dummy_straight_grid(20, 0.03_f64);

--- a/rust/temporal/src/topp/stencil/tests.rs
+++ b/rust/temporal/src/topp/stencil/tests.rs
@@ -2,13 +2,13 @@ use super::*;
 
 #[test]
 fn b_dd_weights_exact_on_quadratic_nonuniform() {
-    // b(s) = 3s² − 2s + 1 → b″ = 6 everywhere, any spacing.
     let b = |s: f64| 3.0 * s * s - 2.0 * s + 1.0;
+    let second_derivative = 6.0;
     let (hl, hr) = (0.3, 0.7);
     let s_i = 1.0;
     let w = b_dd_weights(hl, hr);
     let approx = w[0] * b(s_i - hl) + w[1] * b(s_i) + w[2] * b(s_i + hr);
-    assert!((approx - 6.0).abs() < 1e-10, "got {approx}");
+    assert!((approx - second_derivative).abs() < 1e-10, "got {approx}");
 }
 
 #[test]
@@ -61,7 +61,6 @@ fn b_ddd_weights_exact_on_cubics() {
 
 #[test]
 fn s_snap_on_quartic_b_profile() {
-    // b(s) = (1+s)^4 ⇒ ṡ = (1+s)², s̈ = 2(1+s)³, s⃛ = 6(1+s)⁴, s⁗ = 24(1+s)⁵
     let n = 401;
     let h = 0.5 / (n - 1) as f64;
     let s: Vec<f64> = (0..n).map(|i| i as f64 * h).collect();

--- a/rust/temporal/src/topp/tests.rs
+++ b/rust/temporal/src/topp/tests.rs
@@ -2,9 +2,6 @@ use super::*;
 use crate::Limits;
 use constraints::EndpointConditions;
 
-/// Straight 600 mm collinear cubic at machine-limit speed: v_max = 1000 mm/s,
-/// a_max = 50 km/s². κ = 0 on a straight line, so no curvature row is active;
-/// the solver must produce a usable profile, not MaxIter.
 #[test]
 fn schedule_segment_straight_line_at_1000mms_solves() {
     let cps = vec![
@@ -81,9 +78,6 @@ fn schedule_segment_straight_line_returns_profile() {
 
 #[test]
 fn pinned_nonzero_a_start_converges() {
-    // Reproduction case: v_start=575, a_start=2000, 100mm straight, N=100
-    // previously produced DivergedSlp{ratio≈2.0} with the hard-pin approach.
-    // The tube must make this converge.
     let curve = VectorNurbs::<f64, 3>::try_new(
         1,
         vec![0.0, 0.0, 1.0, 1.0],

--- a/rust/temporal/src/topp/verify.rs
+++ b/rust/temporal/src/topp/verify.rs
@@ -350,12 +350,6 @@ pub(crate) fn check_chain(chain: &ChainGrid, result: &SolverResult) -> VerifyRep
     let mut histogram: Vec<(BindingConstraint, u32)> = histogram_map.into_iter().collect();
     histogram.sort_by(|(ca, na), (cb, nb)| nb.cmp(na).then_with(|| ca.cmp(cb)));
 
-    // The reported worst binding spans ALL families (velocity, accel, jerk, and
-    // the PA families) — it answers "which limit is this move riding, and how
-    // close." A jerk-limited move sits on the jerk ceiling at ratio≈1; reporting
-    // only the non-jerk half (as the feasibility split does, for its looser jerk
-    // tolerance) made such moves falsely report velocity at ~0.5 and a bogus
-    // gap≈0.5. Feasibility still uses the jerk/non-jerk split below.
     let worst = if global_worst_ratio >= SLACK_THRESHOLD
         && !matches!(
             global_worst_tag,

--- a/rust/temporal/src/topp/window.rs
+++ b/rust/temporal/src/topp/window.rs
@@ -44,7 +44,6 @@ pub struct WindowOperator {
 #[derive(Debug, Clone, Default)]
 pub struct WindowHistory {
     pub dt: f64,
-    /// Pre-chain signal values; sample `m` sits at `t = -(m + 0.5) * dt`.
     pub samples: Vec<f64>,
 }
 
@@ -86,9 +85,6 @@ impl WindowOperator {
         Self::from_kernel_with_terminal(kernel, t_map, history, &WindowHistory::empty())
     }
 
-    /// `terminal` holds post-chain signal samples; sample `m` sits at
-    /// `t_end + (m + 0.5) * dt`. Kernel mass beyond the supplied samples
-    /// falls back to holding the final chain sample.
     pub fn from_kernel_with_terminal(
         kernel: &PiecewisePolynomialKernel<f64>,
         t_map: &[f64],

--- a/rust/temporal/tests/anytime.rs
+++ b/rust/temporal/tests/anytime.rs
@@ -1,12 +1,3 @@
-//! Deterministic gates for the anytime / graceful-degradation temporal solve.
-//!
-//! These gates are load-independent: they force the deadline (already-expired vs
-//! far-future) rather than racing wall-clock against a busy CPU. A shipped
-//! `Solved*` status is itself proof that `verify::check_chain` passed, because
-//! `output::map_status` only emits a success status when `verify.feasible` is
-//! true — so feasibility (G1) is asserted via the public status + the binding
-//! ratio surfaced from `check_chain`.
-
 use std::time::{Duration, Instant};
 
 use nurbs::VectorNurbs;
@@ -16,7 +7,6 @@ use temporal::{
 
 const V_MAX: f64 = 300.0;
 
-/// The sharp ~46mm S-bend that took 568ms to solve optimally on the Pi5 bench.
 fn repro_curve() -> VectorNurbs<f64, 3> {
     VectorNurbs::<f64, 3>::try_new(
         3,
@@ -46,7 +36,6 @@ fn repro_grid() -> GridConfig {
     }
 }
 
-/// A representative straight 50mm move, rest-to-rest.
 fn straight_50mm() -> VectorNurbs<f64, 3> {
     VectorNurbs::<f64, 3>::try_new(
         1,
@@ -56,10 +45,6 @@ fn straight_50mm() -> VectorNurbs<f64, 3> {
     .unwrap()
 }
 
-/// A short 4mm rest-to-rest straight move. Too short to reach v_max=300 under
-/// the accel/jerk caps, so velocity tops out well below its limit and the move
-/// is accel/jerk-limited — the exact shape that exposed the velocity-only worst-
-/// binding report on the bench.
 fn short_straight_4mm() -> VectorNurbs<f64, 3> {
     VectorNurbs::<f64, 3>::try_new(
         1,
@@ -76,17 +61,6 @@ fn is_success(status: SolveStatus) -> bool {
     )
 }
 
-/// Regression — the reported worst binding spans all families. A short rest-to-
-/// rest move is jerk-limited: velocity peaks far below its cap (~0.4-0.5) while
-/// jerk is the highest-ratio family. The old report considered only velocity/
-/// accel, so it surfaced the velocity ratio and a gap inflated by the unseen
-/// jerk. The fix surfaces jerk as the worst — the gap is computed against the
-/// genuinely-tightest constraint, not a blind-spot family.
-///
-/// Note this move does NOT ride jerk at ratio 1.0 (it converges near 0.6); that
-/// residual gap is a real property of the relaxed solve on a short isolated
-/// rest-to-rest segment, tracked separately. This test only locks that the
-/// report no longer hides the tighter family behind velocity.
 #[test]
 fn converged_short_move_worst_spans_all_families() {
     let curve = short_straight_4mm();
@@ -111,10 +85,6 @@ fn converged_short_move_worst_spans_all_families() {
         .worst
         .expect("a converged move must report a worst binding");
 
-    // The peak velocity ratio on this short move is well below 1; if the report
-    // still keyed on velocity it would sit near that. Jerk is the tighter family,
-    // so the reported worst must be jerk (or accel) at a ratio above the velocity
-    // peak — proving the all-family worst, not the velocity-only blind spot.
     assert!(
         matches!(
             worst.constraint,
@@ -134,10 +104,6 @@ fn converged_short_move_worst_spans_all_families() {
     );
 }
 
-/// G1 + G2 — forcing an already-expired deadline on the 46mm@50 sharp curve
-/// (which optimally takes 568ms) ships a FEASIBLE floor with a success status
-/// (success ⇒ `check_chain.feasible`), reports a positive gap, names a limiter,
-/// and does not error or panic.
 #[test]
 fn g1_g2_expired_deadline_ships_feasible_floor() {
     let curve = repro_curve();
@@ -205,8 +171,6 @@ fn g1_g2_expired_deadline_ships_feasible_floor() {
     );
 }
 
-/// G1 — the floor is feasible for a representative rest-to-rest straight move
-/// under an expired deadline (success ⇒ `check_chain.feasible`). Slower-but-safe.
 #[test]
 fn g1_floor_feasible_representative() {
     let curve = straight_50mm();
@@ -231,9 +195,6 @@ fn g1_floor_feasible_representative() {
     assert!(profile.total_time.is_finite() && profile.total_time > 0.0);
 }
 
-/// G3 — an ample (far-future) deadline must converge to today's optimum: the
-/// committed trajectory equals the unbounded (deadline = None) full solve within
-/// solver tolerance. Trajectory-neutral when time is ample.
 #[test]
 fn g3_ample_deadline_converges_to_optimum() {
     let curve = repro_curve();
@@ -301,13 +262,6 @@ fn g3_ample_deadline_converges_to_optimum() {
     }
 }
 
-/// G4 — a genuinely infeasible curve must still fail loud: an expired deadline
-/// must NOT launder it into a success. Here the start velocity is pinned far
-/// above the maximum velocity the limits permit (5000 mm/s vs v_max=300), so the
-/// boundary sits above the MVC: NO feasible profile exists at the pinned
-/// boundary at any interior speed. This is the hard boundary — the floor only
-/// dilates interior speed; it cannot lower a pinned boundary, so the solve must
-/// report `Infeasible`, not a feasible-looking floor.
 #[test]
 fn g4_genuine_infeasibility_still_fails_loud() {
     let curve = repro_curve();

--- a/rust/temporal/tests/limits_stress.rs
+++ b/rust/temporal/tests/limits_stress.rs
@@ -1,18 +1,3 @@
-//! Robustness stress battery for the temporal solver.
-//!
-//! "We never know how people will decide to use our fork" — so the solver must
-//! produce a usable trajectory (or a *deliberate*, well-defined infeasibility)
-//! for any physically-valid machine-limit configuration, no matter how absurd
-//! the magnitudes or how extreme the anisotropy. This file sweeps a matrix of
-//! limit sets crossed with representative geometries and asserts that every
-//! combination lands in the acceptable-outcome set: no panic, no `BatchError`,
-//! finite positive trajectory time, and never a "solver gave up" status
-//! (`DivergedSlp` / large-residual `MaxIter`).
-//!
-//! One `#[test]` per geometry; each loops the full limit matrix, collects every
-//! failure, and asserts the collection is empty so a single run prints the whole
-//! failure map instead of aborting on the first bad combination.
-
 use nurbs::VectorNurbs;
 use temporal::{
     BatchInput, BatchOutput, GridStrategy, InfeasibleReason, Limits, SegmentInput, SolveStatus,
@@ -32,7 +17,6 @@ fn cubic(pts: [[f64; 3]; 4]) -> VectorNurbs<f64, 3> {
     .unwrap()
 }
 
-/// Smoothly chained cubic S-curve — the shape that crashed the live planner.
 fn s_chain() -> Vec<VectorNurbs<f64, 3>> {
     let mut curves = Vec::new();
     let mut px = 0.0_f64;
@@ -53,7 +37,6 @@ fn s_chain() -> Vec<VectorNurbs<f64, 3>> {
     curves
 }
 
-/// A tight single cubic with a sharp curvature spike near the middle.
 fn sharp_cubic() -> Vec<VectorNurbs<f64, 3>> {
     vec![cubic([
         [0.0, 0.0, 0.0],
@@ -63,11 +46,9 @@ fn sharp_cubic() -> Vec<VectorNurbs<f64, 3>> {
     ])]
 }
 
-/// Four cubic quarter-arcs chained into a full circle (continuous tangent).
 fn circle_chain() -> Vec<VectorNurbs<f64, 3>> {
     let k = (4.0 / 3.0) * (std::f64::consts::SQRT_2 - 1.0);
     let r = 20.0_f64;
-    // quarter arcs around the origin, CCW
     let quarter = |a0: [f64; 3], a1: [f64; 3], c0: [f64; 3], c1: [f64; 3]| cubic([a0, c0, c1, a1]);
     vec![
         quarter(
@@ -131,13 +112,9 @@ fn geometries() -> Vec<(&'static str, Vec<VectorNurbs<f64, 3>>)> {
     ]
 }
 
-/// The limit matrix: sane defaults through deliberately absurd magnitudes and
-/// extreme axis anisotropy. Every entry is a *physically valid* limit set
-/// (finite, positive caps) — so every entry must yield a usable trajectory.
 fn limit_matrix() -> Vec<(&'static str, Limits)> {
     let iso = |v, a, j| Limits::axis_boxes([v; 3], [a; 3], [j; 3]);
     vec![
-        // --- sane / representative ---
         ("textbook", iso(500.0, 5_000.0, 100_000.0)),
         ("corexy_fast", iso(1_000.0, 65_000.0, 50_000_000.0)),
         (
@@ -152,21 +129,18 @@ fn limit_matrix() -> Vec<(&'static str, Limits)> {
             "norm_all_textbook",
             Limits::norm_all(500.0, 5_000.0, 100_000.0),
         ),
-        // --- single absurd axis-cap ---
         ("tiny_v", iso(1.0, 5_000.0, 100_000.0)),
         ("huge_v", iso(100_000.0, 5_000.0, 100_000.0)),
         ("tiny_a", iso(500.0, 10.0, 100_000.0)),
         ("huge_a", iso(500.0, 5_000_000.0, 100_000.0)),
         ("tiny_j", iso(500.0, 5_000.0, 100.0)),
         ("huge_j", iso(500.0, 5_000.0, 1e12)),
-        // --- absurd combinations ---
         ("tiny_everything", iso(1.0, 10.0, 100.0)),
         ("huge_everything", iso(1e6, 1e7, 1e12)),
         ("huge_a_tiny_j", iso(500.0, 5_000_000.0, 10.0)),
         ("huge_v_tiny_j", iso(1e6, 5_000.0, 1.0)),
         ("huge_v_tiny_a", iso(1e6, 1e-2, 1e6)),
         ("crawl_everything", iso(1e9, 1e-2, 1e-3)),
-        // --- extreme anisotropy ---
         (
             "aniso_x_fast",
             Limits::axis_boxes(
@@ -203,23 +177,15 @@ fn adaptive() -> GridStrategy {
     }
 }
 
-/// Acceptable terminal status for a batch with valid limits. The solver may
-/// succeed, or it may *deliberately* report a boundary infeasibility (a
-/// requested endpoint velocity that genuinely cannot be honored by the limits
-/// over the given path) — that is a correct, well-characterized rejection. What
-/// it must never do is numerically give up: `SolverInfeasible`, `DivergedSlp`,
-/// `MaxIterSlp`, or a large-residual `MaxIter` all indicate the solver failed on
-/// a problem it should have solved.
 fn classify_status(status: &SolveStatus) -> Result<(), String> {
+    const NEGLIGIBLE_MAX_ITER_RESIDUAL: f64 = 1e-6;
     match status {
         SolveStatus::Solved | SolveStatus::SolvedInexact { .. } | SolveStatus::SolvedSlp { .. } => {
             Ok(())
         }
-        // Curved arcs can surface MaxIter with a negligible residual when the
-        // SLP per-axis-jerk linearization gap closes slower than the grid solve.
-        SolveStatus::MaxIter { last_residual } if *last_residual < 1e-6 => Ok(()),
-        // Deliberate, physically-meaningful boundary rejection — never the
-        // numerical `SolverInfeasible`.
+        SolveStatus::MaxIter { last_residual } if *last_residual < NEGLIGIBLE_MAX_ITER_RESIDUAL => {
+            Ok(())
+        }
         SolveStatus::Infeasible { reason, .. }
             if !matches!(reason, InfeasibleReason::SolverInfeasible) =>
         {
@@ -238,10 +204,8 @@ fn check_output(out: &BatchOutput, n_segments: usize) -> Result<(), String> {
     }
     for (i, p) in out.profiles.iter().enumerate() {
         classify_status(&p.status).map_err(|s| format!("profile {i} status {s}"))?;
-        // A deliberate boundary infeasibility carries an intentional INFINITY
-        // total_time and a zeroed envelope — the numeric sanity checks below
-        // apply only to profiles the solver actually scheduled.
-        if matches!(p.status, SolveStatus::Infeasible { .. }) {
+        let deliberate_boundary_infeasibility = matches!(p.status, SolveStatus::Infeasible { .. });
+        if deliberate_boundary_infeasibility {
             continue;
         }
         if !p.total_time.is_finite() || p.total_time <= 0.0 {
@@ -262,8 +226,6 @@ fn check_output(out: &BatchOutput, n_segments: usize) -> Result<(), String> {
     Ok(())
 }
 
-/// Run one geometry against the whole limit matrix at the given endpoint
-/// velocities, collecting every failure into one report.
 fn sweep_geometry_with_endpoints(
     geo_name: &str,
     curves: &[VectorNurbs<f64, 3>],
@@ -309,7 +271,6 @@ fn sweep_geometry_with_endpoints(
     );
 }
 
-/// Run one geometry against the whole limit matrix, rest to rest.
 fn sweep_geometry(geo_name: &str, curves: &[VectorNurbs<f64, 3>]) {
     sweep_geometry_with_endpoints(geo_name, curves, 0.0, 0.0);
 }
@@ -356,12 +317,8 @@ fn stress_tiny_cubic() {
     sweep_geometry(g.0, &g.1);
 }
 
-// --- non-zero endpoint velocities (tube / a_start / boundary-reachable path) ---
-
 #[test]
 fn stress_nonzero_endpoints_straight() {
-    // A long straight so a moderate cruise velocity is reachable under sane
-    // limits; absurd configs land on deliberate boundary rejections.
     let curves = vec![line([0.0; 3], [200.0, 0.0, 0.0])];
     sweep_geometry_with_endpoints("straight_200mm_cruise", &curves, 5.0, 5.0);
     sweep_geometry_with_endpoints("straight_200mm_fast", &curves, 200.0, 0.0);
@@ -373,10 +330,6 @@ fn stress_nonzero_endpoints_gentle_cubic() {
     sweep_geometry_with_endpoints("gentle_cubic_cruise", &g.1, 5.0, 5.0);
 }
 
-// --- mixed per-segment limits within one chain (within-chain dynamic range) ---
-
-/// A smooth collinear chain whose segments alternate between a fast and a crawl
-/// limit set, plus the same chain under every uniform config in the matrix.
 #[test]
 fn stress_mixed_limits_chain() {
     let curves: Vec<VectorNurbs<f64, 3>> = (0..6)

--- a/rust/temporal/tests/micro_move_slp.rs
+++ b/rust/temporal/tests/micro_move_slp.rs
@@ -1,11 +1,3 @@
-/// Regression: a segment where all interior b values fall below `SLP_B_CUT_FLOOR`
-/// must not produce `MaxIterSlp`.
-///
-/// `j_max = [1,1,1]` makes the FD path-jerk ratio fire on the initial SOCP
-/// solution while the 0.03 mm move keeps every b below the cut floor.
-/// Before the fix, `slp_solve_chain` returned `MaxIters` (→ `MaxIterSlp` from
-/// `output::map_status` when the verifier also reported infeasible), stalling
-/// the joining loop with `StalledOnInfeasibleSegment`.
 use nurbs::VectorNurbs;
 use temporal::{GridConfig, GridScheme, Limits, SolveStatus, schedule_segment};
 

--- a/rust/temporal/tests/multi_segment.rs
+++ b/rust/temporal/tests/multi_segment.rs
@@ -465,11 +465,10 @@ mod fixture_6_long_realistic_chain {
 
         assert!(output.joining_sweeps <= 3);
 
+        const G5_CUBIC_ARC_PROFILE_INDEX: usize = 7;
+        const SLP_JERK_LINEARIZATION_RESIDUAL_BUDGET: f64 = 1e-6;
         for (i, profile) in output.profiles.iter().enumerate() {
-            // Profile 7 (a G5 cubic) hits the SLP per-axis-jerk linearization
-            // gap and may surface MaxIter with a tiny residual; all others must
-            // be in the solved set.
-            let is_curved_arc = i == 7;
+            let is_curved_arc = i == G5_CUBIC_ARC_PROFILE_INDEX;
             let acceptable = matches!(
                 profile.status,
                 temporal::SolveStatus::Solved
@@ -478,7 +477,8 @@ mod fixture_6_long_realistic_chain {
             ) || (is_curved_arc
                 && matches!(
                     profile.status,
-                    temporal::SolveStatus::MaxIter { last_residual } if last_residual < 1e-6
+                    temporal::SolveStatus::MaxIter { last_residual }
+                        if last_residual < SLP_JERK_LINEARIZATION_RESIDUAL_BUDGET
                 ));
             assert!(
                 acceptable,
@@ -494,7 +494,7 @@ mod fixture_6_long_realistic_chain {
                     last_dirty_count: 1
                 }
             ) && output.profiles.iter().enumerate().all(|(i, p)| {
-                let is_curved_arc = i == 7;
+                let is_curved_arc = i == G5_CUBIC_ARC_PROFILE_INDEX;
                 matches!(
                     p.status,
                     temporal::SolveStatus::Solved
@@ -503,7 +503,8 @@ mod fixture_6_long_realistic_chain {
                 ) || (is_curved_arc
                     && matches!(
                         p.status,
-                        temporal::SolveStatus::MaxIter { last_residual } if last_residual < 1e-6
+                        temporal::SolveStatus::MaxIter { last_residual }
+                            if last_residual < SLP_JERK_LINEARIZATION_RESIDUAL_BUDGET
                     ))
             }));
         assert!(
@@ -583,16 +584,6 @@ mod fixture_7_curvature_spike_intergrid_sanity {
         GridConfig, GridSample, GridScheme, ToleranceMode, schedule_segment_with_tolerance,
     };
 
-    /// Residual centripetal slack after the inter-grid SOCP rows are enforced.
-    /// Sources of remaining gap:
-    ///   (a) Hermite interpolation of v between solver samples is not exact —
-    ///       the SOCP minimizes ∫ dt via piecewise-linear b, but the Hermite
-    ///       cubic can overshoot v by the inter-sample b curvature (~0.5%).
-    ///   (b) κ evaluated at 3 interior θ positions per SOCP interval;
-    ///       the true κ peak between samples can exceed the sampled κ by
-    ///       at most half the sample spacing (~0.4% for this fixture at n=10).
-    /// Combined budget: empirically ≤ 1.5% on the fixture_7 geometry; 1.02 is
-    /// the tightest factor that the solver + interpolation residuals honestly allow.
     const CENTRIPETAL_RESIDUAL_FACTOR: f64 = 1.02;
 
     #[test]
@@ -697,8 +688,6 @@ mod fixture_7_curvature_spike_intergrid_sanity {
         );
     }
 
-    /// Piecewise-cubic Hermite interpolation of (v, a) solver samples at t ∈ [0,1].
-    /// Treats `sample.v` as function value and `sample.a` as its time-derivative.
     fn hermite_interp(samples: &[GridSample], t: f64) -> (f64, f64) {
         let n = samples.len();
         if n < 2 {

--- a/rust/temporal/tests/step9_cut_identity.rs
+++ b/rust/temporal/tests/step9_cut_identity.rs
@@ -164,9 +164,7 @@ fn row_sum_identity_pathological_paths() {
 
 #[test]
 fn row_sum_identity_holds_at_slp_b_floor() {
-    // The cut helper floors b̄[i] at SLP_B_FLOOR=1.0 before computing coefficients.
-    // The identity must hold at the FLOORED value — compute ground-truth with the
-    // same floor applied.
+    const SLP_B_FLOOR: f64 = 1.0;
     let mut b = synthetic_iterate().0;
     let a = synthetic_iterate().1;
     b[5] = 0.5;
@@ -176,7 +174,7 @@ fn row_sum_identity_holds_at_slp_b_floor() {
     let cppp = 0.2;
 
     let mut b_floored = b.clone();
-    b_floored[i] = b[i].max(1.0);
+    b_floored[i] = b[i].max(SLP_B_FLOOR);
     check_identity_at(&b_floored, &a, i, cp, cpp, cppp, "slp_b_floor");
 }
 

--- a/rust/temporal/tests/throughput_repro.rs
+++ b/rust/temporal/tests/throughput_repro.rs
@@ -1,17 +1,3 @@
-// Offline reproduction harness for the Pi5 planning-latency pathology:
-// "high entry velocity → many cold Clarabel invocations → SegmentLate".
-//
-// Algorithmic signature we are chasing (hardware-independent):
-//   - Clarabel call COUNT grows with entry velocity.
-//   - High-entry cases trigger SLP9 restoration and/or the Auto 1e-8 second pass.
-//   - trajectory total_time must NOT regress (NON-NEGOTIABLE).
-//   - Mac wall-clock numbers are for relative before/after only (~8-10x faster
-//     than Pi5; do not compare to the 867ms Pi5 number).
-//
-// The counter infrastructure lives in temporal::topp::solver::counters and is
-// gated on cfg(test) so it compiles only here.  Each test resets counters,
-// schedules one segment, then prints the table row.
-
 use std::time::Instant;
 
 use nurbs::VectorNurbs;
@@ -19,22 +5,7 @@ use temporal::{
     GridConfig, GridScheme, Limits, ToleranceMode, counters, schedule_segment_with_tolerance,
 };
 
-// ---------------------------------------------------------------------------
-// Shared fixture geometry and limits
-// ---------------------------------------------------------------------------
-
-/// A smooth ~46mm cubic Bézier with pronounced curvature — a deep S-bend that
-/// forces large c'' and c''' at all interior points, creating substantial
-/// axis-jerk violations that require many SLP9 outer iterations to linearize.
-///
-/// The "46mm G5 cubic at cruise velocity" from the Pi5 SegmentLate failure is
-/// reproduced by: significant curvature (non-zero c'', c'''), moderate v_max
-/// (so the trajectory actually runs near v_max), and tight axis-jerk limits
-/// (so SLP9 fires and back-tracks many times at high entry velocities).
 fn repro_curve() -> VectorNurbs<f64, 3> {
-    // An S-curve: P0 → P1 pulls hard in +Y, P2 pulls hard in −Y, ending at P3.
-    // This gives non-zero c'' throughout and a sign-change in c''' (the jerk
-    // projection changes sign), which is exactly what stresses SLP9 cuts.
     VectorNurbs::<f64, 3>::try_new(
         3,
         vec![0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
@@ -48,13 +19,6 @@ fn repro_curve() -> VectorNurbs<f64, 3> {
     .unwrap()
 }
 
-/// Limits that reproduce the pathology: moderate v_max (binding at cruise),
-/// high a_max (not binding), TIGHT j_max (binding — forces many SLP9 iters).
-///
-/// j_max = 50_000 mm/s³: tight enough that axis-jerk violations are substantial
-/// at cruise speed (v=300 mm/s, |j_axis| ≈ c''' * v³ ≈ large on an S-curve).
-/// The asymmetric Y jerk (tighter than X) mimics a Trident-class machine where
-/// Y has lower jerk budget due to heavier carriage.
 fn velocity_bound_limits() -> Limits {
     Limits::axis_boxes(
         [300.0, 300.0, 300.0],
@@ -63,8 +27,6 @@ fn velocity_bound_limits() -> Limits {
     )
 }
 
-/// Grid: 92 points ≈ 0.5mm spacing on a ~46mm arc; matches the adaptive grid
-/// that a real Pi5 run would produce for this segment length.
 fn repro_grid() -> GridConfig {
     GridConfig {
         scheme: GridScheme::UniformArclength,
@@ -73,10 +35,6 @@ fn repro_grid() -> GridConfig {
 }
 
 const V_MAX: f64 = 300.0;
-
-// ---------------------------------------------------------------------------
-// Single-segment velocity sweep
-// ---------------------------------------------------------------------------
 
 struct Row {
     v_entry_frac: f64,
@@ -97,10 +55,8 @@ fn schedule_one(v_start_frac: f64) -> Row {
     let limits = velocity_bound_limits();
     let grid = repro_grid();
     let v_start = v_start_frac * V_MAX;
-    // v_end = 0: forces full decel regardless of entry velocity.  This is the
-    // max-stress scenario — the solver must push speed as high as possible in
-    // the middle while respecting all jerk caps and decelerating to rest.
-    let v_end = 0.0;
+    let v_end_full_decel_to_rest = 0.0;
+    let v_end = v_end_full_decel_to_rest;
 
     counters::reset();
     let t0 = Instant::now();
@@ -176,14 +132,6 @@ fn velocity_sweep_single_segment() {
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Algorithmic-signature assertions (hardware-independent)
-    // -----------------------------------------------------------------------
-
-    // 1. The high-entry cases (0.75 and 0.95 * v_max) must produce more
-    //    Clarabel calls than the rest-to-rest case — the call count must grow
-    //    overall, even if it does not grow strictly monotone at each step
-    //    (some intermediate velocities may hit easier sub-problems).
     let counts: Vec<u32> = rows.iter().map(|r| r.clarabel_total).collect();
     let max_high_entry = counts[3].max(counts[4]);
     assert!(
@@ -193,8 +141,6 @@ fn velocity_sweep_single_segment() {
         counts[0],
     );
 
-    // 2. At least one of the high-entry cases must hit the pathology signature:
-    //    substantial Clarabel calls (≥ 10), or restoration, or auto second pass.
     let pathology_at_high_entry = rows[3..]
         .iter()
         .any(|r| r.clarabel_total >= 10 || r.restoration_fired || r.auto_second_pass);
@@ -210,7 +156,6 @@ fn velocity_sweep_single_segment() {
         rows[4].auto_second_pass,
     );
 
-    // 3. Trajectory total_time must be finite and positive for all entries.
     for r in &rows {
         assert!(
             r.total_time_ms.is_finite() && r.total_time_ms > 0.0,
@@ -220,14 +165,11 @@ fn velocity_sweep_single_segment() {
         );
     }
 
-    // 4. At the rest-to-rest entry (v_frac=0), the solver must produce a clean
-    //    solution (SolvedSlp, Solved, or SolvedInexact) — the easy case.
     assert!(
         rows[0].status_ok,
         "rest-to-rest (v_frac=0) must produce a solved status",
     );
 
-    // 5. Per-phase accounting must be consistent across all cases.
     for r in &rows {
         let accounted = r.path_jerk_calls + r.slp9_tr_calls + r.slp9_no_tr_calls;
         assert_eq!(
@@ -237,16 +179,6 @@ fn velocity_sweep_single_segment() {
         );
     }
 
-    // 6. NON-REGRESSION HARD GATE (Lever 3).
-    // CLAUDE.md non-negotiable: the planner never ships a measurably slower
-    // trajectory than the best we can compute. So the gate is one-sided — for
-    // EVERY entry velocity, the post-Lever-3 trajectory time must be ≤ the
-    // pre-Lever-3 baseline (within a tiny relative tolerance). No case may get
-    // slower. The 0.75 crawl must get strictly faster.
-    //
-    // PRE_LEVER3_BASELINE: committed Mac dev-build reference, captured before the
-    // seeding + speed-polish + fail-loud work. These are the numbers Lever 3 is
-    // measured against; they are NOT a both-sided target.
     const PRE_LEVER3_BASELINE_MS: [f64; 5] = [445.426, 406.920, 388.272, 998.769, 317.078];
     for (r, &base_ms) in rows.iter().zip(PRE_LEVER3_BASELINE_MS.iter()) {
         assert!(
@@ -259,11 +191,6 @@ fn velocity_sweep_single_segment() {
         );
     }
 
-    // 6a. Cases that never trigger seeding (0, 0.25, 0.50) converge without
-    // restoration and must stay byte-stable in trajectory time. They may take
-    // FEWER Clarabel calls (a free win from the wider initial trust region), but
-    // the converged time-optimal trajectory is a property of the problem, not the
-    // iteration path, so it is unchanged to within solver tolerance.
     for i in 0..3 {
         let rel =
             (rows[i].total_time_ms - PRE_LEVER3_BASELINE_MS[i]).abs() / PRE_LEVER3_BASELINE_MS[i];
@@ -283,21 +210,6 @@ fn velocity_sweep_single_segment() {
         );
     }
 
-    // 6b. The 0.75 crawl: seeding + recovery must make it strictly faster than
-    // the 998.8ms baseline (the throughput win), and it must land in the solved
-    // set (feasible). The fail-loud rule means the recovered, not-provably-SLP-
-    // optimal profile wears SolvedInexact rather than the SolvedSlp optimal
-    // badge — it must NOT be SolvedSlp.
-    //
-    // NOTE (honest): the aspirational target was ~360-450ms (in line with the
-    // 0.66-0.70 neighbors, which converge directly to ~370-440ms). The in-scope
-    // SLP linearization hits a hard descent cliff just above v_frac≈0.71: from
-    // the high-entry start it cannot reduce the entry-region axis-jerk ratio at
-    // all (accepted=0), and the feasible recovery seed only reaches the
-    // uniform-dilation feasible point at ~749ms. Closing that gap needs a
-    // warm-start / better SLP, which is explicitly out of scope here. So the
-    // gate we ENFORCE is the non-negotiable one (strictly faster than baseline,
-    // no regression, fail-loud), not the aspirational ~600ms number.
     assert!(
         rows[3].total_time_ms < PRE_LEVER3_BASELINE_MS[3],
         "v_frac=0.75 must be strictly faster than the 998.8ms crawl; got {:.3}ms",
@@ -315,9 +227,6 @@ fn velocity_sweep_single_segment() {
         rows[3].status_label,
     );
 
-    // 6c. FAIL-LOUD: the genuinely-infeasible 0.95 case (v_start=285mm/s on the
-    // tight-Y-jerk S-curve) must remain a NON-success. Seeding must not launder
-    // it into a fake Converged/SolvedSlp.
     assert!(
         !rows[4].status_ok,
         "v_frac=0.95 is geometrically infeasible and must stay a non-success; \
@@ -325,7 +234,6 @@ fn velocity_sweep_single_segment() {
         rows[4].status_label,
     );
 
-    // 8. Report pathology reproduction status (informational).
     let worst = rows.iter().max_by_key(|r| r.clarabel_total).unwrap();
     let pathology_reproduced = worst.clarabel_total >= 50
         || rows.iter().any(|r| r.restoration_fired)
@@ -351,10 +259,6 @@ fn velocity_sweep_single_segment() {
         );
     }
 }
-
-// ---------------------------------------------------------------------------
-// Per-phase breakdown at cruise entry (worst case)
-// ---------------------------------------------------------------------------
 
 #[test]
 fn cruise_entry_phase_breakdown() {
@@ -402,7 +306,6 @@ fn cruise_entry_phase_breakdown() {
     );
     eprintln!("  Mac wall_us          : {}", wall_us);
 
-    // Structural sanity: call totals must be consistent.
     let total_accounted = snap.clarabel_calls_path_jerk
         + snap.clarabel_calls_slp9_tr
         + snap.clarabel_calls_slp9_no_tr;
@@ -417,18 +320,10 @@ fn cruise_entry_phase_breakdown() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Chained plan_batch case: 5 smooth tangent-continuous cubics
-// ---------------------------------------------------------------------------
-
 #[test]
 fn chained_five_cubics_plan_batch() {
     use temporal::{BatchInput, GridStrategy, JoiningStatus, SegmentInput, plan_batch};
 
-    // Six S-curve cubics chained end-to-end (tangent-continuous at junctions).
-    // Each has the same shape as `repro_curve()` (alternating S/Z sign), so
-    // inner segments are solved at junction velocity near cruise — reproducing
-    // the "mid-stream segment at cruise velocity" Pi5 scenario.
     let segments_curves: Vec<VectorNurbs<f64, 3>> = (0..6)
         .map(|i| {
             let x0 = i as f64 * 46.0;
@@ -483,9 +378,6 @@ fn chained_five_cubics_plan_batch() {
     let wall_us = t0.elapsed().as_micros() as u64;
     let snap = counters::snapshot();
 
-    // NOTE: plan_batch always spawns worker threads (even with worker_threads=1).
-    // Thread-local counters on the test thread therefore show 0 — that is expected.
-    // The wall_us and per-profile status are the meaningful outputs here.
     eprintln!("\n=== throughput_repro: 6-cubic chain plan_batch ===");
     eprintln!(
         "  Total Clarabel calls : {} (0 = thread-local; spawned workers)",

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -122,10 +122,6 @@ pub struct ReplanWorstBinding {
 pub struct ReplanBindingSummary {
     pub histogram: Vec<(temporal::BindingConstraint, u32)>,
     pub worst: Option<ReplanWorstBinding>,
-    /// True when any segment in the window shipped a deadline-truncated profile,
-    /// i.e. the real-time budget — not convergence — ended refinement. This is
-    /// the authoritative `deadline_limited` signal, replacing the wall-clock
-    /// heuristic that misfired on slow-but-converged solves under host load.
     pub deadline_truncated: bool,
     pub peak_utilization: f64,
     pub peak_util_family: Option<crate::utilization::UtilFamily>,
@@ -325,16 +321,14 @@ fn beta_iterate_inner(
     })
 }
 
-/// In `WorstCaseFuture` mode the last XY segment's limit is halved: for a
-/// symmetric unit-DC kernel the past-only term must be ≤ 0.5·a_machine for
-/// the convolution bound to stay ≤ a_machine. Applied to the whole segment
-/// for simplicity; only the trailing-h region actually bites.
+const WORST_CASE_FUTURE_SYMMETRIC_KERNEL_DERATE: f64 = 0.5;
+
 fn effective_machine_a_max(machine_a_max: &[[f64; 3]], safety_mode: SafetyMode) -> Vec<[f64; 3]> {
     let mut effective = machine_a_max.to_vec();
     if matches!(safety_mode, SafetyMode::WorstCaseFuture) {
-        if let Some(last) = effective.last_mut() {
-            for axis in last.iter_mut() {
-                *axis *= 0.5;
+        if let Some(last_segment) = effective.last_mut() {
+            for axis in last_segment.iter_mut() {
+                *axis *= WORST_CASE_FUTURE_SYMMETRIC_KERNEL_DERATE;
             }
         }
     }

--- a/rust/trajectory/src/emit_shaped.rs
+++ b/rust/trajectory/src/emit_shaped.rs
@@ -16,7 +16,6 @@ const CONSTANT_AXIS_EPS: f64 = 1e-12;
 
 #[derive(Debug, Clone, Default)]
 pub struct PerAxisHistory<'a> {
-    /// Index = axis registry index; missing trailing axes mean no history.
     pub axes: Vec<&'a [BezierPiece<f64>]>,
 }
 
@@ -31,9 +30,6 @@ impl PerAxisHistory<'_> {
     }
 }
 
-/// Emission output: shaped per-segment tracks plus, per follower (parallel to
-/// `chains.followers`), the pre-gain input-track pieces — the follower's
-/// nominal position ledger over the batch.
 #[derive(Debug)]
 pub struct ShapeEmission {
     pub segments: Vec<ShapedSegment>,
@@ -66,14 +62,9 @@ pub fn emit_shaped(
     )
 }
 
-/// Pins each follower's nominal ledger to a committed value at time `t`:
-/// emitted follower tracks are shifted so the pre-gain ledger passes through
-/// `values[i]` at `t`. Regions before `t` are never re-dispatched, so drift
-/// from re-fitting them must not leak into the committed stream.
 #[derive(Debug, Clone, Copy)]
 pub struct FollowerAnchor<'a> {
     pub t: f64,
-    /// Parallel to `chains.followers`.
     pub values: &'a [f64],
 }
 
@@ -87,12 +78,6 @@ impl FollowerAnchor<'_> {
     }
 }
 
-/// Like [`emit_shaped`] but overrides the left-boundary slope for the FIRST
-/// segment's per-axis `fit_c2_cubic` call.  Passing the previous emission's
-/// right-boundary slope enforces C1 continuity across the dispatch seam.
-///
-/// `first_seg_left_bc` is indexed by axis registry index;
-/// missing trailing entries mean no override.
 #[allow(clippy::too_many_arguments)]
 pub fn emit_shaped_with_left_bc(
     planned: &[FittedSegment],

--- a/rust/trajectory/src/emit_shaped/tests.rs
+++ b/rust/trajectory/src/emit_shaped/tests.rs
@@ -262,12 +262,12 @@ fn pad_segment_axis_with_history_seam_reads_history_tail() {
         .find(|p| 0.8 >= p.u_start - 1e-12 && 0.8 <= p.u_end + 1e-12)
         .expect("padded curve should cover t = 0.8")
         .evaluate(0.8);
-    // With no history the left pad continues at the segment's entry velocity (slope 20 through
-    // position 10 at the t=1.0 seam) rather than holding the start position: at t=0.8 that is
-    // 10 + 20*(0.8 - 1.0) = 6.0.
+    let seam_position = 10.0;
+    let entry_velocity = 20.0;
+    let vel_extrapolated_at_08 = seam_position + entry_velocity * (0.8 - 1.0);
     assert!(
-        (val_08_no_history - 6.0).abs() < 1e-9,
-        "no-history path should extrapolate at entry velocity to 6.0 at t=0.8, got {val_08_no_history}",
+        (val_08_no_history - vel_extrapolated_at_08).abs() < 1e-9,
+        "no-history path should extrapolate at entry velocity to {vel_extrapolated_at_08} at t=0.8, got {val_08_no_history}",
     );
     assert!(
         (val_08 - val_08_no_history).abs() > 1.0,
@@ -310,15 +310,6 @@ fn empty_history_pad_matches_legacy() {
 
 #[test]
 fn constant_y_axis_emits_cubic_matching_moving_x_corexy_degree_invariant() {
-    // Regression: when the fitter produces a degree-5 FittedSegment and Y is
-    // bitwise-constant, emit_shaped returned the fitter's native degree-5 curve
-    // for Y while fitting X to degree-3 via fit_c2_cubic. The degree mismatch
-    // caused add_with_knot_union to return KnotMismatch and panicked at
-    // motion-engine/src/enqueue.rs:30 on any CoreXY dispatch.
-    //
-    // Trigger condition: pure-X jogs queued back-to-back while the first is
-    // in flight; the terminal-decel splice rebuilds Y as bitwise-constant.
-
     let x_composed: Vec<[BezierPiece<f64>; 3]> = (0..4)
         .map(|i| {
             let s = f64::from(i);

--- a/rust/trajectory/src/fit.rs
+++ b/rust/trajectory/src/fit.rs
@@ -3,15 +3,15 @@ use nurbs::ScalarNurbs;
 
 const HERMITE_REFIT_MAX_SUBDIVISIONS: usize = 8;
 const MIN_HERMITE_PIECE_DURATION: f64 = 1e-12;
+const PHASE1_HERMITE_DEGREE: u8 = 4;
+const PHASE2_BOTH_ENDS_PINNED_HERMITE_DEGREE: u8 = 5;
+const LAST_PIECE_TIME_MATCH_EPSILON: f64 = 1e-12;
 
 #[derive(Debug, Clone)]
 pub struct FittedSegment {
     pub axes: [ScalarNurbs<f64>; 3],
     pub t_start: f64,
     pub t_end: f64,
-    /// Planned path progress `s(t)` for a follower-only (virtual-path)
-    /// segment. The spatial axes are zero-displacement constants; followers
-    /// pay out `start + ratio·s(t)` from this track instead of the odometer.
     pub virtual_s_of_t: Option<ScalarNurbs<f64>>,
 }
 
@@ -43,18 +43,14 @@ pub fn fit_and_split(
             }
         })?;
 
-    // Normalize all axes to a uniform degree (the max across all pieces on any
-    // axis).  Phase-2 re-fitting produces degree-5 pieces for the last output
-    // piece while Phase-1 produces degree-4 for the others; `bezier_pieces_to_nurbs`
-    // requires a uniform degree throughout.
-    let max_degree = fitted
+    let uniform_degree_required_by_bezier_pieces_to_nurbs = fitted
         .iter()
         .flat_map(|axis_pieces| axis_pieces.iter().map(|p| p.coeffs.len().saturating_sub(1)))
         .max()
-        .unwrap_or(4);
+        .unwrap_or(usize::from(PHASE1_HERMITE_DEGREE));
     for axis_pieces in fitted.iter_mut() {
         for piece in axis_pieces.iter_mut() {
-            while piece.coeffs.len() <= max_degree {
+            while piece.coeffs.len() <= uniform_degree_required_by_bezier_pieces_to_nurbs {
                 piece.coeffs.push(0.0);
             }
         }
@@ -123,14 +119,18 @@ fn fit_hermite_c2_adaptive(
 ) -> Result<[Vec<BezierPiece<f64>>; 3], nurbs::algebra::FitError> {
     use nurbs::algebra::{fit_hermite_c1_clamped, FitError};
 
-    // Phase 1: run the original start-pin-only fit (degree-4) to get a
-    // well-behaved velocity profile.  This is unchanged from the prior
-    // single-pin implementation.
     let mut refined = composed.to_vec();
     let mut fitted: [Vec<BezierPiece<f64>>; 3] = std::array::from_fn(|_| Vec::new());
 
     for depth in 0..=HERMITE_REFIT_MAX_SUBDIVISIONS {
-        match fit_hermite_c1_clamped::<3>(&refined, tolerance, 4, Some(d2_start), None) {
+        let phase1_start_pin_only = None;
+        match fit_hermite_c1_clamped::<3>(
+            &refined,
+            tolerance,
+            PHASE1_HERMITE_DEGREE,
+            Some(d2_start),
+            phase1_start_pin_only,
+        ) {
             Ok(f) => {
                 fitted = f;
                 break;
@@ -145,9 +145,6 @@ fn fit_hermite_c2_adaptive(
         }
     }
 
-    // Phase 2: re-fit the last output piece with the end-accel pin added.
-    // We operate on the same `refined` array used by Phase 1 and locate the
-    // composed pieces that were merged into the last output piece.
     refit_last_piece_with_end_pin(&mut fitted, &refined, tolerance, d2_end)?;
 
     Ok(fitted)
@@ -161,18 +158,15 @@ fn refit_last_piece_with_end_pin(
 ) -> Result<(), nurbs::algebra::FitError> {
     use nurbs::algebra::{fit_hermite_c1_clamped, FitError};
 
-    // Find the time range of the last Phase-1 output piece (axis 0 is
-    // representative; all axes have pieces over the same time domain).
-    let last_out_start = match fitted[0].last() {
+    let representative_axis = 0;
+    let last_out_start = match fitted[representative_axis].last() {
         Some(p) => p.u_start,
         None => return Ok(()),
     };
 
-    // Collect the refined composed pieces that were folded into the last output
-    // piece: those whose time range falls within [last_out_start, global_end].
     let last_refined: Vec<[BezierPiece<f64>; 3]> = refined
         .iter()
-        .filter(|ps| ps[0].u_start >= last_out_start - 1e-12)
+        .filter(|ps| ps[0].u_start >= last_out_start - LAST_PIECE_TIME_MATCH_EPSILON)
         .cloned()
         .collect();
 
@@ -180,9 +174,6 @@ fn refit_last_piece_with_end_pin(
         return Ok(());
     }
 
-    // The start accel pin for Phase 2 is the composed accel at last_out_start
-    // (read from the first last-range composed piece) so that the new last
-    // piece is C2 with the preceding Phase-1 piece on its left side as well.
     let last_d2_start: [f64; 3] = std::array::from_fn(|axis| {
         let piece = &last_refined[0][axis];
         piece
@@ -191,11 +182,6 @@ fn refit_last_piece_with_end_pin(
             .evaluate(piece.u_start)
     });
 
-    // Re-fit the last piece range with BOTH accel pins at degree-5. degree-5
-    // is required because the both-ends pin (start + end accel) imposes 6
-    // constraints that exactly determine a degree-5 polynomial; a single
-    // both-pinned piece is numerically well-behaved for the short time span
-    // covered by the last output piece.
     let mut refined_last = last_refined;
     let mut last_fitted: Option<[Vec<BezierPiece<f64>>; 3]> = None;
 
@@ -203,7 +189,7 @@ fn refit_last_piece_with_end_pin(
         match fit_hermite_c1_clamped::<3>(
             &refined_last,
             tolerance,
-            5,
+            PHASE2_BOTH_ENDS_PINNED_HERMITE_DEGREE,
             Some(last_d2_start),
             Some(d2_end),
         ) {
@@ -223,9 +209,8 @@ fn refit_last_piece_with_end_pin(
 
     if let Some(new_last) = last_fitted {
         for axis in 0..3 {
-            // Remove the Phase-1 last piece (degree-4, end-free).
-            fitted[axis].pop();
-            // Append the re-fitted last piece(s) (degree-5, end pinned).
+            let phase1_last_piece_end_free = fitted[axis].pop();
+            debug_assert!(phase1_last_piece_end_free.is_some());
             fitted[axis].extend(new_last[axis].iter().cloned());
         }
     }

--- a/rust/trajectory/src/fit/tests.rs
+++ b/rust/trajectory/src/fit/tests.rs
@@ -190,10 +190,6 @@ fn fit_and_split_reduces_piece_count() {
 
 #[test]
 fn fit_and_split_start_d2_matches_composed_input() {
-    // Verify that fit_and_split pins the output's 2nd derivative at the global
-    // start to match the composed input's start 2nd derivative.
-    // Source: x(t) = 0.5*t², y(t) = t, z(t) = 0 on [0, 2].
-    // x''(0) = 1 (constant curvature); y''(0) = 0.
     let composed: Vec<[BezierPiece<f64>; 3]> = (0..2)
         .map(|i| {
             let s = f64::from(i);
@@ -238,11 +234,6 @@ fn fit_and_split_start_d2_matches_composed_input() {
 
 #[test]
 fn fit_and_split_end_d2_matches_composed_input() {
-    // Symmetric to the start-pin test: fit_and_split must also pin the output's
-    // 2nd derivative at the global end to match the composed input's end d2.
-    // Source: x(t) = 50*t² on [0, 1] followed by [1, 2].
-    // Pascal-shifted at s: coeffs = [50*s², 100*s, 50].
-    // x''(t) = 100 everywhere; composed end d2 = 100.
     let a = 50.0_f64;
     let composed: Vec<[BezierPiece<f64>; 3]> = (0..2)
         .map(|i| {
@@ -290,15 +281,6 @@ fn fit_and_split_end_d2_matches_composed_input() {
 
 #[test]
 fn fit_and_split_junction_c2_continuity() {
-    // Fused 2-segment accelerating chain.  Both segments represent uniform
-    // acceleration (x'' = 100 everywhere) so the SOCP boundary condition makes
-    // the composed d2 equal on both sides of the junction.  After fitting each
-    // segment independently through fit_and_split, the fitted end d2 of seg0
-    // must equal the fitted start d2 of seg1.
-    //
-    // Seg0: x(t) = 50*t² on [0, 1].  Pascal-shifted: [0, 0, 50].
-    // Seg1: x(t) = 50 + 100*(t-1) + 50*(t-1)² on [1, 2].
-    //        Pascal-shifted at 1: [50, 100, 50].
     let a = 50.0_f64;
     let seg0: Vec<[BezierPiece<f64>; 3]> = vec![[
         BezierPiece {
@@ -361,23 +343,9 @@ fn fit_and_split_junction_c2_continuity() {
 
 #[test]
 fn junction_accel_step_before_vs_after_both_pin() {
-    // Honest measurement: how much does the junction acceleration gap shrink
-    // when the end-accel pin is added?
-    //
-    // Geometry: a degree-6 x-axis composed piece (sin approximation) whose
-    // 2nd derivative at the end is NOT zero.  A degree-4 start-only fit cannot
-    // reproduce the end curvature exactly; the end d2 will drift.  The
-    // both-pin fit (fit_and_split) must nail the end d2 to the composed value.
-    //
-    // Source curve: f(t) = sin(t) on [0, π/3].  f''(π/3) = -sin(π/3) ≈ −0.866.
-    // We represent it with a degree-6 Pascal-shifted polynomial computed from
-    // the Taylor expansion at t=0.  The position error of this truncated series
-    // is small over [0, π/3] but nonzero, giving the fitter genuine work to do.
     use nurbs::algebra::fit_hermite_c1_clamped;
 
     let t_end = std::f64::consts::PI / 3.0;
-    // Taylor coefficients of sin(t) at 0: t - t^3/6 + t^5/120 - t^7/5040
-    // Pascal-shifted at 0 these are the raw coefficients:
     let sin_coeffs = vec![
         0.0_f64,     // c0 = sin(0)
         1.0,         // c1 = cos(0)
@@ -415,8 +383,6 @@ fn junction_accel_step_before_vs_after_both_pin() {
         p.differentiate().differentiate().evaluate(p.u_end)
     };
 
-    // "Before": start-pin-only fit at degree-4.  The fitter is free to choose
-    // any end d2 it likes in order to minimise position residual.
     let before_fit =
         fit_hermite_c1_clamped::<3>(&composed_seg0, 0.005, 4, Some(composed_d2_start), None)
             .unwrap();
@@ -425,7 +391,6 @@ fn junction_accel_step_before_vs_after_both_pin() {
         p.differentiate().differentiate().evaluate(p.u_end)
     };
 
-    // "After": both pins via fit_and_split.
     let after_fit = fit_and_split(&composed_seg0, 0.005, None).unwrap();
     let after_pieces = nurbs::bezier::extract_bezier_pieces(&after_fit.axes[0]);
     let after_end_d2 = {
@@ -436,12 +401,10 @@ fn junction_accel_step_before_vs_after_both_pin() {
     let gap_before = (before_end_d2 - composed_d2_end).abs();
     let gap_after = (after_end_d2 - composed_d2_end).abs();
 
-    // After must nail the end accel to the composed value.
     assert!(
         gap_after < 1e-4,
         "After both-pin fit: end d2 gap={gap_after:.6e} (expected < 1e-4)"
     );
-    // Before must show a larger gap (demonstrating the improvement).
     assert!(
         gap_before > gap_after,
         "Before gap ({gap_before:.6}) should exceed after gap ({gap_after:.6e}); \

--- a/rust/trajectory/src/kernel.rs
+++ b/rust/trajectory/src/kernel.rs
@@ -1,14 +1,9 @@
 use nurbs::algebra::PiecewisePolynomialKernel;
 
-// inline(never): per-call-site float codegen produced last-ulp coefficient
-// differences between kernels built in tests vs beta_loop; one body keeps
-// kernel construction bit-identical everywhere.
 #[inline(never)]
 fn build_bell_kernel(t_sm: f64) -> PiecewisePolynomialKernel<f64> {
     let h = t_sm / 2.0;
     let c = 15.0 / (16.0 * h.powi(5));
-    // w(t) = c·(h² − t²)² = c·h⁴ − 2c·h²·t² + c·t⁴
-    // Absolute monomial basis: coeffs[k] is the coefficient of t^k.
     let coeffs = vec![
         c * h.powi(4),    // t^0
         0.0,              // t^1

--- a/rust/trajectory/src/kernel/tests.rs
+++ b/rust/trajectory/src/kernel/tests.rs
@@ -57,9 +57,18 @@ fn kernel_derivative_vanishes_at_boundaries() {
     let kernel = build_smooth_zv_kernel(0.8025 / 150.0);
     let (lo, hi) = kernel.support();
     let dk = kernel.pieces[0].differentiate();
-    // hi: large-magnitude terms cancel at s=2h, so float error ≈ 1e-8, not 1e-12.
-    assert!(dk.evaluate(lo).abs() < 1e-10, "lo = {}", dk.evaluate(lo));
-    assert!(dk.evaluate(hi).abs() < 1e-8, "hi = {}", dk.evaluate(hi));
+    let lo_tolerance = 1e-10;
+    let hi_tolerance_after_cancellation_at_2h = 1e-8;
+    assert!(
+        dk.evaluate(lo).abs() < lo_tolerance,
+        "lo = {}",
+        dk.evaluate(lo)
+    );
+    assert!(
+        dk.evaluate(hi).abs() < hi_tolerance_after_cancellation_at_2h,
+        "hi = {}",
+        dk.evaluate(hi)
+    );
 }
 
 #[test]

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -25,12 +25,8 @@ pub use streaming::ReplanReport;
 #[derive(Debug)]
 pub struct ShapeBatchInput<'a> {
     pub segments: &'a [ShapeSegmentInput<'a>],
-    /// Per-axis post-processor chains — the single source for solver shaping,
-    /// PA gains, and emission.
     pub chains: &'a AxisChainSet,
-    /// Physical start position per follower, parallel to `chains.followers`.
     pub follower_start: &'a [f64],
-    /// Realized pre-batch per-axis velocity for the shaper window's left edge.
     pub follower_history: Option<&'a temporal::FollowerHistory>,
     pub grid_strategy: temporal::multi::GridStrategy,
     pub worker_threads: usize,
@@ -40,11 +36,6 @@ pub struct ShapeBatchInput<'a> {
     pub initial_v: f64,
     pub initial_a: f64,
     pub terminal_v: f64,
-    /// Axis-wise second derivatives `[d²x/dt², d²y/dt², d²z/dt²]` to pin at the
-    /// very first sample of the very first fitted segment. `None` uses the composed
-    /// polynomial's own boundary curvature. Set by the streaming state to the
-    /// old plan's derivatives at `t_dispatched` so the new plan achieves exact C2
-    /// continuity at the replan boundary.
     pub start_d2_override: Option<[f64; 3]>,
 }
 
@@ -71,7 +62,6 @@ pub struct BetaWarning {
 
 #[derive(Debug, Clone)]
 pub struct ShapedSegment {
-    /// Index = axis registry index: 0..3 spatial, 3.. followers. Always ≥ 3.
     pub axes: Vec<nurbs::ScalarNurbs<f64>>,
     pub followers: Vec<geometry::segment::FollowerDemand>,
     pub t_start: f64,

--- a/rust/trajectory/src/pad/tests.rs
+++ b/rust/trajectory/src/pad/tests.rs
@@ -53,9 +53,6 @@ fn pad_single_segment_extends_left_by_velocity_right_by_constant() {
         pieces.last().unwrap().u_end
     );
 
-    // The left pad is a constant-velocity continuation of the entry motion (slope 10 through
-    // position 0 at the t=0 seam), NOT a constant-position hold: holding position injects a
-    // phantom velocity step that the shaper convolves into a spurious acceleration spike.
     let left = &pieces[0];
     assert!(
         left.evaluate(0.0).abs() < 1e-9,
@@ -68,7 +65,6 @@ fn pad_single_segment_extends_left_by_velocity_right_by_constant() {
         "left pad must continue at the entry velocity 10, got slope {left_slope}",
     );
 
-    // The trailing edge faces an unknown future, so it still holds the end position constant.
     let right_val = pieces
         .last()
         .unwrap()

--- a/rust/trajectory/src/plan_velocity.rs
+++ b/rust/trajectory/src/plan_velocity.rs
@@ -7,9 +7,6 @@ pub use crate::beta::{PlanOutput, PlanStats};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SafetyMode {
     TerminalKnown,
-    /// Streaming case: the terminal velocity is speculative (decel-to-zero default).
-    /// β-medium derates against the worst-case-future bound by tightening the
-    /// effective machine accel limit on the trailing region.
     WorstCaseFuture,
 }
 
@@ -25,7 +22,6 @@ pub struct PlanInput<'a> {
     pub segments: &'a [PlanSegment<'a>],
     pub grid_strategy: temporal::multi::GridStrategy,
     pub worker_threads: usize,
-    /// Per-axis post-processor chains — single source for solver shaping and PA.
     pub chains: &'a AxisChainSet,
     pub fit_tolerance_mm: f64,
     pub beta_max_iters: u8,
@@ -35,18 +31,9 @@ pub struct PlanInput<'a> {
     pub terminal_v: f64,
     pub safety_mode: SafetyMode,
     pub follower_history: Option<&'a temporal::FollowerHistory>,
-    /// Axis-wise second derivatives to pin at the first sample of the first fitted
-    /// segment. Forwarded verbatim to [`ShapeBatchInput::start_d2_override`].
     pub start_d2_override: Option<[f64; 3]>,
 }
 
-///
-/// # Errors
-///
-/// - [`ShapeError::EmptySegments`] — `input.segments` is empty.
-/// - [`ShapeError::UnsupportedBoundaryVelocity`] — `initial_v` or `terminal_v` is non-finite or negative.
-/// - [`ShapeError::UnsupportedBoundaryAccel`] — `initial_a` is non-finite, or non-zero when `initial_v` is 0.0.
-/// - Any error from the underlying β-medium loop.
 pub fn plan_velocity(input: &PlanInput<'_>) -> Result<PlanOutput, ShapeError> {
     if input.segments.is_empty() {
         return Err(ShapeError::EmptySegments);

--- a/rust/trajectory/src/post_processor.rs
+++ b/rust/trajectory/src/post_processor.rs
@@ -13,7 +13,6 @@ pub enum PostProcessorType {
 }
 
 impl PostProcessorType {
-    /// Single-instance chain — the common test/config shorthand.
     #[must_use]
     pub fn into_chain(self) -> CompiledChain {
         CompiledChain::compile(&[PostProcessorInstance::new("inline", self)])
@@ -147,9 +146,7 @@ impl CompiledChain {
 
 #[derive(Debug, Clone, Default)]
 pub struct AxisChainSet {
-    /// Index = axis registry index; spatial 0..3 then followers.
     pub chains: Vec<CompiledChain>,
-    /// `(follower_axis_index, followed_axis_indices)` — from the axis registry.
     pub followers: Vec<(usize, Vec<usize>)>,
 }
 
@@ -170,8 +167,6 @@ impl AxisChainSet {
         }
     }
 
-    /// Legacy bridge: spatial-only chain set from the `[X, Y, Z, E]` kernel
-    /// array. The E slot must be empty — followers carry their own chains.
     #[must_use]
     pub fn spatial_from_kernels(kernels: &[Option<PiecewisePolynomialKernel<f64>>; 4]) -> Self {
         assert!(

--- a/rust/trajectory/src/reparam.rs
+++ b/rust/trajectory/src/reparam.rs
@@ -1,22 +1,15 @@
 use nurbs::bezier::BezierPiece;
 use nurbs::VectorNurbs;
 
-/// Velocity threshold below which a grid interval is treated as near-zero
-/// (constant-position). Both endpoints must be below this threshold.
 const NEAR_ZERO_V: f64 = 0.01;
 
-/// Arc-length table accuracy for the s→u inversion (built once per segment).
 pub(crate) const ARC_TABLE_TOL: f64 = 1e-9;
 pub(crate) const ARC_TABLE_SAMPLES: usize = 16384;
-/// |x'(u)| (mm per unit u) below this is a cusp — not a smooth segment.
 const TANGENT_SPEED_FLOOR: f64 = 1e-6;
-/// Per-piece time-domain position fit: degree and accuracy gate (geometry budget,
-/// far below the 5 µm user fit_tolerance_mm).
 const POS_FIT_DEGREE: usize = 9;
 const POS_FIT_TOL_MM: f64 = 1e-6;
 const POS_FIT_MAX_SUBDIV: usize = 8;
 
-/// 5-point Gauss-Legendre nodes on [-1, 1].
 const GL5_NODES: [f64; 5] = [
     -0.906_179_845_938_664,
     -0.538_469_310_105_683_1,
@@ -24,7 +17,6 @@ const GL5_NODES: [f64; 5] = [
     0.538_469_310_105_683_1,
     0.906_179_845_938_664,
 ];
-/// 5-point Gauss-Legendre weights.
 const GL5_WEIGHTS: [f64; 5] = [
     0.236_926_885_056_189_1,
     0.478_628_670_499_366_5,
@@ -33,9 +25,6 @@ const GL5_WEIGHTS: [f64; 5] = [
     0.236_926_885_056_189_1,
 ];
 
-/// Arc length from 0 to `u`: the bracketing table node's stored arc length
-/// (accurate to the table build tolerance) plus one 5-point GL integration
-/// over the short residual interval `[u_node, u]`. O(5) curve evals.
 fn arc_length_to_u(
     table: &nurbs::ArcLengthTableRef<'_, f64>,
     deriv: &VectorNurbs<f64, 3>,
@@ -64,9 +53,6 @@ fn arc_length_to_u(
     s_node + seg * half
 }
 
-/// Invert arc length `s` to curve parameter `u`: seed from the table, then two
-/// Newton steps using O(1) arc-length via table node + local GL residual.
-/// Returns `ZeroTangent` at a cusp.
 fn invert_s_to_u(
     table: &nurbs::ArcLengthTableRef<'_, f64>,
     deriv: &VectorNurbs<f64, 3>,
@@ -91,9 +77,6 @@ fn invert_s_to_u(
     Ok(u)
 }
 
-/// Solve for power-basis coefficients c[k] of p(x) = Σ c[k] (x - origin)^k that
-/// interpolate (nodes[i], vals[i]). Square system (len == degree+1), Gaussian
-/// elimination with partial pivoting. Nodes must be distinct.
 fn solve_power_basis(nodes: &[f64], vals: &[f64], origin: f64) -> Vec<f64> {
     let n = nodes.len();
     let mut a = vec![vec![0.0_f64; n + 1]; n];
@@ -128,9 +111,6 @@ fn solve_power_basis(nodes: &[f64], vals: &[f64], origin: f64) -> Vec<f64> {
     (0..n).map(|k| a[k][n] / a[k][k]).collect()
 }
 
-/// Fit position-over-time x(t) by sampling the EXACT curve at the inverted
-/// parameter. Bisects the time interval on residual miss. Returns one or more
-/// contiguous [x,y,z] power-basis pieces over s_of_t's time domain.
 fn fit_position_of_t(
     curve: &VectorNurbs<f64, 3>,
     deriv: &VectorNurbs<f64, 3>,

--- a/rust/trajectory/src/reparam/tests.rs
+++ b/rust/trajectory/src/reparam/tests.rs
@@ -353,7 +353,6 @@ fn fit_position_of_t_tracks_exact_curve() {
     let tv = table.as_view();
     let s_max = tv.s_max();
 
-    // Constant-speed s(t) = s_max * t over t in [0,1] (one piece).
     let s_of_t = nurbs::bezier::BezierPiece {
         u_start: 0.0,
         u_end: 1.0,

--- a/rust/trajectory/src/smooth_fit.rs
+++ b/rust/trajectory/src/smooth_fit.rs
@@ -1,28 +1,21 @@
 use nurbs::bezier::BezierPiece;
 
-/// Clamped interpolating cubic spline through `knots` (strictly increasing,
-/// len m+1 >= 2) with values `y`, matching first derivative `yp0` at the start
-/// and `ypn` at the end. Returns `m` cubic `BezierPiece`s in local monomial
-/// basis. C2-continuous across interior joints by construction.
 fn build_clamped_spline(knots: &[f64], y: &[f64], yp0: f64, ypn: f64) -> Vec<BezierPiece<f64>> {
     let m = knots.len() - 1;
     debug_assert!(m >= 1 && y.len() == knots.len());
 
     let h: Vec<f64> = (0..m).map(|i| knots[i + 1] - knots[i]).collect();
 
-    // Solve for second derivatives M[0..=m] (clamped boundary conditions).
     let n = m + 1;
-    let mut a = vec![0.0; n]; // sub-diagonal
-    let mut b = vec![0.0; n]; // diagonal
-    let mut c = vec![0.0; n]; // super-diagonal
-    let mut d = vec![0.0; n]; // rhs
+    let mut a = vec![0.0; n];
+    let mut b = vec![0.0; n];
+    let mut c = vec![0.0; n];
+    let mut d = vec![0.0; n];
 
-    // Start clamped: 2 h0 M0 + h0 M1 = 6((y1-y0)/h0 - yp0)
     b[0] = 2.0 * h[0];
     c[0] = h[0];
     d[0] = 6.0 * ((y[1] - y[0]) / h[0] - yp0);
 
-    // Interior i=1..m-1: h[i-1] M[i-1] + 2(h[i-1]+h[i]) M[i] + h[i] M[i+1] = rhs
     for i in 1..m {
         a[i] = h[i - 1];
         b[i] = 2.0 * (h[i - 1] + h[i]);
@@ -30,31 +23,30 @@ fn build_clamped_spline(knots: &[f64], y: &[f64], yp0: f64, ypn: f64) -> Vec<Bez
         d[i] = 6.0 * ((y[i + 1] - y[i]) / h[i] - (y[i] - y[i - 1]) / h[i - 1]);
     }
 
-    // End clamped: h[m-1] M[m-1] + 2 h[m-1] M[m] = 6(ypn - (ym - y[m-1])/h[m-1])
     a[m] = h[m - 1];
     b[m] = 2.0 * h[m - 1];
     d[m] = 6.0 * (ypn - (y[m] - y[m - 1]) / h[m - 1]);
 
-    let mm = solve_tridiagonal(&a, &b, &c, &d);
+    let second_deriv = solve_tridiagonal(&a, &b, &c, &d);
 
-    // Build each cubic piece in local monomial basis (x = t - knots[i]):
-    //   S_i(x) = y_i + b_i x + (M_i/2) x^2 + ((M_{i+1}-M_i)/(6 h_i)) x^3
-    //   b_i = (y_{i+1}-y_i)/h_i - h_i (2 M_i + M_{i+1})/6
     (0..m)
         .map(|i| {
-            let bi = (y[i + 1] - y[i]) / h[i] - h[i] * (2.0 * mm[i] + mm[i + 1]) / 6.0;
+            let slope = (y[i + 1] - y[i]) / h[i]
+                - h[i] * (2.0 * second_deriv[i] + second_deriv[i + 1]) / 6.0;
             BezierPiece {
                 u_start: knots[i],
                 u_end: knots[i + 1],
-                coeffs: vec![y[i], bi, mm[i] / 2.0, (mm[i + 1] - mm[i]) / (6.0 * h[i])],
+                coeffs: vec![
+                    y[i],
+                    slope,
+                    second_deriv[i] / 2.0,
+                    (second_deriv[i + 1] - second_deriv[i]) / (6.0 * h[i]),
+                ],
             }
         })
         .collect()
 }
 
-/// Thomas algorithm for a tridiagonal system. `a` is the sub-diagonal
-/// (a[0] ignored), `b` the diagonal, `c` the super-diagonal (c[n-1] ignored),
-/// `d` the right-hand side. Returns the solution vector.
 fn solve_tridiagonal(a: &[f64], b: &[f64], c: &[f64], d: &[f64]) -> Vec<f64> {
     let n = b.len();
     debug_assert!(n > 0 && a.len() == n && c.len() == n && d.len() == n);
@@ -86,11 +78,6 @@ pub struct FitError {
     pub achieved_mm: f64,
 }
 
-/// Adaptive clamped C2 cubic-spline fit of `f` on `[t_start, t_end]` to
-/// `tolerance`. Knots are inserted at the worst-error location until the max
-/// deviation (sampled within intervals) is within tolerance. End slopes are
-/// taken from finite differences of `f`. Fails loudly if `MAX_KNOTS` is
-/// exhausted before tolerance is met.
 pub fn fit_c2_cubic<F: Fn(f64) -> f64>(
     f: &F,
     t_start: f64,
@@ -100,14 +87,6 @@ pub fn fit_c2_cubic<F: Fn(f64) -> f64>(
     fit_c2_cubic_with_bc(f, t_start, t_end, tolerance, None, None)
 }
 
-/// Like [`fit_c2_cubic`] but pins the left boundary slope to `yp0_override`
-/// and/or the right boundary slope to `ypn_override` when those are `Some`.
-/// The caller must supply the exact slope value; `None` falls back to a
-/// finite-difference estimate from `f`.
-///
-/// Providing a matching left slope to a subsequent fit at the same point
-/// enforces C1 continuity at the join, eliminating dispatch-stream velocity
-/// seams at replan boundaries.
 pub fn fit_c2_cubic_with_bc<F: Fn(f64) -> f64>(
     f: &F,
     t_start: f64,

--- a/rust/trajectory/src/smooth_fit/tests.rs
+++ b/rust/trajectory/src/smooth_fit/tests.rs
@@ -40,15 +40,11 @@ fn duplicate_knot_guard_no_panic_finite_error() {
 
 #[test]
 fn thomas_solves_known_system() {
-    // Tridiagonal system:
-    // [ 2 1 0 ] [x0]   [3]
-    // [ 1 2 1 ] [x1] = [4]   -> solution x = [1, 1, 1]
-    // [ 0 1 2 ] [x2]   [3]
-    let a = [0.0, 1.0, 1.0]; // sub-diagonal (a[0] unused)
-    let b = [2.0, 2.0, 2.0]; // diagonal
-    let c = [1.0, 1.0, 0.0]; // super-diagonal (c[n-1] unused)
-    let d = [3.0, 4.0, 3.0];
-    let x = solve_tridiagonal(&a, &b, &c, &d);
+    let sub_diagonal = [0.0, 1.0, 1.0];
+    let diagonal = [2.0, 2.0, 2.0];
+    let super_diagonal = [1.0, 1.0, 0.0];
+    let rhs = [3.0, 4.0, 3.0];
+    let x = solve_tridiagonal(&sub_diagonal, &diagonal, &super_diagonal, &rhs);
     for xi in &x {
         assert!((xi - 1.0).abs() < 1e-12, "x = {x:?}");
     }
@@ -56,7 +52,6 @@ fn thomas_solves_known_system() {
 
 #[test]
 fn clamped_spline_interpolates_and_is_c2() {
-    // Fit f(t) = sin(t) on [0, PI] with 5 equal knots, clamped to f'=cos at ends.
     let knots: Vec<f64> = (0..5)
         .map(|i| std::f64::consts::PI * i as f64 / 4.0)
         .collect();
@@ -67,12 +62,10 @@ fn clamped_spline_interpolates_and_is_c2() {
 
     assert_eq!(pieces.len(), 4);
 
-    // Interpolation: each piece hits its endpoint knot values.
     for (i, p) in pieces.iter().enumerate() {
         assert!((p.evaluate(knots[i]) - values[i]).abs() < 1e-12);
         assert!((p.evaluate(knots[i + 1]) - values[i + 1]).abs() < 1e-12);
     }
-    // C2: 2nd derivative continuous across interior joints.
     for i in 0..pieces.len() - 1 {
         let left = pieces[i].differentiate().differentiate();
         let right = pieces[i + 1].differentiate().differentiate();
@@ -89,12 +82,10 @@ use nurbs::eval::eval;
 
 #[test]
 fn fit_c2_cubic_matches_smooth_fn_with_few_pieces() {
-    // Target: a smooth bump on [0, 1]. Fit to 0.1 um tolerance.
     let f = |t: f64| (3.0 * t).sin() * (1.0 - t) * t;
     let tol = 1e-4;
     let curve = fit_c2_cubic(&f, 0.0, 1.0, tol).expect("fit succeeds");
 
-    // Accuracy sampled densely WITHIN pieces (not just at knots).
     for i in 0..=2000 {
         let t = i as f64 / 2000.0;
         assert!(
@@ -102,7 +93,6 @@ fn fit_c2_cubic_matches_smooth_fn_with_few_pieces() {
             "error at t={t}",
         );
     }
-    // Compactness: a smooth bump needs few pieces, nowhere near hundreds.
     let n = extract_bezier_pieces(&curve).len();
     assert!(n < 40, "expected few pieces, got {n}");
 }

--- a/rust/trajectory/src/streaming/emit.rs
+++ b/rust/trajectory/src/streaming/emit.rs
@@ -8,24 +8,6 @@ use crate::ShapedSegment;
 const T_EPSILON: f64 = 1e-12;
 
 impl ShaperState {
-    /// Produce shaped output for the dispatch-eligible region `[t_dispatched,
-    /// t_decel_start − max_h]`, advance `t_dispatched`, and trim old per-axis history.
-    ///
-    /// The method maintains a `pending_freeze` buffer: after each successful emission,
-    /// the shaped output for the kernel-support window immediately after the new
-    /// `t_dispatched` is stored.  On the next call (whether or not a replan occurred),
-    /// this buffer is dispatched first so the MCU receives a bit-identical signal for
-    /// the overlap region — preventing the velocity seam that would otherwise arise from
-    /// re-fitting the frozen zone over a shorter domain.
-    ///
-    /// Returns an empty vector when `target ≤ t_dispatched` (nothing newly
-    /// eligible, including fresh state before any `append_and_replan`).
-    ///
-    /// On error the state is left unchanged so the caller can re-attempt.
-    ///
-    /// # Errors
-    ///
-    /// Forwards any [`ShapeError`] from [`emit_shaped`].
     pub fn emit_committed(
         &mut self,
         ctx: &EmitContext<'_>,
@@ -223,16 +205,6 @@ impl ShaperState {
         Ok(dispatched)
     }
 
-    /// Commit and dispatch the held-back trailing region `[t_dispatched, t_appended]`
-    /// including the terminal decel-to-zero ramp.
-    ///
-    /// Idempotent: returns `Ok(Vec::new())` if `t_dispatched >= t_appended − ε`.
-    ///
-    /// On error the state is left unchanged.
-    ///
-    /// # Errors
-    ///
-    /// Forwards [`ShapeError`]s from [`emit_shaped`].
     pub fn commit_decel_to_zero(
         &mut self,
         ctx: &EmitContext<'_>,
@@ -338,11 +310,6 @@ impl ShaperState {
         Ok(dispatched)
     }
 
-    /// Committed ledger value per follower at the emit window start: the lane
-    /// value where prior emissions wrote it. When `anchor_t` falls past the
-    /// lane's committed coverage (e.g. across an idle gap), the follower holds
-    /// its realized endpoint — the ledger never snaps back to the at-rest
-    /// fallback while pieces exist.
     fn follower_anchor_values(&self, ctx: &EmitContext<'_>, emit_start: f64) -> Vec<f64> {
         let anchor_t = emit_start.max(
             self.planned_fitted
@@ -366,9 +333,6 @@ impl ShaperState {
             .collect()
     }
 
-    /// Replace each follower lane's ledger pieces from the new emission's
-    /// input tracks. Pieces from older emissions are trimmed back to the new
-    /// coverage start so overlap regions always read the freshest plan.
     fn store_follower_ledgers(
         &mut self,
         ctx: &EmitContext<'_>,

--- a/rust/trajectory/src/streaming/mod.rs
+++ b/rust/trajectory/src/streaming/mod.rs
@@ -29,77 +29,50 @@ mod tests;
 
 #[derive(Debug, Clone)]
 pub struct AxisLane {
-    /// Unshaped polynomial pieces, in time order.
     pub pieces: VecDeque<BezierPiece<f64>>,
-    /// Smooth-shaper kernel for this axis. `None` for passthrough.
     pub kernel: Option<PiecewisePolynomialKernel<f64>>,
-    /// Kernel half-support in seconds (`T_sm / 2`; `0.0` for passthrough).
     pub h: f64,
 }
 
 #[derive(Debug, Clone)]
 pub struct UncommittedMove {
     pub segment: CubicSegment,
-    /// Absolute start time in the planner timeline; set by `append_and_replan`.
     pub t_start: f64,
-    /// Expected end time as of the most recent replan; updated on every replan.
     pub t_end: f64,
 }
 
 #[derive(Debug, Clone)]
 pub struct ReplanContext {
     pub limits: temporal::Limits,
-    /// Per-axis post-processor chains — single source for solver shaping,
-    /// PA gains, and emission.
     pub chains: AxisChainSet,
-    /// L-infinity tolerance for the C1-constrained fit (mm).
     pub fit_tolerance_mm: f64,
     pub beta_max_iters: u8,
     pub beta_convergence_ratio: f64,
-    /// Worker thread count for TOPP-RA's parallel fan-out.
     pub worker_threads: usize,
     pub grid_strategy: temporal::multi::GridStrategy,
-    /// Fallback path speed at `t_dispatched` when the cursor is outside the `pieces` domain.
     pub fallback_initial_v: f64,
     pub safety_mode: SafetyMode,
-    /// Test/diagnostic hook: force the legacy whole-window re-solve (no bounded
-    /// front-freeze). Production always leaves this `false`; the trajectory-
-    /// neutrality tests flip it to compare bounded vs full committed output.
     pub force_full_resolve: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct EmitContext<'a> {
-    /// Per-axis post-processor chains, shared with the replan side.
     pub chains: &'a AxisChainSet,
 }
 
 #[derive(Debug)]
 pub struct ShaperState {
-    /// Index = axis registry index; spatial lanes hold the fitted (unshaped)
-    /// pieces, follower lanes hold the emitted input-track (nominal ledger)
-    /// pieces.
     pub axes: Vec<AxisLane>,
 
     pub uncommitted_moves: VecDeque<UncommittedMove>,
 
     pub t_appended: f64,
-    /// Start of the most-recently-submitted move's terminal decel-to-zero ramp.
     pub t_decel_start: f64,
     pub t_shaped: f64,
-    /// Latest absolute time for which a shaped sample has been dispatched to the wire.
     pub t_dispatched: f64,
 
     pub(crate) planned_fitted: Vec<FittedSegment>,
-    /// Per-segment metadata parallel to `planned_fitted`.
     pub(crate) planned_meta: Vec<EmitSegmentMeta>,
-    /// Shaped segments computed in the previous `emit_committed` for the kernel-support
-    /// freeze zone `[t_dispatched, t_dispatched + max_h]`.  After a replan, these are
-    /// dispatched directly (bypassing re-computation) to preserve C1 continuity with the
-    /// already-sent output.  Cleared by `emit_committed`, `commit_decel_to_zero`, and
-    /// `advance_idle`.
     pub(crate) pending_freeze: Vec<crate::ShapedSegment>,
-    /// Follower nominal-ledger value at `planned_fitted[0].t_start`, parallel
-    /// to the chain set's `followers`. Seeds pass-two emission.
     pub(crate) follower_emit_start: Vec<f64>,
 }

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -84,10 +84,6 @@ impl ShaperState {
         self.t_dispatched = 0.0;
     }
 
-    /// Swap in recompiled chains after a runtime post-processor parameter
-    /// change. Lane histories survive — they hold pre-kernel input pieces;
-    /// only the kernels and their half-supports refresh. Takes effect at the
-    /// next replan; committed trajectory is never rewritten.
     pub fn update_chains(&mut self, chains: &AxisChainSet) {
         assert_eq!(
             self.axes.len(),
@@ -392,10 +388,6 @@ impl ShaperState {
         Some(accel)
     }
 
-    /// Realized per-axis velocities over `[t_freeze - max_h, t_freeze]` from
-    /// the retained shaped pieces, for the shaper window's left edge. `None`
-    /// when no kernel is active or no uncommitted segment carries followers;
-    /// all-zero samples before any motion exists (cold start at rest).
     fn follower_history_at(
         &self,
         t_freeze: f64,
@@ -422,33 +414,6 @@ impl ShaperState {
         Some(temporal::FollowerHistory { dt, axis_velocity })
     }
 
-    /// Smallest tail-start index whose `[t_sub, t_appended]` sub-window
-    /// provably contains the backward deceleration-reach of the just-appended
-    /// terminal `v=0` boundary, so freezing the prior solution's `(v,a)` at
-    /// `t_sub` is trajectory-neutral. Returns `0` (full window) for the cold
-    /// start / short-window case.
-    ///
-    /// The reach left-edge is the prior solve's terminal decel onset
-    /// (`prior_t_decel_start`, itself moved earlier by the new news on each
-    /// append) extended backward by `JERK_RAMP_SAFETY` analytic full-speed→0
-    /// braking intervals `v_cruise / a_brake`, where `v_cruise`/`a_brake` are
-    /// the spatial-XY velocity ceiling and tightest accel cap (Z is excluded —
-    /// its slow caps would otherwise blow the horizon up to the whole window).
-    /// The safety multiplier pads the analytic constant-accel braking time for
-    /// the jerk-limited S-curve ramp; the neutrality tests pin it down — at the
-    /// shipped value the bounded committed trajectory matches the full re-solve
-    /// to solver tolerance on both a smooth chain and the decel-to-corner stress
-    /// case. Because the new terminal is always `v=0` — the most aggressive
-    /// possible terminal — the new backward reach can never exceed this. If a
-    /// corner (chain boundary) sits at or
-    /// behind the reach-derived index, `t_sub` is snapped back to it — the
-    /// cleanest freeze point, where the prior solve pinned `v=0`. Snapping only
-    /// ever grows the sub-window. When no corner lies in the reach window (a
-    /// purely smooth chain), the reach-derived segment boundary is itself a
-    /// valid pin: the prior solution's `(v,a)` at that interior node is
-    /// invariant to the new terminal because the node sits before the backward
-    /// reach, so re-solving the suffix from that pinned boundary reproduces the
-    /// downstream profile to solver tolerance.
     fn bounded_freeze_idx(
         &self,
         t_freeze: f64,
@@ -501,10 +466,6 @@ impl ShaperState {
         reach_idx
     }
 
-    /// Reads the prior solution's `(path_speed, path_accel, per_axis_accels)`
-    /// at absolute time `t` from `planned_fitted`/`axes`. This is the boundary
-    /// state pinned into the next solve — at `t_freeze` for the dispatched
-    /// front, or at the bounded sub-window start `t_sub` for the frozen front.
     fn boundary_pin_at(
         &self,
         t: f64,
@@ -560,10 +521,6 @@ impl ShaperState {
             .collect()
     }
 
-    /// Diagnostic sampler over the unshaped planned pieces: `(position, velocity)`
-    /// for `axis_idx` at absolute planner time `t`, or `None` outside the
-    /// piece domain. Used by trajectory-neutrality tests to compare the bounded
-    /// and full re-solve committed output.
     #[must_use]
     pub fn sample_axis(&self, axis_idx: usize, t: f64) -> Option<(f64, f64)> {
         Some((

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -1779,9 +1779,6 @@ fn streaming_routes_follower_only_virtual_move() {
 
 #[test]
 fn follower_only_retract_then_idle_then_move_holds_ledger() {
-    // Reproduces the bench crash: `M83; G1 E-1` (follower-only retract) leaves the
-    // follower ledger at -1; after an idle gap the next move must anchor the
-    // follower at -1, not snap back to the at-rest 0 (a 1mm pump junction fault).
     let ctx = follower_replan_context(None, 0.0);
     let mut state = ShaperState::new(&[0.0; 4], &ctx.chains);
     let ctx_emit = EmitContext {
@@ -1814,8 +1811,6 @@ fn follower_only_retract_then_idle_then_move_holds_ledger() {
     all.extend(state.emit_committed(&ctx_emit).expect("emit second"));
     all.extend(state.commit_decel_to_zero(&ctx_emit).expect("flush second"));
 
-    // The follower holds its ledger across the idle gap: the first post-idle
-    // segment must start where the pre-idle stream ended (-1), not snap to 0.
     let post_idle_start = nurbs::eval::eval(&all[before_idle].axes[3], all[before_idle].t_start);
     assert!(
         (post_idle_start - (-1.0)).abs() < 1e-3,

--- a/rust/trajectory/tests/continuous_throughput_repro.rs
+++ b/rust/trajectory/tests/continuous_throughput_repro.rs
@@ -1,35 +1,8 @@
-//! Faithful offline reproduction of the continuous-streaming throughput
-//! problem, instrumented in DETERMINISTIC, LOAD-INDEPENDENT COUNTS.
-//!
-//! The streaming planner re-plans its entire uncommitted lookahead window every
-//! time a curve arrives: `append_and_replan` builds `plan_segments` from ALL
-//! uncommitted moves (`state.rs` ~line 173) and calls `plan_velocity` on the
-//! whole window. A move only leaves the window when it commits
-//! (`uncommitted_moves.retain(|m| m.t_end > t_freeze)`, driven by
-//! `t_dispatched`). So per-append solver WORK grows with live window depth.
-//!
-//! WALL-CLOCK IS NOT A GATE HERE. This machine runs many things at once and
-//! background load drifts, so the gate is on COUNTS that are identical
-//! regardless of CPU load:
-//!   - `window_segments` fed to the solver per append,
-//!   - total grid points solved per append (Σ chain `n_points()`),
-//!   - Clarabel solve count per append (`clarabel_calls_total`),
-//!   - SLP / SLP9 outer-iteration counts per append.
-//!
-//! These are read from `temporal::counters` (thread-local, reset before each
-//! append, snapshotted after) plus `ReplanReport`. A single isolated wall-time
-//! estimate is printed but explicitly labeled rough / non-gating.
-//!
-//! Run with:
-//!   cargo nextest run -p trajectory -E 'test(continuous_throughput)' --no-capture
-
 use geometry::segment::{CubicSegment, SourceRange};
 use nurbs::VectorNurbs;
 use trajectory::streaming::{ReplanContext, ShaperState};
 use trajectory::{AxisChainSet, CompiledChain, PostProcessorType};
 
-/// Trident-like asymmetric CoreXY limit set (X/Y identical, Z slow).
-/// v in mm/s, a in mm/s^2, j in mm/s^3.
 fn trident_limits() -> temporal::Limits {
     temporal::Limits::axis_boxes(
         [500.0, 500.0, 10.0],
@@ -61,17 +34,12 @@ fn replan_ctx() -> ReplanContext {
     }
 }
 
-/// Baseline-measurement context: forces the legacy whole-window re-solve so
-/// Measurements 1-5 keep characterizing the ORIGINAL O(window-depth) behavior
-/// they were written to expose. The bounded front-freeze (now the production
-/// default) is measured separately by the `bounded_*` tests below.
 fn baseline_full_ctx() -> ReplanContext {
     let mut ctx = replan_ctx();
     ctx.force_full_resolve = true;
     ctx
 }
 
-/// Build one planar cubic Bézier from 4 explicit control points (z = 0).
 fn cubic_from_cps(cps: [[f64; 2]; 4], feedrate: f64) -> CubicSegment {
     let cp3 = |p: [f64; 2]| [p[0], p[1], 0.0];
     let control = vec![cp3(cps[0]), cp3(cps[1]), cp3(cps[2]), cp3(cps[3])];
@@ -91,9 +59,6 @@ fn cubic_from_cps(cps: [[f64; 2]; 4], feedrate: f64) -> CubicSegment {
     .unwrap()
 }
 
-/// Generate a tangent-continuous (G1/C1) chain of `k` planar cubic Béziers
-/// approximating a sine wave the toolhead sweeps in +X. Returns chord length
-/// per segment (mm) so playback duration can be estimated.
 fn chained_curves(
     k: usize,
     dx_mm: f64,
@@ -123,12 +88,6 @@ fn chained_curves(
     (segments, chords)
 }
 
-/// A decel-to-corner chain: a long straight run-up followed by a hard ~90°
-/// corner, then a short outgoing leg. The corner forces a deep backward
-/// velocity-propagation (deceleration-reach) horizon — the worst case for the
-/// "freeze the front" sub-window cap, because the decel ramp that must brake
-/// for the corner can reach many segments back. Used to stress how far the
-/// backward horizon extends relative to window depth.
 fn decel_to_corner_chain(
     run_up_segments: usize,
     leg_mm: f64,
@@ -157,38 +116,24 @@ fn decel_to_corner_chain(
     (segments, chords)
 }
 
-/// Per-append deterministic WORK COUNTS. Identical regardless of CPU load.
 #[derive(Debug, Clone, Copy)]
 struct WorkCounts {
-    /// Segments fed to the whole-window re-solve this append.
     window_segments: usize,
-    /// Σ ChainGrid::n_points() over every chain scheduled this append.
     grid_points: u64,
-    /// Number of chain schedules (≈ Clarabel-bearing chain solves).
     chains_scheduled: u32,
-    /// Total Clarabel SOCP solves (base + path-jerk SLP + SLP9 probes).
     clarabel_total: u32,
-    /// Clarabel solves outside SLP9: base SOCP + path-jerk SLP outer iters.
     clarabel_path_jerk: u32,
-    /// SLP9 (axis-jerk) trust-region Clarabel probes.
     clarabel_slp9_tr: u32,
-    /// SLP9 no-trust-region fallback Clarabel solves.
     clarabel_slp9_no_tr: u32,
-    /// β-medium outer iteration count for this append.
     beta_iterations: u8,
-    /// Rough wall-clock for the solve only (NON-GATING; load-dependent).
     solve_us: u64,
 }
 
-/// Append one curve with the counters reset immediately before, snapshotted
-/// immediately after, so every count is attributed to exactly this append.
 fn append_counted(state: &mut ShaperState, ctx: &ReplanContext, seg: CubicSegment) -> WorkCounts {
     temporal::counters::reset();
     let report = state
         .append_and_replan(seg, ctx)
         .expect("append should plan");
-    // snapshot_global aggregates across the worker threads the solve fans out
-    // to; the thread-local snapshot would read 0 on the orchestrating thread.
     let c = temporal::counters::snapshot_global();
     WorkCounts {
         window_segments: report.window_segments,
@@ -203,14 +148,6 @@ fn append_counted(state: &mut ShaperState, ctx: &ReplanContext, seg: CubicSegmen
     }
 }
 
-// ---------------------------------------------------------------------------
-// Measurement 1: per-append WORK COUNTS vs LIVE WINDOW DEPTH (no drain)
-// ---------------------------------------------------------------------------
-//
-// t_dispatched stays at 0, so nothing commits and the window grows to depth K.
-// Each row is the deterministic work the solver did on that append. The point:
-// grid_points / clarabel_total / chains_scheduled grow ~linearly with
-// window_segments => cumulative work over the chain is ~quadratic.
 #[test]
 fn continuous_throughput_window_depth_scaling() {
     const K: usize = 16;
@@ -260,7 +197,8 @@ fn continuous_throughput_window_depth_scaling() {
     println!("{}", "-".repeat(96));
 
     let n = rows.len();
-    let first = rows[1]; // append #2: first append with a real window > 1
+    const FIRST_REAL_WINDOW_APPEND: usize = 1;
+    let first = rows[FIRST_REAL_WINDOW_APPEND];
     let last = rows[n - 1];
     let d_depth = (last.window_segments - first.window_segments) as f64;
     let grid_slope = (last.grid_points as f64 - first.grid_points as f64) / d_depth;
@@ -286,8 +224,6 @@ fn continuous_throughput_window_depth_scaling() {
     );
     println!();
 
-    // Deterministic gate: the marginal grid-point cost per added segment must be
-    // strictly positive — i.e. work demonstrably scales with depth, not flat.
     assert!(
         last.grid_points > first.grid_points,
         "expected grid points to grow with window depth (last {} > first {})",
@@ -298,8 +234,6 @@ fn continuous_throughput_window_depth_scaling() {
         last.clarabel_total >= first.clarabel_total,
         "expected Clarabel solves to grow with window depth",
     );
-    // Per-segment grid density is ~constant (whole-window re-solve), so grid
-    // points must track window_segments closely.
     let approx_per_seg = last.grid_points as f64 / last.window_segments as f64;
     assert!(
         approx_per_seg > 1.0,
@@ -307,28 +241,12 @@ fn continuous_throughput_window_depth_scaling() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Measurement 2: STEADY-STATE WINDOW DEPTH per feedrate WITH REALISTIC DRAIN
-// ---------------------------------------------------------------------------
-//
-// Models a real host buffer: the toolhead plays back at `feed`, and the host
-// keeps a bounded lookahead of ~`buffer_s` seconds of motion queued ahead of
-// playback. We advance a simulated playback clock and set `t_dispatched` to it
-// before each append, so committed moves drop out of the window
-// (`retain(|m| m.t_end > t_freeze)`). The window reaches a steady-state depth
-// bounded by how many curves fit in `buffer_s` at that feedrate. We report
-// that steady-state depth AND the per-append WORK COUNTS at steady state.
 #[test]
 fn continuous_throughput_steady_state_depth_with_drain() {
     const DX_MM: f64 = 12.0;
     const AMP_MM: f64 = 6.0;
     const K: usize = 18;
 
-    // Host buffer depths in SECONDS of queued motion ahead of playback. 1.0s at
-    // 500mm/s would need depth ~20 > K to reach steady state; we keep the sweep
-    // within K so every reported steady depth is buffer-limited, not chain-
-    // length-limited, and the test stays fast. The trend (depth grows with feed
-    // and buffer) is fully visible at these points.
     let buffers_s = [0.25_f64, 0.5, 1.0];
     let feedrates = [50.0_f64, 100.0, 200.0, 350.0];
 
@@ -359,13 +277,6 @@ fn continuous_throughput_steady_state_depth_with_drain() {
             let mut steady_work: Vec<WorkCounts> = Vec::new();
 
             for (i, seg) in curves.into_iter().enumerate() {
-                // Drain: the toolhead has played everything more than buffer_s
-                // behind the most-recent planned append end. t_dispatched is the
-                // absolute planner time playback has reached; trailing the
-                // actual planned front by buffer_s (using real segment end times,
-                // which include accel/decel, not nominal chord time) commits and
-                // drops those moves on the next append's
-                // `retain(|m| m.t_end > t_freeze)`.
                 let playback_t = (state.t_appended - buffer_s).max(0.0);
                 if playback_t > state.t_dispatched {
                     state.t_dispatched = playback_t.min(state.t_appended);
@@ -373,9 +284,8 @@ fn continuous_throughput_steady_state_depth_with_drain() {
 
                 let w = append_counted(&mut state, &ctx, seg);
 
-                // Collect the back half as "steady state" (front transient
-                // while the buffer fills is excluded).
-                if i >= K / 2 {
+                let in_steady_state = i >= K / 2;
+                if in_steady_state {
                     steady_depths.push(w.window_segments);
                     steady_work.push(w);
                 }
@@ -413,15 +323,6 @@ fn continuous_throughput_steady_state_depth_with_drain() {
     println!();
 }
 
-// ---------------------------------------------------------------------------
-// Measurement 3: keep-ahead picture in COUNT terms (no-drain worst case)
-// ---------------------------------------------------------------------------
-//
-// COUNT-based keep-ahead: Σgrid_points (total deterministic solver work to plan
-// the chain) vs Σplayback (toolhead execution time at feed). The ratio of
-// solver work to available real-time scales with feedrate because faster feeds
-// shrink Σplayback while the no-drain window grows. This is the worst-case
-// burst (back-to-back curves while nothing has played yet).
 #[test]
 fn continuous_throughput_keep_ahead_counts() {
     const K: usize = 12;
@@ -474,15 +375,6 @@ fn continuous_throughput_keep_ahead_counts() {
     println!();
 }
 
-// ---------------------------------------------------------------------------
-// Measurement 4: decel-to-corner backward horizon (worst case for front-freeze)
-// ---------------------------------------------------------------------------
-//
-// A long straight run-up into a hard corner. The corner forces deceleration
-// that propagates backward many segments — this is the LARGEST backward
-// velocity-propagation horizon, the case where freezing the sub-window front
-// must include the deepest tail to stay trajectory-neutral. We report per-append
-// work counts; the corner append is where backward propagation is deepest.
 #[test]
 fn continuous_throughput_decel_to_corner_counts() {
     const RUN_UP: usize = 12;
@@ -531,13 +423,6 @@ fn continuous_throughput_decel_to_corner_counts() {
     println!();
 }
 
-// ---------------------------------------------------------------------------
-// Measurement 5: ISOLATED wall-time estimate (ROUGH, NON-GATING)
-// ---------------------------------------------------------------------------
-//
-// Single-process median of >= 5 reps of the per-append solve at a fixed window
-// depth. Labeled rough; this is NOT a gate. The real real-time validation
-// happens later on the actual Pi bench. Counts above are the gate.
 #[test]
 fn continuous_throughput_isolated_walltime_estimate() {
     const DEPTH: usize = 8;
@@ -585,13 +470,6 @@ fn continuous_throughput_isolated_walltime_estimate() {
     println!();
 }
 
-// ---------------------------------------------------------------------------
-// THE FIX — trajectory-neutrality + bounded-work tests (DETERMINISTIC GATE)
-// ---------------------------------------------------------------------------
-
-/// Sample the committed (unshaped planned) trajectory of `state` on a dense
-/// time grid over `[0, t_end]`, returning per-axis `(pos, vel)` rows. This is
-/// the deterministic value used to compare bounded vs full re-solve output.
 fn sample_committed(state: &ShaperState, t_end: f64, n: usize) -> Vec<[(f64, f64); 2]> {
     let mut rows = Vec::with_capacity(n + 1);
     for i in 0..=n {
@@ -605,10 +483,6 @@ fn sample_committed(state: &ShaperState, t_end: f64, n: usize) -> Vec<[(f64, f64
     rows
 }
 
-/// Run a chain of curves through `append_and_replan`, advancing a simulated
-/// playback clock so moves commit and drop out of the window (realistic drain),
-/// and after every append capture the committed trajectory and the per-append
-/// `window_segments`. `force_full` selects the legacy whole-window re-solve.
 fn run_chain_capture(
     curves: &[CubicSegment],
     feed: f64,
@@ -625,36 +499,27 @@ fn run_chain_capture(
     let _ = chords;
 
     for seg in curves {
-        // Drain to a WHOLE-segment boundary: snap the playback clock back to the
-        // most recent uncommitted move start that is still ≤ the buffer-trailing
-        // time. This commits whole segments and avoids the mid-segment Bézier
-        // split (a separate, pre-existing Newton-inversion path) so the test
-        // isolates the bounded re-solve's trajectory-neutrality.
-        let raw_playback = (state.t_appended - buffer_s).max(0.0);
-        let snapped = state
+        let buffer_trailing_time = (state.t_appended - buffer_s).max(0.0);
+        let snapped_to_segment_boundary = state
             .uncommitted_moves
             .iter()
             .map(|m| m.t_start)
-            .filter(|&t| t <= raw_playback)
+            .filter(|&t| t <= buffer_trailing_time)
             .fold(0.0_f64, f64::max);
-        if snapped > state.t_dispatched {
-            state.t_dispatched = snapped.min(state.t_appended);
+        if snapped_to_segment_boundary > state.t_dispatched {
+            state.t_dispatched = snapped_to_segment_boundary.min(state.t_appended);
         }
         let report = state
             .append_and_replan(seg.clone(), &ctx)
             .expect("append should plan");
         win_segs.push(report.window_segments);
-        // Compare only the immutable / dispatched region — everything at or
-        // before t_dispatched is committed and must be bit-stable between the
-        // bounded and full re-solve.
-        let t_cmp = state.t_dispatched.max(0.0);
-        committed_snaps.push(sample_committed(&state, t_cmp, 200));
+        let committed_region_end = state.t_dispatched.max(0.0);
+        committed_snaps.push(sample_committed(&state, committed_region_end, 200));
     }
     let _ = feed;
     (committed_snaps, win_segs, state)
 }
 
-/// Max abs (position, velocity) difference between two committed snapshots.
 fn snap_diff(a: &[Vec<[(f64, f64); 2]>], b: &[Vec<[(f64, f64); 2]>]) -> (f64, f64) {
     let mut dp = 0.0_f64;
     let mut dv = 0.0_f64;
@@ -696,10 +561,6 @@ fn bounded_equals_full_smooth_chain() {
     const DX_MM: f64 = 12.0;
     const AMP_MM: f64 = 6.0;
     const FEEDRATE: f64 = 200.0;
-    // Shallow buffer keeps the drain shaper-split-free (the SmoothZV kernel
-    // half-support pushes the freeze point mid-segment at deeper buffers,
-    // exercising an unrelated Bézier-split path). The work-bound win is shown
-    // by the no-drain and decel-to-corner tests; this test's job is neutrality.
     const BUFFER_S: f64 = 0.25;
 
     let (curves, chords) = chained_curves(K, DX_MM, AMP_MM, FEEDRATE);
@@ -791,13 +652,6 @@ fn bounded_equals_full_decel_to_corner() {
         dv < VEL_TOL_MM_S,
         "decel-to-corner bounded drifted committed velocity by {dv} mm/s (> {VEL_TOL_MM_S})"
     );
-    // t_appended is the frontier of the still-MUTABLE tail, not the committed
-    // region. Its absolute value carries the frozen-front segment durations
-    // from the appends in which those segments were last the live tail, so it
-    // differs from the full re-solve by accumulated per-segment solver-timing
-    // noise (≈50 µs/segment). Trajectory-neutrality is defined on the COMMITTED
-    // (dispatched, immutable) region, asserted tightly above; here we only
-    // bound the tail-frontier drift to confirm it is solver-noise small.
     const TAIL_FRONTIER_TOL_S: f64 = 2.0e-3;
     assert!(
         (full_state.t_appended - bnd_state.t_appended).abs() < TAIL_FRONTIER_TOL_S,
@@ -805,8 +659,6 @@ fn bounded_equals_full_decel_to_corner() {
         full_state.t_appended,
         bnd_state.t_appended,
     );
-    // Adaptive-K: the corner append must grow the bounded window well beyond the
-    // smooth steady-state cap to cover the corner's deep backward decel reach.
     let bnd_corner = *bnd_win.last().unwrap();
     let bnd_steady = bnd_win[..bnd_win.len() - 1]
         .iter()
@@ -822,9 +674,6 @@ fn bounded_equals_full_decel_to_corner() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// THE GATE — per-append WORK COUNTS are bounded (capped ~K) vs growing depth
-// ---------------------------------------------------------------------------
 #[test]
 fn bounded_work_is_capped_vs_depth() {
     const K: usize = 28;
@@ -881,7 +730,6 @@ fn bounded_work_is_capped_vs_depth() {
     let full_max_gp = full_rows.iter().map(|w| w.grid_points).max().unwrap();
     let bnd_max_gp = bnd_rows.iter().map(|w| w.grid_points).max().unwrap();
 
-    // Steady-state (back half) bounded window must be flat, not growing.
     let back = &bnd_rows[K / 2..];
     let back_min = back.iter().map(|w| w.window_segments).min().unwrap();
     let back_max = back.iter().map(|w| w.window_segments).max().unwrap();
@@ -897,20 +745,15 @@ fn bounded_work_is_capped_vs_depth() {
     );
     println!();
 
-    // The full re-solve must grow with depth (baseline behaviour).
     assert_eq!(
         full_rows.last().unwrap().window_segments,
         K,
         "full re-solve window must reach the whole chain depth"
     );
-    // The bounded re-solve must NOT grow to full depth — it is capped.
     assert!(
         bnd_max_seg < full_max_seg,
         "bounded window_segments ({bnd_max_seg}) must be strictly below full depth ({full_max_seg})"
     );
-    // And the steady-state bounded window must be flat: the range over the back
-    // half must be small (a constant cap), proving work does not scale with
-    // accumulated window depth.
     assert!(
         back_max - back_min <= 2,
         "bounded steady-state window must be flat (cap), got range [{back_min}, {back_max}]"

--- a/rust/trajectory/tests/curve_reparam_regression.rs
+++ b/rust/trajectory/tests/curve_reparam_regression.rs
@@ -1,7 +1,3 @@
-//! Regression: smooth curved segments plan successfully and track the exact
-//! curve; genuine cusps still fail loud. Guards the fix for the planner_fatal
-//! abort on curved (G5) segments.
-
 use nurbs::VectorNurbs;
 use temporal::multi::{GridStrategy, SegmentInput};
 use trajectory::{AxisChainSet, ShapeBatchInput, ShapeError, ShapeSegmentInput};

--- a/rust/trajectory/tests/end_to_end.rs
+++ b/rust/trajectory/tests/end_to_end.rs
@@ -1,13 +1,3 @@
-//! End-to-end integration tests for `shape_batch`.
-//!
-//! These tests exercise the full pipeline: partition -> TOPP-RA -> time-reparam ->
-//! composition -> convolution -> peak-accel -> beta loop -> output assembly.
-//!
-//! Low shaper frequencies (10 Hz) are used for numerical stability: the kernel
-//! normalization constant c = 15/(16*h^5) scales as f^5, so narrow kernels
-//! (high f) produce large polynomial coefficients that amplify floating-point
-//! error in the convolution + double-differentiation pipeline.
-
 use geometry::segment::FollowerDemand;
 
 const E_FOLLOWER_04: &[FollowerDemand] = &[FollowerDemand {
@@ -149,18 +139,9 @@ fn shape_batch_short_low_velocity_line_refits_at_five_microns() {
     assert!(seg.t_end.is_finite());
 }
 
-// TOPP-RA joining produces platform-dependent results at 10 Hz shaper with
-// multi-segment batches (passes macOS, stalls on Linux CI). The same code
-// paths are covered by the beta unit tests at 120/180 Hz which pass on all
-// platforms. Tracked for investigation.
 #[test]
 #[cfg_attr(target_os = "linux", ignore)]
 fn shape_batch_two_segments() {
-    // Two collinear CoupledToXy segments (same direction, no sharp corner).
-    // Collinear segments avoid the joining-loop oscillation that occurs with
-    // sharp corners at low grid density. The L-shape case is a known limitation
-    // of Fixed(20) grid strategy — the temporal multi-segment tests use Adaptive
-    // grids for sharp corners.
     let curve1 = make_straight_line([0.0, 0.0, 0.0], [50.0, 0.0, 0.0]);
     let curve2 = make_straight_line([50.0, 0.0, 0.0], [100.0, 0.0, 0.0]);
 

--- a/rust/trajectory/tests/jog_50mm_live_limits.rs
+++ b/rust/trajectory/tests/jog_50mm_live_limits.rs
@@ -81,7 +81,6 @@ fn jog_50mm_at_100mms_with_live_limits() {
         result.beta_warning,
     );
     eprintln!("[probe] temporal_status={:?}", result.temporal_status);
-    // No assertion — pure probe. CARGO_LOG=1 cargo test prints duration.
     assert!(
         duration < 5.0,
         "trajectory exploded to {duration}s — probe needs adjustment"

--- a/rust/trajectory/tests/live_jog_velocity_probe.rs
+++ b/rust/trajectory/tests/live_jog_velocity_probe.rs
@@ -86,14 +86,6 @@ fn run_jog_experiment(
     converged
 }
 
-/// Mid-flight replan of back-to-back fast moves used to drive the jerk-relaxation
-/// derate loop to its iteration cap without converging: the feasibility emit padded
-/// the first window segment's left edge against empty shaper history, fabricating a
-/// velocity step at the dispatch seam whose convolution looked like a ~2x acceleration
-/// spike. Derating planning accel could not move a boundary artifact, so the loop spun
-/// to the cap (~294 ms on the Pi) and starved playback. With the left pad extrapolated
-/// at the entry velocity instead, the phantom is gone and every regime converges in one
-/// iteration — regardless of direction reversal, segment length, or feedrate-to-vmax ratio.
 #[test]
 fn mid_flight_fast_jog_replan_converges_across_regimes() {
     let feedrate = 1000.0;
@@ -279,10 +271,6 @@ fn probe_stream(label: &str, segments: &[ShapedSegment]) {
     }
 }
 
-/// Regression for the 2026-06-11 Trident crash: back-to-back +30/-30 mm jogs at the
-/// 1000 mm/s axis limit. Each mid-flight replan must converge within the iteration cap;
-/// non-convergence is what blew the real-time budget (294 ms solve for 30 ms of motion)
-/// and tripped the SegmentLate fatal abort.
 #[test]
 fn back_to_back_fast_jogs_replan_stays_realtime() {
     let ctx = live_ctx();


### PR DESCRIPTION
## What

Removes every standalone comment block from the motion-planner code:

- **Rust crates:** `motion-engine`, `trajectory`, `geometry`, `nurbs`, `temporal`, `gcode` (src + tests + examples)
- **Python:** `klippy/motion.py`, `motion_engine.py`, `motion_kinematics.py`, `motion_endstop.py`

624 comment blocks removed across 138 files. Trailing same-line comments are kept (the only comment form allowed by the cleanup rule).

## How

Each file was handled independently. Where a comment carried non-obvious intent, the code was reworked to express it directly — local renames, extracted helpers, named constants, asserts encoding invariants — rather than just dropping the knowledge (49 files refactored this way). Refactors are file-local: no public-API or cross-file renames, no behavior change, since this is throughput-critical motion code.

The one executable doc-test (`nurbs::algebra::add_with_knot_union`) was preserved by moving it into a real `#[test]` instead of being deleted.

## Verification

- `./scripts/ci.sh quick` — green (ruff, rust tests, clippy `-D warnings`, `cargo fmt --check`, watchdog canary)
- doc-tests across all six crates — pass
- Python host suite — 406 passed, 109 skipped, 2 xfailed, 0 failed

## Follow-up (out of scope)

While reviewing `geometry::velocity`, noted that the orphan-config fallback jerk (`VelocityConfig::default().max_jerk_mm_s3 = 100_000`) is an open tuning question — `config.rs` already derives jerk from `max_accel` (2× multiple) when a limit section exists, so the 100k only applies when no accel/jerk is configured at all. Worth a separate look at whether that fallback should derive from accel or fail loudly.