### PR TITLE
Restore Mainsail Z-offset workflow (probe save + ecosystem config parity)

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -600,6 +600,7 @@ class PrinterConfig:
         self.status_settings = {}
         for (section, option), value in config.access_tracking.items():
             self.status_settings.setdefault(section, {})[option] = value
+        self._mirror_axes_to_legacy_steppers()
         for (section, option, value), msg in self.deprecated.items():
             _type = "deprecated_value"
             self.warn(_type, msg, section, option, value)
@@ -615,6 +616,15 @@ class PrinterConfig:
             _type = "unused_section"
             msg = f"Section '{section}' is invalid"
             self.warn(_type, msg, section)
+
+    def _mirror_axes_to_legacy_steppers(self):
+        axis_prefix = "axis "
+        for store in (self.status_settings, self.status_raw_config):
+            for section in list(store):
+                if not section.startswith(axis_prefix):
+                    continue
+                legacy = "stepper_" + section[len(axis_prefix) :]
+                store.setdefault(legacy, dict(store[section]))
 
     def get_status(self, eventtime):
         return {

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -40,6 +40,7 @@ class PrinterProbe:
     cmd_PROBE_help = "Probe Z-height at the current XY position"
     cmd_QUERY_PROBE_help = "Return the current probe state"
     cmd_PROBE_ACCURACY_help = "Probe Z-height repeatedly and report statistics"
+    cmd_Z_OFFSET_APPLY_PROBE_help = "Adjust the probe's z_offset"
 
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -79,6 +80,8 @@ class PrinterProbe:
         self.last_query = False
         self.last_z_result = 0.0
 
+        self.name = config.get_name()
+        self.gcode_move = self.printer.load_object(config, "gcode_move")
         ppins.register_chip("probe", self)
         gcode = self.printer.lookup_object("gcode")
         gcode.register_command(
@@ -91,6 +94,11 @@ class PrinterProbe:
             "PROBE_ACCURACY",
             self.cmd_PROBE_ACCURACY,
             desc=self.cmd_PROBE_ACCURACY_help,
+        )
+        gcode.register_command(
+            "Z_OFFSET_APPLY_PROBE",
+            self.cmd_Z_OFFSET_APPLY_PROBE,
+            desc=self.cmd_Z_OFFSET_APPLY_PROBE_help,
         )
         query_endstops = self.printer.load_object(config, "query_endstops")
         query_endstops.register_endstop(self._endstop, "probe")
@@ -260,6 +268,21 @@ class PrinterProbe:
                 sigma,
             )
         )
+
+    def cmd_Z_OFFSET_APPLY_PROBE(self, gcmd):
+        offset = self.gcode_move.get_status()["homing_origin"].z
+        if offset == 0.0:
+            gcmd.respond_info("Nothing to do: Z Offset is 0")
+            return
+        new_calibrate = self.z_offset - offset
+        gcmd.respond_info(
+            "%s: z_offset: %.3f\n"
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "with the above and restart the printer."
+            % (self.name, new_calibrate)
+        )
+        configfile = self.printer.lookup_object("configfile")
+        configfile.set(self.name, "z_offset", "%.3f" % (new_calibrate,))
 
 
 class ProbePointsHelper:


### PR DESCRIPTION
## Problem

On `sota-motion`, the Mainsail Z-offset panel is broken end to end:

1. **Save path missing.** The rewritten `probe.py` dropped `Z_OFFSET_APPLY_PROBE`. Mainsail's "save" button issues that command (then `SAVE_CONFIG`) and only shows the button when the command is in Moonraker's gcode list — so saving the offset into `[probe] z_offset` was impossible.
2. **Panel crashes and unmounts.** The motion rewrite moved axes to `[axis <name>]`/`[motor <name>]`, so `configfile.settings` has no `stepper_z`. Mainsail/Fluidd/KlipperScreen compute `isEndstopProbe` from `settings.stepper_z.endstop_pin`; with it `null`, their getter does `null.replaceAll()` and Vue tears out the whole Z-offset section the instant a non-zero offset is applied:

   ```
   TypeError: Cannot read properties of null (reading 'replaceAll')
       at get isEndstopProbe
       at get showSaveButton
   ```

The live value (`gcode_move.homing_origin`) was always correct host-side — the panel that displays it was just being unmounted.

## Fix

- **`feat(probe): restore Z_OFFSET_APPLY_PROBE`** — re-register the command; fold `gcode_move.homing_origin.z` into the probe's `z_offset` via `configfile.set`, matching mainline semantics. All probe variants (`bltouch`/`eddy`/`smart_effector`/`dockable`) route through `PrinterProbe`, so they inherit it.
- **`fix(configfile): expose legacy stepper_<axis> aliases`** — mirror each `[axis <name>]` section to a `stepper_<name>` alias in the config status (settings + raw config), without clobbering a real section. Restores the section name the whole ecosystem keys on.

## Verification (live on the Neptune bench, `194d1dd63`)

```
settings.stepper_z.endstop_pin = "probe:z_virtual_endstop"   (was null → the crash)
settings.stepper_x.endstop_pin = "PA13"
Z_OFFSET_APPLY_PROBE registered = True
```

Host-Python only — no MCU flash; klippy restart picks it up. After a hard refresh the panel renders, ticks live with the offset, and shows the probe-save button.

## Notes

- Pre-existing, out of scope: `bltouch`/`probe_eddy_current`/`smart_effector`/`dockable_probe` call `PrinterProbe(config, mcu_probe)` with a second arg the rewritten constructor doesn't accept — those probe types can't instantiate on this branch independent of z-offset.