### PR TITLE
RESONANCE_BUZZ over EtherCAT (CSP + native chirp + triple feedforward)

### DIFF
--- a/_bmad-output/brainstorming/brainstorming-session-2026-06-22-074642.md
+++ b/_bmad-output/brainstorming/brainstorming-session-2026-06-22-074642.md
@@ -1,0 +1,186 @@
+---
+stepsCompleted: [1, 2, 3, 4]
+workflow_completed: true
+session_active: false
+ideas_generated: 22
+inputDocuments: []
+session_topic: 'Implementing buzz (resonance-test sinusoidal excitation) for EtherCAT servo drives, where the drive accepts position commands at a fixed cyclic update rate but we need to excite arbitrary frequencies'
+session_goals: 'Make RESONANCE_BUZZ and RESONANCE_BUZZ_SWEEP work on EtherCAT servos. Target excitation band UP TO 300-350 Hz. Manual listening first; accelerometer verification a later add-on. Resolve fixed CSP grid vs arbitrary frequency (Nyquist, drive interpolation, phase coherence, capture sync, where the generator lives).'
+selected_approach: 'progressive-flow'
+techniques_used: ['First Principles Thinking', 'What If Scenarios', 'Morphological Analysis', 'Constraint Mapping', 'Failure Analysis', 'Decision Tree Mapping']
+context_file: ''
+---
+
+# Brainstorming Session Results
+
+**Facilitator:** dderg
+**Date:** 2026-06-22
+
+## Session Overview
+
+**Topic:** Buzz for EtherCAT — exciting an arbitrary resonance-test frequency through a fixed-rate CSP position command path.
+
+**Goals:** Architecture + implementation ideas; resolve the fixed-grid vs arbitrary-frequency tension.
+
+### Context Guidance
+
+Existing buzz (regular stepping) lives in `rust/runtime/src/buzz.rs`, `buzz_gen.rs`, `buzz_stream.rs`. It works by solving the exact sub-microsecond times the chirp sinusoid crosses each microstep boundary and emitting step events at those instants — arbitrary frequency is "free" because steps fire at arbitrary times.
+
+EtherCAT path (`rust/ethercat-rt/`): CSP mode 8, default 1 kHz DC cycle (`--cycle-us`), writes target position `0x607A` in encoder counts (default 3276.8 counts/mm). Per-cycle setpoint comes from cubic polynomial "pieces" in an `AxisRing` (`curves.rs`), evaluated at the DC clock timestamp. Host (klippy) talks to the `ethercat-rt` daemon over a Unix socket with framed commands (`PushPieces`, `SetTorque`, `Stop`, `StartCapture`, `SeedServoHome`, SDO ops). Drive interpolates between received targets (CiA `0x60C2`).
+
+**Key reframings established at session start:**
+1. EtherCAT buzz has NO microstep-quantization problem — position is continuous in counts, so the crossing solver does not transfer.
+2. The hard part moves to: sampling a chirp onto the fixed time grid (Nyquist), the drive's interpolation low-pass + phase lag, phase coherence of the sweep, sync with accelerometer capture, and where the generator lives (host pieces vs native ethercat-rt generator).
+
+### Session Setup
+
+_(facilitation in progress)_
+
+## Idea Log
+
+### Phase 1 — First Principles + What If (control mode & drive transparency)
+
+**[Phys #1] Command-the-derivative.** CSV/CST carry more signal amplitude per unit toolhead motion at high f (velocity ∝ 1/f, torque ∝ flat, vs position ∝ 1/f²). Sidesteps the ~10-count micro-sine problem at 350 Hz / 3276.8 counts/mm.
+
+**[Phys #2] CSP and CST are opposite tests.** Position = displacement-controlled, self-limiting (fails by drive following-error trip), but resonance-hiding. Torque = force-controlled, resonance-honest (textbook modal analysis, force-in/accel-out) but self-amplifying — displacement = F·Q/k, Q≈10–50× at the peak → "shake into parts."
+
+**[Phys #3] CSP is the faithful equivalent of stepper buzz.** Both are motor-side displacement sources; the resonance lives on the toolhead, downstream of the rotor encoder, OUTSIDE the position loop. The loop "fighting" the reflected force only keeps the input clean; the belt still rings the toolhead. De-risks project to "reuse displacement-buzz semantics over a new transport." (Note: this faithfulness argument applies to CSV too — it does not uniquely select CSP.)
+
+**[Safety #1] Response-limited torque (outer AGC).** If we ever do torque excitation: close a slow outer loop on measured response (drive streams Position Actual 0x6064, Following Error 0x60F4) and scale the torque tone down when displacement/following-error exceeds a ceiling. The gain-pullback curve is itself a resonance signature. PARKED — not on critical path.
+
+**[Grid #1] DEAD — Buzz at higher SYNC0.** Killed: the grid-rate ceiling is the Pi5 EtherCAT master packet rate, not the drive. If we can't sustain 4 kHz for printing we can't for buzz. Asterisk: buzz is a 1–5 s burst, not sustained-hours, so a higher burst rate *might* be tolerable — parked, not leaned on. Assume ~1 kHz output rate.
+
+**[Grid #2] CSV gets free smoothing from the drive integrator.** CSP linear-interpolates POSITION → velocity discontinuous every cycle (broadband impulse, harmonics, audible clicks). CSV commands velocity, drive integrates → position is piecewise-quadratic (C¹), velocity continuous. Built-in reconstruction upgrade at the same rate. Cost → [Grid #4].
+
+**[Grid #3] At 1 kHz, 350 Hz is below Nyquist (500 Hz) — enemy is reconstruction, not information.** The samples contain the tone; the drive's crude *linear* reconstruction mangles it. Battle = reconstruction quality. Composable upgrades: (a) CSV integrator, (b) pre-emphasis — inverse-filter our samples by the known linear-interp sinc² response so the post-drive result is the sine. Honest caveat: 350/500 = 0.7 Nyquist is rough for any reconstruction; expect degradation past ~250–300 Hz at 1 kHz.
+
+**[Grid #4] CSV drifts — no absolute position anchor.** Position = integral of velocity; any DC bias/quantization integrates to position walk over a multi-second buzz. Needs DC-balance / slow CSP position-trim. Failure mode flips from "following-error trip" to "axis walks into a wall." This is why pure CSV was rejected.
+
+**Resolved band target:** ~250–300 Hz clean at 1 kHz is acceptable now; declare "2 kHz required for higher (up to 350+)."
+
+### Phase 1 payoff — manual findings (A6-EC = Inovance-class servo)
+
+**[Drive #1] Three in-band filter layers between our command and the shaft.** (a) Notch filters §7.14: 5 notches 50–8000 Hz, two adaptive (C01.30). ADAPTIVE NOTCH HUNTS AND CANCELS A SUSTAINED RESONANCE — it would notch out the exact frequency we're measuring → silent dropout at the peak. Static notches from a prior auto-tune punch holes in the sweep. (b) Speed/torque FF filters C01.15/C01.18 default cutoff = 318 Hz, right at top of band. (c) Position reference filter §7.8 (LPF + moving average). Default drive is clean (notches off, C01.30=0); a TUNED drive is not.
+
+**[Drive #2] Buzz needs a transparent drive profile: snapshot → override → restore.** Reuse existing ethercat-rt SdoRead/SdoWrite + SetDriveLimits/RestoreDriveLimits. Override during buzz: C01.30=0 (adaptive notch off), in-band notches disabled, position-ref filter off, FF cutoffs raised >350 Hz, FF sources = Communication (C01.13=5, C01.16=5). Restore after.
+
+**[Mode #1] ★ CSP + full triple feedforward (the "better idea").** Stay in CSP (position anchored, no CSV drift). Each cycle feed target position 0x607A (sine) + velocity offset 0x60B1 (1st deriv) + torque offset 0x60B2 (inertial 2nd deriv). FF carries the high-f content where it has large numeric amplitude (vel ∝1/f, torque ∝flat) — gets CSV's big-signal benefit WITHOUT drift. Reuses ethercat-rt's existing dynamics-model torque-FF path (curves.rs already returns accel). Requires C01.13=5/C01.16=5 and raised FF cutoffs from [Drive #2].
+
+**[Meas #1] Loop-effort as accelerometer-free resonance signal (parked).** Drive streams 60F4 (position deviation) + actual torque/velocity. The position loop's *effort* to hold the sine is itself a transfer-function measurement → possible resonance detection without an accelerometer. Cousin of [Safety #1].
+
+**[Drive #3] CSP safety guards already exist in-protocol.** Excessive position deviation 6065h (default 3,145,728 counts) + following-error timeout 6066h fault the drive if tracking fails — natural high-frequency safety net. C01.30=4 ("resonance frequency tested only") is a built-in resonance detector worth noting.
+
+**No internal function/chirp generator or FFT exposed over EtherCAT** — "speed/torque reference signal observation" is a scope, not a generator; "Mechanical Characteristics" §12.5.1 is just motor spec. So we generate the waveform (host or ethercat-rt), not the drive.
+
+### Phase 1 → 2 bridge — Neptune bench config (validates Mode #1)
+
+Bench `[motor motor_x]`: drive=servo, protocol=ethercat, rotation_distance=40, encoder_counts_per_rev=131072 → 3276.8 counts/mm. `velocity_ff: True` AND `dynamics_profile:` set → **pos+vel+torque FF path is ALREADY ACTIVE.** Gains (manual mode C00.04=0): position gain C01.00=220 rad/s ≈ 35 Hz, speed gain C01.01≈137.5 Hz, integral 9.09 ms. max_torque 100, following_error 10 mm. NO notch params → adaptive notch off, no static notches ("only simple stuff tuned" confirmed). SDO config pushed via printer.cfg `params:` block (object.subindex syntax, e.g. `0x2001.0x01: u16 1280`).
+
+**[Mode #2] ★ Excitation channel changes with frequency — triple-FF mandatory for COVERAGE, not just resolution.** 0–35 Hz: position loop tracks (position channel). 35–137 Hz: position loop dead, speed loop tracks → velocity FF carries. 137–300 Hz: speed loop rolling off → only torque FF (→ current loop ~kHz BW) reaches the shaft. Without torque FF, cannot excite >137 Hz; without velocity FF, can't cleanly clear 35 Hz. The 0–300 Hz band maps onto which FF channel renders it. The ONE mandatory transparent-profile item even on this lightly-tuned bench: raise FF filter cutoffs C01.15/C01.18 (default 318 Hz) above the buzz ceiling, else the top of the band is attenuated.
+
+**Confirmed band target: design for 300 Hz now; "2 kHz EtherCAT rate required for higher."**
+
+### Phase 2 — Morphological Analysis (architecture convergence)
+
+Framing correction from user: `ethercat-rt` IS our "MCU" (the A6-EC drive is just the power stage). So it must generate buzz natively, exactly like the stepper MCU (which arms with params via `engine.resonance_buzz` → `buzz.arm`, NOT host-streamed). The crossing solver (`buzz_gen::next_crossing`) is stepper-specific (microstep quantization) and does NOT port; only the chirp phase math (`phase`, `omega_inst`, `amp_eff`, `envelope`) ports, evaluated continuously per DC cycle.
+
+**Design-space axes & winners:**
+- **A. Generator location** → **A2 native ethercat-rt generator** (mirror stepper-MCU arm-and-generate)
+- **B. Waveform representation** → **B2 direct per-cycle analytic sine** (exact chirp, trivial phase coherence via eval at DC timestamp, avoids ~1200 pieces/s firehose of B1 cubic-piece approx)
+- **C. FF richness** → **C3 pos+vel+torque** (mandatory for COVERAGE per [Mode #2], already active on bench)
+- **D. Drive profile** → **D2/D3 snapshot-override-restore + mandatory raise FF cutoffs C01.15/C01.18** (bench notches already off, so D-work mostly optional EXCEPT FF cutoffs)
+- **E. Command path** → **motion_engine route + new wire Command** (NOT zero-host-change)
+
+**[Arch #1] Native generator (A2/B2) is the architecturally consistent choice** — EtherCAT mirror of the existing MCU buzz pattern (arm-with-ToneParams, generate locally). The temptation is to reuse the piece pipeline because it's there; the cleaner move is to reuse the MCU buzz's *design pattern* on the new transport.
+
+**[Arch #2] ★ Buzz routes through motion_engine, not the MCU command bus — "zero host change" does NOT hold.** Proof: `ServoRail.get_steppers()` returns `[]` (servo_axis.py:113), and `_engine_mcus()` is built only from `kin.get_steppers()` → `get_mcu()` (motion.py). So the servo contributes no engine MCU; `submit_resonance_buzz` today sends `kalico_resonance_buzz` to the F401 stepper MCU (Y/Z/E) and NEVER reaches the servo. Fix: `submit_resonance_buzz` adds a dispatch branch through the EtherCAT engine handle, mirroring `motion_engine.sdo_write(engine_handle, …)`; `ethercat-rt` gains a new `Command::ResonanceBuzz` (MessageKind in wire.rs) carrying the SAME 7 args; daemon arms a native generator. Correct invariant: **buzz semantics/args identical to stepper path; only the transport differs.** Host gains one dispatch branch, not a redesign.
+
+**Open fork inside the native generator (for Phase 3):** does per-cycle eval bypass `AxisRing`/`curves.sample()` entirely (separate buzz state armed in the DC loop), or feed synthesized setpoints through the existing `sample()`+dynamics path so torque-FF computation is shared? And how is chirp phase anchored to the DC clock (analogous to MCU buzz `anchor_cycle` set on first refill)?
+
+### Phase 3 — Constraint Mapping + Failure Analysis
+
+**[Arch #3] ★ Bypass-vs-feedthrough fork DISSOLVES: buzz = alternate triplet source.** Everything downstream of `ring.sample(now)` in the DC loop (ethercat-rt.rs:703-748: mm_to_counts, vel*counts_per_mm, dynamics.torque_ff(acc,vel), clamp_torque, the 3 ec_rt_set_* writes) only needs a `(pos_mm, vel_mm_s, acc_mm_s2)` triplet — mode-agnostic. So: `let triplet = if buzz.active() { buzz.eval(now) } else { ring.sample(now) };`. All FF/counts/clamp/write reused verbatim. The integration seam is the triplet, not the pipeline or the wire. Oscillator = ~3 libm trig evals/cycle.
+
+**Constraints (real vs assumed):**
+- FF cutoff 318 Hz: ASSUMED-hard → ACTUALLY-soft. C01.15/C01.18 range 5–16000 Hz, modify-during-operation. We raise via SDO. ✅
+- DC-loop headroom: ASSUMED-tight → ACTUALLY-soft. ~3 trig evals in a 1 ms budget; sample() already does Horner + same torque_ff. ✅
+- Torque-FF model accuracy at 300 Hz: REAL, medium. Model (servo-ident τ≈J·a+friction) can't know the toolhead resonance (the thing being excited). FF good enough for excitation; excitation amplitude vs freq won't be perfectly flat (measure response separately).
+- Following-error trip: REAL, low. At 300 Hz/15000 mm/s² ceiling, commanded pos amplitude ≈4 µm ≈14 counts; trip thresholds (6065h ~3.1M counts; following_error 10mm≈32k counts) are far away. Risk lives at LOW-f near a real structural resonance (large displacement).
+
+**Failure modes:**
+- **[Fail #1 — RESOLVED] Detuned drive left behind.** Restore = SdoRead-snapshot C01.15/C01.18 before override, write back after + on-fault (hook existing drive-fault path). Backstop: firmware/daemon restart re-pushes printer.cfg `params:` baseline (note: C01.15/18 are NOT in params, they sit at default 318 — hence the snapshot is required, restart only covers params-listed objects).
+- **[Fail #2] Torque-FF clipping → harmonics.** clamp_torque/ff_saturation exist; clipping corrupts a clean tone. Accel ceiling (15000 mm/s²) bounds torque FF; keep amplitude in linear range.
+- **[Fail #3] Position centering / phase anchor.** Center buzz on rotor's current position at arm (reuse CountMap soft-home offset); anchor chirp phase to first cycle timestamp (EtherCAT analog of MCU anchor_cycle). Errors → start jump or end DC step.
+
+**[Constraint ★ — RESOLVED] Amplitude law = constant peak velocity (A ∝ 1/f).** PROVEN identity: respecting accel_per_hz (peak_accel = accel_per_hz·f, resonance_tester.py:323) ≡ constant peak velocity ≡ A ∝ 1/f. User's reasoning confirmed: const-accel starves top (A∝1/f²), const-displacement explodes top (accel∝f²), const-velocity is the right middle. ALREADY IMPLEMENTED in buzz_gen::amp_eff (amplitude·omega/omega_inst ∝ 1/f). EtherCAT generator reuses phase/amp_eff/envelope; only new math = analytic accel_rel (2nd derivative, ~10 lines).
+
+### Phase 4 — Decision Tree / Action Planning (staged build, gates + fallbacks)
+
+Host integration template (motion_engine.py:115-209): MotionEngineWrapper exposes sdo_read/sdo_write/set_torque/start_servo_capture — each (mcu_handle,…)→native MotionEngine→socket frame. Buzz = one more method in that mold. start_servo_capture/stop_servo_capture already exist → [Meas #1] capture during buzz needs zero daemon code.
+
+- **Stage 0 — Wire end-to-end (no motion).** wire.rs Command::ResonanceBuzz + decode (7 args); host-rt MotionEngine::resonance_buzz → frame; motion_engine.py resonance_buzz wrapper. Gate: args round-trip, logged.
+- **Stage 1 — Native oscillator → triplet, position channel only.** Add accel_rel to buzz_gen; new ethercat-rt buzz module (arm ToneParams, eval(now)→triplet, phase-anchored, centered via CountMap); DC loop triplet switch (FF for free downstream). Gate: 20–30 Hz (inside 35 Hz pos-loop BW) rotor oscillates. Fallback: jump/drift bug isolated to centering/anchor.
+- **Stage 2 — Climb the band.** No new code. Gate: audible 50–137 Hz (vel FF) then 137–300 Hz (torque FF) — empirical [Mode #2] test. Fallback: dies ~137 Hz → do Stage 3 first (likely the 318 Hz cutoff).
+- **Stage 3 — Transparent profile (mandatory override).** sdo_read snapshot + raise C01.15/C01.18 to ~2000 Hz; restore after + on-fault. Gate: 300 Hz cleaner with raise. Fallback: if raising destabilizes drive, back to highest stable cutoff, accept top rolloff.
+- **Stage 4 — RESONANCE_BUZZ_SWEEP + ramps.** Same args freq_start≠freq_end; envelope already present. Gate: 5→300 Hz sweep audible. Fallback: mushy top → test 2 kHz burst (Pi5 sustains ~3 s?) → buzz-only re-rate or declare honest ceiling.
+
+**[Risk ★] Axis→engine routing.** submit_resonance_buzz currently broadcasts to all engine MCUs (F401); servo & F401 have INDEPENDENT axis-index spaces (servo NUM_AXES=1, EC_AXIS_IDX=0). Must route by target axis's drive type: drive:servo → motion_engine.resonance_buzz(node_handle, mask=bit0,…); else existing MCU path. The real host design work — small, but get per-engine mask translation right.
+
+**Measurement path:** manual listening (MVP) → start_servo_capture during buzz captures position-actual + following-error = [Meas #1] loop-effort transfer-function signal, zero new daemon code → later accelerometer via existing resonance_tester ADXL path.
+
+
+## Idea Organization and Prioritization
+
+### Thematic Organization
+
+**Theme A — Excitation physics (mode & frequency-dependent FF).**
+The intellectual core. CSP is the faithful equivalent of stepper buzz (motor-side displacement source; resonance lives on the toolhead, outside the position loop). But position-commanding alone dies above ~35 Hz, so the excitation channel hands off with frequency. Ideas: Phys#1 (command-the-derivative), Phys#2 (CSP vs CST are opposite tests), Phys#3 (CSP = faithful stepper-buzz equivalent), Mode#1 (CSP + triple FF), **Mode#2 (★ FF channel changes with frequency: pos≤35Hz → vel 35–137Hz → torque 137–300Hz)**, Constraint★ (constant peak velocity, A∝1/f).
+
+**Theme B — Drive transparency & safety.**
+The A6-EC is not a wire; three in-band filter layers + safety guards. Ideas: Drive#1 (notch/adaptive-notch/FF-filter/pos-ref-filter all in-band; adaptive notch would cancel the resonance being measured), Drive#2 (snapshot→override→restore profile), Drive#3 (6065h/6066h following-error guards exist), Fail#1 (restore-on-fault, restart-reloads-params backstop), Fail#2 (torque-FF clipping → harmonics), Fail#3 (centering + phase anchor).
+
+**Theme C — Architecture & integration.**
+Where the code lives and how it's wired. Ideas: Arch#1 (native ethercat-rt generator, mirror MCU buzz pattern), **Arch#2 (★ buzz routes via motion_engine, NOT the MCU command bus — "zero host change" is false; servo is not an engine-MCU)**, Arch#3 (★ bypass-vs-feedthrough dissolves: buzz = alternate (pos,vel,acc) triplet source), Risk★ (axis→engine routing by drive type), Grid#2/3/4 (CSV smoothing/drift, reconstruction-not-Nyquist — informed the rejection of pure CSV).
+
+**Theme D — Measurement (future).**
+Manual listening is the MVP; richer verification later. Ideas: Meas#1 (loop-effort / following-error as accelerometer-free transfer-function signal via existing start_servo_capture), Safety#1 (response-limited torque AGC — parked), pre-emphasis (parked), 2 kHz-burst feasibility (escape hatch for >300 Hz).
+
+### Prioritization Results
+
+**Critical path (build these, in order):**
+1. Arch#3 — triplet-source switch in the DC loop (the integration seam).
+2. Mode#1 + Mode#2 — triple-FF emission (already wired downstream; comes "for free" once the triplet flows).
+3. Constraint★ — reuse buzz_gen amp_eff/phase/envelope + add accel_rel (only new math).
+4. Arch#2 + Risk★ — host axis→engine routing + new wire Command + motion_engine.resonance_buzz.
+
+**Mandatory guardrails (ship with the above):**
+- Drive#2 / Stage 3 — raise FF cutoffs C01.15/C01.18 during buzz (the one non-optional drive override).
+- Fail#1 — SdoRead snapshot + restore-on-fault; restart-reloads-params backstop.
+- Fail#3 — center on current rotor position + anchor chirp phase to first cycle.
+
+**Parked / breakthrough-for-later:**
+- Meas#1 — capture-during-buzz transfer function (zero new daemon code; do when graduating from manual listening).
+- Safety#1 — torque-AGC excitation (only if force-honest modal analysis is ever wanted).
+- Pre-emphasis + 2 kHz-burst — the >300 Hz path.
+
+### Action Planning (staged build with gates + fallbacks)
+
+- **Stage 0 — Wire end-to-end (no motion).** wire.rs `Command::ResonanceBuzz` (+decode, 7 args) · host-rt `MotionEngine::resonance_buzz` · motion_engine.py wrapper. Gate: args round-trip + logged.
+- **Stage 1 — Native oscillator, position channel.** Add `accel_rel` to buzz_gen · new ethercat-rt buzz module (arm ToneParams, eval→triplet, phase-anchored, CountMap-centered) · DC-loop triplet switch. Gate: 20–30 Hz rotor oscillates (FF free downstream). Fallback: jump/drift → centering/anchor bug, isolated.
+- **Stage 2 — Climb the band.** No new code. Gate: audible 50–137 Hz (vel FF) then 137–300 Hz (torque FF) = empirical Mode#2 proof. Fallback: dies ~137 Hz → do Stage 3 first.
+- **Stage 3 — Transparent profile.** sdo_read snapshot + raise C01.15/C01.18 (~2000 Hz); restore after + on-fault. Gate: 300 Hz cleaner with raise. Fallback: instability → highest stable cutoff, accept top rolloff.
+- **Stage 4 — RESONANCE_BUZZ_SWEEP + ramps.** Same args freq_start≠freq_end; envelope present. Gate: 5→300 Hz sweep audible. Fallback: mushy top → test 2 kHz burst → re-rate or declare honest ceiling.
+
+## Session Summary and Insights
+
+**Key achievements:**
+- Reframed the stated problem ("fixed update rate vs arbitrary frequency") — the real enemy is the drive's in-band reconstruction/filtering, not Nyquist (300 Hz < 500 Hz Nyquist at 1 kHz).
+- Settled the control mode: CSP + triple feedforward (rejected pure CSP for resolution, pure CSV for drift, pure CST for runaway).
+- Discovered the load-bearing constraint (Mode#2): the excitation channel is frequency-dependent; torque FF is mandatory for coverage above ~137 Hz, not an optimization.
+- Caught a silent data-corrupter (adaptive notch cancels the measured resonance) — off on the bench, but must stay off / be documented.
+- Corrected a false assumption (Arch#2): the servo isn't an engine-MCU, so the host needs one routing branch; the right invariant is "same buzz args, different transport."
+- Produced a staged, gated, fallback-equipped build plan grounded in the actual DC loop and host API.
+
+**Most surprising:** how much of the design already exists — velocity_ff + dynamics_profile active on the bench, amp_eff already encodes the constant-velocity law, the DC loop is mode-agnostic at the triplet, and start_servo_capture is a ready measurement hook. The feature is mostly "route + a small native oscillator," not new infrastructure.
+
+**Breakthrough concept:** Arch#3 — the integration seam is the (pos, vel, acc) triplet, the one place the buzz oscillator and the piece engine naturally agree, dissolving the bypass-vs-feedthrough debate.

--- a/klippy/extras/resonance_buzz.py
+++ b/klippy/extras/resonance_buzz.py
@@ -1,0 +1,188 @@
+import math
+
+MOTOR_A = 0b001
+MOTOR_B = 0b010
+MOTOR_Z = 0b100
+
+
+def buzz_axis_to_motor_mask(axis, coupled):
+    axis = axis.lower()
+    if coupled:
+        corexy_in_phase = (MOTOR_A | MOTOR_B, 0)
+        corexy_anti_phase = (MOTOR_A | MOTOR_B, MOTOR_B)
+        mapping = {
+            "x": corexy_in_phase,
+            "y": corexy_anti_phase,
+            "z": (MOTOR_Z, 0),
+        }
+    else:
+        mapping = {
+            "x": (MOTOR_A, 0),
+            "y": (MOTOR_B, 0),
+            "z": (MOTOR_Z, 0),
+        }
+    if axis not in mapping:
+        raise ValueError("unsupported buzz axis %r" % (axis,))
+    return mapping[axis]
+
+
+BUZZ_PEAK_ACCEL_CEILING_MM_S2 = 15000.0
+BUZZ_MAX_AMPLITUDE_MM = 5.0
+
+
+def sinusoid_peak_accel(accel_per_hz, freq_hz):
+    return accel_per_hz * freq_hz
+
+
+def sinusoid_amplitude_mm(accel_per_hz, freq_hz):
+    return accel_per_hz / (4.0 * math.pi**2 * freq_hz)
+
+
+class ResonanceBuzz:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object("gcode")
+        self.gcode.register_command(
+            "RESONANCE_BUZZ",
+            self.cmd_RESONANCE_BUZZ,
+            desc=self.cmd_RESONANCE_BUZZ_help,
+        )
+        self.gcode.register_command(
+            "RESONANCE_BUZZ_SWEEP",
+            self.cmd_RESONANCE_BUZZ_SWEEP,
+            desc=self.cmd_RESONANCE_BUZZ_SWEEP_help,
+        )
+
+    def _submit_buzz(
+        self,
+        gcmd,
+        axis_name,
+        freq_start,
+        freq_end,
+        duration,
+        ramp,
+        accel_per_hz,
+        amplitude_mm,
+    ):
+        if axis_name not in ("x", "y", "z"):
+            raise gcmd.error("AXIS must be x, y, or z")
+        toolhead = self.printer.lookup_object("toolhead")
+        motion = self.printer.lookup_object("motion")
+        kin = toolhead.get_kinematics()
+        coupled = bool(getattr(kin, "coupled_xy", lambda: False)())
+        try:
+            axis_mask, sign_mask = buzz_axis_to_motor_mask(axis_name, coupled)
+        except ValueError as e:
+            raise gcmd.error(str(e))
+
+        if amplitude_mm <= 0.0:
+            highest_freq = max(freq_start, freq_end)
+            if (
+                sinusoid_peak_accel(accel_per_hz, highest_freq)
+                > BUZZ_PEAK_ACCEL_CEILING_MM_S2
+            ):
+                accel_per_hz = BUZZ_PEAK_ACCEL_CEILING_MM_S2 / highest_freq
+                gcmd.respond_info(
+                    "RESONANCE_BUZZ: clamped accel_per_hz to %.1f to keep peak "
+                    "accel <= %.0f mm/s^2 at %.1f Hz"
+                    % (
+                        accel_per_hz,
+                        BUZZ_PEAK_ACCEL_CEILING_MM_S2,
+                        highest_freq,
+                    )
+                )
+            amplitude_mm = sinusoid_amplitude_mm(accel_per_hz, freq_start)
+        if amplitude_mm > BUZZ_MAX_AMPLITUDE_MM:
+            raise gcmd.error(
+                "RESONANCE_BUZZ amplitude %.3f mm at %.1f Hz exceeds %.1f mm "
+                "ceiling" % (amplitude_mm, freq_start, BUZZ_MAX_AMPLITUDE_MM)
+            )
+
+        toolhead.wait_moves()
+        motion.submit_resonance_buzz(
+            axis_mask,
+            sign_mask,
+            int(round(freq_start * 1000.0)),
+            int(round(freq_end * 1000.0)),
+            int(round(amplitude_mm * 1e6)),
+            int(round(duration * 1000.0)),
+            int(round(ramp * 1000.0)),
+        )
+        phasing = ""
+        if coupled and axis_name in ("x", "y"):
+            phasing = " (corexy A/B %s)" % (
+                "in-phase" if axis_name == "x" else "anti-phase"
+            )
+        if abs(freq_end - freq_start) < 1e-6:
+            freq_desc = "freq=%.1fHz" % (freq_start,)
+        else:
+            freq_desc = "sweep=%.1f->%.1fHz" % (freq_start, freq_end)
+        gcmd.respond_info(
+            "RESONANCE_BUZZ axis=%s %s amplitude@start=%.1fum duration=%.2fs%s"
+            % (axis_name, freq_desc, amplitude_mm * 1000.0, duration, phasing)
+        )
+        reactor = self.printer.get_reactor()
+        reactor.pause(reactor.monotonic() + duration + 0.1)
+
+    cmd_RESONANCE_BUZZ_help = (
+        "Excite a single resonance frequency on one axis via the engine-"
+        "resident buzz generator"
+    )
+
+    def cmd_RESONANCE_BUZZ(self, gcmd):
+        axis_name = gcmd.get("AXIS", "x").lower()
+        freq = gcmd.get_float("FREQ", 50.0, above=0.0)
+        duration = gcmd.get_float("DURATION", 1.0, above=0.0)
+        accel_per_hz = gcmd.get_float("ACCEL_PER_HZ", 75.0, above=0.0)
+        amplitude_mm = gcmd.get_float("AMPLITUDE", 0.0, minval=0.0)
+        ramp = gcmd.get_float(
+            "RAMP", min(duration * 0.25, 3.0 / freq), above=0.0
+        )
+        self._submit_buzz(
+            gcmd,
+            axis_name,
+            freq,
+            freq,
+            duration,
+            ramp,
+            accel_per_hz,
+            amplitude_mm,
+        )
+
+    cmd_RESONANCE_BUZZ_SWEEP_help = (
+        "Sweep a frequency band on one axis via the engine-resident chirp "
+        "generator (one fade-in/out for the whole sweep)"
+    )
+
+    def cmd_RESONANCE_BUZZ_SWEEP(self, gcmd):
+        axis_name = gcmd.get("AXIS", "x").lower()
+        freq_start = gcmd.get_float("FREQ_START", 5.0, above=0.0)
+        freq_end = gcmd.get_float("FREQ_END", 135.0, above=0.0)
+        accel_per_hz = gcmd.get_float("ACCEL_PER_HZ", 75.0, above=0.0)
+        amplitude_mm = gcmd.get_float("AMPLITUDE", 0.0, minval=0.0)
+        hz_per_sec = gcmd.get_float("HZ_PER_SEC", 1.0, above=0.0)
+        span = abs(freq_end - freq_start)
+        duration = gcmd.get_float("DURATION", 0.0, minval=0.0)
+        if duration <= 0.0:
+            duration = max(span / hz_per_sec, 0.1)
+        three_periods_of_lowest = 3.0 / min(freq_start, freq_end)
+        tenth_of_sweep = 0.1 * duration
+        ramp = gcmd.get_float(
+            "RAMP",
+            min(tenth_of_sweep, three_periods_of_lowest),
+            above=0.0,
+        )
+        self._submit_buzz(
+            gcmd,
+            axis_name,
+            freq_start,
+            freq_end,
+            duration,
+            ramp,
+            accel_per_hz,
+            amplitude_mm,
+        )
+
+
+def load_config(config):
+    return ResonanceBuzz(config)

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -289,44 +289,6 @@ class ResonanceTestExecutor:
             toolhead.move([X + decel_X, Y + decel_Y, Z, E], abs(last_v))
 
 
-MOTOR_A = 0b001
-MOTOR_B = 0b010
-MOTOR_Z = 0b100
-
-
-def buzz_axis_to_motor_mask(axis, coupled):
-    axis = axis.lower()
-    if coupled:
-        corexy_in_phase = (MOTOR_A | MOTOR_B, 0)
-        corexy_anti_phase = (MOTOR_A | MOTOR_B, MOTOR_B)
-        mapping = {
-            "x": corexy_in_phase,
-            "y": corexy_anti_phase,
-            "z": (MOTOR_Z, 0),
-        }
-    else:
-        mapping = {
-            "x": (MOTOR_A, 0),
-            "y": (MOTOR_B, 0),
-            "z": (MOTOR_Z, 0),
-        }
-    if axis not in mapping:
-        raise ValueError("unsupported buzz axis %r" % (axis,))
-    return mapping[axis]
-
-
-BUZZ_PEAK_ACCEL_CEILING_MM_S2 = 15000.0
-BUZZ_MAX_AMPLITUDE_MM = 5.0
-
-
-def sinusoid_peak_accel(accel_per_hz, freq_hz):
-    return accel_per_hz * freq_hz
-
-
-def sinusoid_amplitude_mm(accel_per_hz, freq_hz):
-    return accel_per_hz / (4.0 * math.pi**2 * freq_hz)
-
-
 class ResonanceTester:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -379,16 +341,6 @@ class ResonanceTester:
             "SHAPER_CALIBRATE",
             self.cmd_SHAPER_CALIBRATE,
             desc=self.cmd_SHAPER_CALIBRATE_help,
-        )
-        self.gcode.register_command(
-            "RESONANCE_BUZZ",
-            self.cmd_RESONANCE_BUZZ,
-            desc=self.cmd_RESONANCE_BUZZ_help,
-        )
-        self.gcode.register_command(
-            "RESONANCE_BUZZ_SWEEP",
-            self.cmd_RESONANCE_BUZZ_SWEEP,
-            desc=self.cmd_RESONANCE_BUZZ_SWEEP_help,
         )
         self.printer.register_event_handler("klippy:connect", self.connect)
 
@@ -653,136 +605,6 @@ class ResonanceTester:
         gcmd.respond_info(
             "The SAVE_CONFIG command will update the printer config file\n"
             "with these parameters and restart the printer."
-        )
-
-    def _submit_buzz(
-        self,
-        gcmd,
-        axis_name,
-        freq_start,
-        freq_end,
-        duration,
-        ramp,
-        accel_per_hz,
-        amplitude_mm,
-    ):
-        if axis_name not in ("x", "y", "z"):
-            raise gcmd.error("AXIS must be x, y, or z")
-        toolhead = self.printer.lookup_object("toolhead")
-        motion = self.printer.lookup_object("motion")
-        kin = toolhead.get_kinematics()
-        coupled = bool(getattr(kin, "coupled_xy", lambda: False)())
-        try:
-            axis_mask, sign_mask = buzz_axis_to_motor_mask(axis_name, coupled)
-        except ValueError as e:
-            raise gcmd.error(str(e))
-
-        if amplitude_mm <= 0.0:
-            highest_freq = max(freq_start, freq_end)
-            if (
-                sinusoid_peak_accel(accel_per_hz, highest_freq)
-                > BUZZ_PEAK_ACCEL_CEILING_MM_S2
-            ):
-                accel_per_hz = BUZZ_PEAK_ACCEL_CEILING_MM_S2 / highest_freq
-                gcmd.respond_info(
-                    "RESONANCE_BUZZ: clamped accel_per_hz to %.1f to keep peak "
-                    "accel <= %.0f mm/s^2 at %.1f Hz"
-                    % (
-                        accel_per_hz,
-                        BUZZ_PEAK_ACCEL_CEILING_MM_S2,
-                        highest_freq,
-                    )
-                )
-            amplitude_mm = sinusoid_amplitude_mm(accel_per_hz, freq_start)
-        if amplitude_mm > BUZZ_MAX_AMPLITUDE_MM:
-            raise gcmd.error(
-                "RESONANCE_BUZZ amplitude %.3f mm at %.1f Hz exceeds %.1f mm "
-                "ceiling" % (amplitude_mm, freq_start, BUZZ_MAX_AMPLITUDE_MM)
-            )
-
-        toolhead.wait_moves()
-        motion.submit_resonance_buzz(
-            axis_mask,
-            sign_mask,
-            int(round(freq_start * 1000.0)),
-            int(round(freq_end * 1000.0)),
-            int(round(amplitude_mm * 1e6)),
-            int(round(duration * 1000.0)),
-            int(round(ramp * 1000.0)),
-        )
-        phasing = ""
-        if coupled and axis_name in ("x", "y"):
-            phasing = " (corexy A/B %s)" % (
-                "in-phase" if axis_name == "x" else "anti-phase"
-            )
-        if abs(freq_end - freq_start) < 1e-6:
-            freq_desc = "freq=%.1fHz" % (freq_start,)
-        else:
-            freq_desc = "sweep=%.1f->%.1fHz" % (freq_start, freq_end)
-        gcmd.respond_info(
-            "RESONANCE_BUZZ axis=%s %s amplitude@start=%.1fum duration=%.2fs%s"
-            % (axis_name, freq_desc, amplitude_mm * 1000.0, duration, phasing)
-        )
-        reactor = self.printer.get_reactor()
-        reactor.pause(reactor.monotonic() + duration + 0.1)
-
-    cmd_RESONANCE_BUZZ_help = (
-        "Excite a single resonance frequency on one axis via the MCU-resident "
-        "buzz generator"
-    )
-
-    def cmd_RESONANCE_BUZZ(self, gcmd):
-        axis_name = gcmd.get("AXIS", "x").lower()
-        freq = gcmd.get_float("FREQ", 50.0, above=0.0)
-        duration = gcmd.get_float("DURATION", 1.0, above=0.0)
-        accel_per_hz = gcmd.get_float("ACCEL_PER_HZ", 75.0, above=0.0)
-        amplitude_mm = gcmd.get_float("AMPLITUDE", 0.0, minval=0.0)
-        ramp = gcmd.get_float(
-            "RAMP", min(duration * 0.25, 3.0 / freq), above=0.0
-        )
-        self._submit_buzz(
-            gcmd,
-            axis_name,
-            freq,
-            freq,
-            duration,
-            ramp,
-            accel_per_hz,
-            amplitude_mm,
-        )
-
-    cmd_RESONANCE_BUZZ_SWEEP_help = (
-        "Sweep a frequency band on one axis via the MCU-resident chirp "
-        "generator (one fade-in/out for the whole sweep)"
-    )
-
-    def cmd_RESONANCE_BUZZ_SWEEP(self, gcmd):
-        axis_name = gcmd.get("AXIS", "x").lower()
-        freq_start = gcmd.get_float("FREQ_START", 5.0, above=0.0)
-        freq_end = gcmd.get_float("FREQ_END", 135.0, above=0.0)
-        accel_per_hz = gcmd.get_float("ACCEL_PER_HZ", 75.0, above=0.0)
-        amplitude_mm = gcmd.get_float("AMPLITUDE", 0.0, minval=0.0)
-        hz_per_sec = gcmd.get_float("HZ_PER_SEC", 1.0, above=0.0)
-        span = abs(freq_end - freq_start)
-        duration = gcmd.get_float("DURATION", 0.0, minval=0.0)
-        if duration <= 0.0:
-            duration = max(span / hz_per_sec, 0.1)
-        three_periods_of_lowest = 3.0 / min(freq_start, freq_end)
-        tenth_of_sweep = 0.1 * duration
-        ramp = gcmd.get_float(
-            "RAMP",
-            min(tenth_of_sweep, three_periods_of_lowest),
-            above=0.0,
-        )
-        self._submit_buzz(
-            gcmd,
-            axis_name,
-            freq_start,
-            freq_end,
-            duration,
-            ramp,
-            accel_per_hz,
-            amplitude_mm,
         )
 
     cmd_MEASURE_AXES_NOISE_help = (

--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -198,6 +198,7 @@ class Motion:
             "manual_probe",
             "tuning_tower",
             "garbage_collection",
+            "resonance_buzz",
         ):
             printer.load_object(config, module_name)
 
@@ -256,7 +257,7 @@ class Motion:
         duration_ms,
         ramp_ms,
     ):
-        from .extras.resonance_tester import buzz_axis_to_motor_mask
+        from .extras.resonance_buzz import buzz_axis_to_motor_mask
 
         stepper_mask = axis_mask
         sent = False

--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -256,32 +256,72 @@ class Motion:
         duration_ms,
         ramp_ms,
     ):
+        from .extras.resonance_tester import buzz_axis_to_motor_mask
+
+        stepper_mask = axis_mask
         sent = False
-        for mcu_obj in self._engine_mcus():
-            try:
-                cmd = mcu_obj.lookup_command(
-                    "kalico_resonance_buzz axis_mask=%c sign_mask=%c"
-                    " freq_start_millihz=%u freq_end_millihz=%u amplitude_nm=%u"
-                    " duration_ms=%u ramp_ms=%u"
+        if self.kin is not None:
+            for lane_idx, _axis_name, _motors in self.kin.lanes():
+                rail = self.kin.rails[lane_idx]
+                if not isinstance(rail, servo_axis.ServoRail):
+                    continue
+                rail_mask, _ = buzz_axis_to_motor_mask(rail.axis, False)
+                if not (axis_mask & rail_mask):
+                    continue
+                stepper_mask &= ~rail_mask
+                node = self.printer.lookup_object(
+                    "ethercat_node " + rail.get_node_name(), None
                 )
-            except Exception:
-                continue
-            cmd.send(
-                [
-                    axis_mask,
-                    sign_mask,
+                handle = node.get_engine_handle() if node is not None else None
+                if handle is None:
+                    raise self.printer.command_error(
+                        "RESONANCE_BUZZ: servo axis %s has no live EtherCAT "
+                        "engine handle" % rail.axis
+                    )
+                self.engine.resonance_buzz(
+                    handle,
+                    1,
+                    1 if (sign_mask & rail_mask) else 0,
                     freq_start_millihz,
                     freq_end_millihz,
                     amplitude_nm,
                     duration_ms,
                     ramp_ms,
-                ]
-            )
+                )
+                sent = True
+        if stepper_mask:
+            stepper_sent = False
+            for mcu_obj in self._engine_mcus():
+                try:
+                    cmd = mcu_obj.lookup_command(
+                        "kalico_resonance_buzz axis_mask=%c sign_mask=%c"
+                        " freq_start_millihz=%u freq_end_millihz=%u amplitude_nm=%u"
+                        " duration_ms=%u ramp_ms=%u"
+                    )
+                except Exception:
+                    continue
+                cmd.send(
+                    [
+                        stepper_mask,
+                        sign_mask,
+                        freq_start_millihz,
+                        freq_end_millihz,
+                        amplitude_nm,
+                        duration_ms,
+                        ramp_ms,
+                    ]
+                )
+                stepper_sent = True
+            if not stepper_sent:
+                raise self.printer.command_error(
+                    "No engine MCU advertises kalico_resonance_buzz; rebuild and "
+                    "reflash MCU firmware with CONFIG_RUNTIME=y"
+                )
             sent = True
         if not sent:
             raise self.printer.command_error(
-                "No engine MCU advertises kalico_resonance_buzz; rebuild and "
-                "reflash MCU firmware with CONFIG_RUNTIME=y"
+                "RESONANCE_BUZZ: no target engine for axis_mask=0x%02x"
+                % axis_mask
             )
 
     def set_extruder(self, extruder, extrude_pos):

--- a/klippy/motion_engine.py
+++ b/klippy/motion_engine.py
@@ -188,6 +188,28 @@ class MotionEngineWrapper:
     def sdo_write(self, mcu_handle, index, subindex, size, value):
         return self._engine.sdo_write(mcu_handle, index, subindex, size, value)
 
+    def resonance_buzz(
+        self,
+        mcu_handle,
+        axis_mask,
+        sign_mask,
+        freq_start_millihz,
+        freq_end_millihz,
+        amplitude_nm,
+        duration_ms,
+        ramp_ms,
+    ):
+        return self._engine.resonance_buzz(
+            mcu_handle,
+            axis_mask,
+            sign_mask,
+            freq_start_millihz,
+            freq_end_millihz,
+            amplitude_nm,
+            duration_ms,
+            ramp_ms,
+        )
+
     def release_mcu(self, handle):
         return self._engine.release_mcu(handle)
 

--- a/rust/ethercat-rt/src/bin/ethercat-rt-stub.rs
+++ b/rust/ethercat-rt/src/bin/ethercat-rt-stub.rs
@@ -17,10 +17,11 @@ use ethercat_rt::torque::{
 };
 use ethercat_rt::wire::{
     claim_handshake_reply_frame, identify_response_frame, push_pieces_response_frame,
-    restore_drive_limits_response_frame, resume_stream_response_frame, runtime_caps_response_frame,
-    sdo_read_response_frame, sdo_write_response_frame, seed_servo_home_response_frame,
-    set_drive_limits_response_frame, set_torque_response_frame, start_capture_response_frame,
-    status_heartbeat_frame, stop_capture_response_frame, stop_response_frame, Command,
+    resonance_buzz_response_frame, restore_drive_limits_response_frame,
+    resume_stream_response_frame, runtime_caps_response_frame, sdo_read_response_frame,
+    sdo_write_response_frame, seed_servo_home_response_frame, set_drive_limits_response_frame,
+    set_torque_response_frame, start_capture_response_frame, status_heartbeat_frame,
+    stop_capture_response_frame, stop_response_frame, Command,
 };
 use mcu_protocol::messages::{SdoReadResponse, SlaveState, StopCaptureResponse};
 
@@ -285,6 +286,16 @@ fn main() {
                 } => {
                     eprintln!("ec-rt-stub: SeedServoHome home_q16={home_q16}");
                     server.respond(&seed_servo_home_response_frame(correlation_id, 0));
+                }
+                Command::ResonanceBuzz {
+                    correlation_id,
+                    msg,
+                } => {
+                    eprintln!(
+                        "ec-rt-stub: ResonanceBuzz axis_mask=0x{:02x} freq={}->{} mHz",
+                        msg.axis_mask, msg.freq_start_millihz, msg.freq_end_millihz,
+                    );
+                    server.respond(&resonance_buzz_response_frame(correlation_id, 0));
                 }
                 Command::SdoRead {
                     correlation_id,

--- a/rust/ethercat-rt/src/bin/ethercat-rt.rs
+++ b/rust/ethercat-rt/src/bin/ethercat-rt.rs
@@ -6,6 +6,7 @@
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use ethercat_rt::buzz::BuzzOsc;
 use ethercat_rt::capture::{
     Capture, CaptureConfig, CaptureRecord, DriveSample, PendingStart, PendingStop,
     FLAG_MOTION_ACTIVE, FLAG_TORQUE_ENABLED,
@@ -29,11 +30,11 @@ use ethercat_rt::torque::{
 };
 use ethercat_rt::wire::{
     claim_handshake_reply_frame, identify_response_frame, motor_state_empty_frame,
-    motor_state_response_frame, push_pieces_response_frame, restore_drive_limits_response_frame,
-    resume_stream_response_frame, runtime_caps_response_frame, sdo_read_response_frame,
-    sdo_write_response_frame, seed_servo_home_response_frame, set_drive_limits_response_frame,
-    set_torque_response_frame, start_capture_response_frame, status_heartbeat_frame,
-    stop_capture_response_frame, stop_response_frame, Command,
+    motor_state_response_frame, push_pieces_response_frame, resonance_buzz_response_frame,
+    restore_drive_limits_response_frame, resume_stream_response_frame, runtime_caps_response_frame,
+    sdo_read_response_frame, sdo_write_response_frame, seed_servo_home_response_frame,
+    set_drive_limits_response_frame, set_torque_response_frame, start_capture_response_frame,
+    status_heartbeat_frame, stop_capture_response_frame, stop_response_frame, Command,
 };
 use mcu_protocol::messages::{
     SlaveState, StopCaptureResponse, ERR_SDO_TRANSPORT, ERR_SDO_UNSUPPORTED_SIZE,
@@ -163,6 +164,7 @@ fn main() {
         .unwrap_or(500);
 
     let mut ring = AxisRing::new();
+    let mut buzz = BuzzOsc::new();
     let mut cmap: Option<CountMap> = None;
     let mut framed = false;
     let mut seed_home_inflight: Option<u32> = None;
@@ -489,6 +491,52 @@ fn main() {
                         });
                     }
                 }
+                Command::ResonanceBuzz {
+                    correlation_id,
+                    msg,
+                } => {
+                    let rc = if gate.state() != TorqueState::Enabled {
+                        eprintln!("ec-rt: ResonanceBuzz rejected — drive not operation-enabled");
+                        ethercat_rt::buzz::ERR_BUZZ_NOT_ENABLED
+                    } else if !ring.is_empty() || buzz.active() {
+                        eprintln!("ec-rt: ResonanceBuzz rejected — motion in progress");
+                        if buzz.active() {
+                            ethercat_rt::buzz::ERR_BUZZ_BUSY
+                        } else {
+                            ethercat_rt::buzz::ERR_BUZZ_STREAMING
+                        }
+                    } else {
+                        let base_counts = if framed {
+                            unsafe { ffi::ec_rt_get_position_actual() }
+                        } else {
+                            0
+                        };
+                        let rc = buzz.arm(
+                            msg.axis_mask,
+                            msg.sign_mask,
+                            msg.freq_start_millihz,
+                            msg.freq_end_millihz,
+                            msg.amplitude_nm,
+                            msg.duration_ms,
+                            msg.ramp_ms,
+                            base_counts,
+                        );
+                        eprintln!(
+                            "ec-rt: ResonanceBuzz axis_mask=0x{:02x} sign_mask=0x{:02x} \
+                             freq={}->{} mHz amplitude={} nm duration={} ms ramp={} ms \
+                             base_counts={base_counts} rc={rc}",
+                            msg.axis_mask,
+                            msg.sign_mask,
+                            msg.freq_start_millihz,
+                            msg.freq_end_millihz,
+                            msg.amplitude_nm,
+                            msg.duration_ms,
+                            msg.ramp_ms,
+                        );
+                        rc
+                    };
+                    server.respond(&resonance_buzz_response_frame(correlation_id, rc));
+                }
                 Command::SdoRead {
                     correlation_id,
                     msg,
@@ -700,7 +748,14 @@ fn main() {
 
         let mut motion_active = false;
         if gate.state() == TorqueState::Enabled {
-            if let Some((pos_mm, vel_mm_s, acc_mm_s2)) = ring.sample(now) {
+            let setpoint = if buzz.active() {
+                buzz.eval(now).map(|(rel_mm, vel_mm_s, acc_mm_s2)| {
+                    let counts = buzz
+                        .base_counts()
+                        .wrapping_add(mm_to_counts(f64::from(rel_mm), counts_per_mm));
+                    (counts, vel_mm_s, acc_mm_s2)
+                })
+            } else if let Some((pos_mm, vel_mm_s, acc_mm_s2)) = ring.sample(now) {
                 let counts = if framed {
                     mm_to_counts(f64::from(pos_mm), counts_per_mm)
                 } else {
@@ -710,6 +765,12 @@ fn main() {
                     });
                     map.target_counts(f64::from(pos_mm))
                 };
+                Some((counts, vel_mm_s, acc_mm_s2))
+            } else {
+                None
+            };
+
+            if let Some((counts, vel_mm_s, acc_mm_s2)) = setpoint {
                 let vel_offset = if velocity_ff {
                     (f64::from(vel_mm_s) * counts_per_mm).round() as i32
                 } else {
@@ -745,7 +806,9 @@ fn main() {
                 }
                 motion_active = true;
             } else {
-                cmap = None;
+                if !buzz.active() {
+                    cmap = None;
+                }
                 unsafe {
                     ffi::ec_rt_set_velocity_offset(0);
                     ffi::ec_rt_set_torque_offset(0);

--- a/rust/ethercat-rt/src/buzz.rs
+++ b/rust/ethercat-rt/src/buzz.rs
@@ -1,0 +1,117 @@
+use runtime::buzz::Buzz;
+use runtime::buzz_gen::{sample_rel, ToneParams};
+
+pub const ERR_BUZZ_NOT_ENABLED: i32 = -828;
+pub const ERR_BUZZ_STREAMING: i32 = -829;
+pub const ERR_BUZZ_BUSY: i32 = -830;
+
+#[allow(missing_debug_implementations)]
+pub struct BuzzOsc {
+    params: ToneParams,
+    base_counts: i32,
+    anchor_ns: u64,
+    anchored: bool,
+    active: bool,
+}
+
+impl BuzzOsc {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            params: ToneParams {
+                omega: 0.0,
+                mu: 0.0,
+                amplitude_mm: 0.0,
+                sign: 1.0,
+                base_mm: 0.0,
+                microstep_distance: 1.0,
+                anchor_cycle: 0,
+                cycles_per_second: 1.0,
+                total_seconds: 0.0,
+                ramp_seconds: 0.0,
+            },
+            base_counts: 0,
+            anchor_ns: 0,
+            anchored: false,
+            active: false,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn arm(
+        &mut self,
+        axis_mask: u8,
+        sign_mask: u8,
+        freq_start_millihz: u32,
+        freq_end_millihz: u32,
+        amplitude_nm: u32,
+        duration_ms: u32,
+        ramp_ms: u32,
+        base_counts: i32,
+    ) -> i32 {
+        self.active = false;
+        let mut buzz = Buzz::new();
+        let rc = buzz.arm(
+            1,
+            axis_mask,
+            sign_mask,
+            freq_start_millihz,
+            freq_end_millihz,
+            amplitude_nm,
+            duration_ms,
+            ramp_ms,
+        );
+        if rc != 0 {
+            return rc;
+        }
+        let excitations = buzz.take_excitations();
+        let Some(first) = excitations.first() else {
+            return -1;
+        };
+        self.params = (*first).into_params(0.0, 1.0, 1.0, 0);
+        self.base_counts = base_counts;
+        self.anchored = false;
+        self.active = true;
+        0
+    }
+
+    #[must_use]
+    pub fn active(&self) -> bool {
+        self.active
+    }
+
+    #[must_use]
+    pub fn base_counts(&self) -> i32 {
+        self.base_counts
+    }
+
+    pub fn clear(&mut self) {
+        self.active = false;
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn eval(&mut self, now_ns: u64) -> Option<(f32, f32, f32)> {
+        if !self.active {
+            return None;
+        }
+        if !self.anchored {
+            self.anchor_ns = now_ns;
+            self.anchored = true;
+        }
+        let t = now_ns.saturating_sub(self.anchor_ns) as f64 * 1.0e-9;
+        if t as f32 >= self.params.total_seconds {
+            self.active = false;
+            return None;
+        }
+        Some(sample_rel(&self.params, t as f32))
+    }
+}
+
+impl Default for BuzzOsc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/ethercat-rt/src/buzz/tests.rs
+++ b/rust/ethercat-rt/src/buzz/tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+const FS: u32 = 40_000;
+const FE: u32 = 40_000;
+const AMP_NM: u32 = 1_000_000;
+const DUR_MS: u32 = 100;
+const RAMP_MS: u32 = 10;
+
+fn armed(base_counts: i32) -> BuzzOsc {
+    let mut osc = BuzzOsc::new();
+    let rc = osc.arm(0b1, 0, FS, FE, AMP_NM, DUR_MS, RAMP_MS, base_counts);
+    assert_eq!(rc, 0, "arm should succeed");
+    osc
+}
+
+#[test]
+fn arm_activates_and_records_base() {
+    let osc = armed(12_345);
+    assert!(osc.active());
+    assert_eq!(osc.base_counts(), 12_345);
+}
+
+#[test]
+fn rejects_zero_axis_mask() {
+    let mut osc = BuzzOsc::new();
+    let rc = osc.arm(0, 0, FS, FE, AMP_NM, DUR_MS, RAMP_MS, 0);
+    assert!(!osc.active(), "zero mask must not arm");
+    assert_eq!(rc, -1);
+}
+
+#[test]
+fn anchors_on_first_eval_and_starts_near_zero() {
+    let mut osc = armed(0);
+    let (pos, _vel, _acc) = osc.eval(1_000_000_000).expect("active");
+    assert!(pos.abs() < 1.0e-6, "envelope starts at zero, pos={pos}");
+}
+
+#[test]
+fn deactivates_after_duration() {
+    let mut osc = armed(0);
+    let start = 5_000_000_000u64;
+    assert!(osc.eval(start).is_some());
+    let past = start + u64::from(DUR_MS) * 1_000_000 + 1_000_000;
+    assert!(osc.eval(past).is_none(), "past duration yields None");
+    assert!(!osc.active(), "osc clears itself when done");
+}
+
+#[test]
+fn midpoint_produces_finite_motion() {
+    let mut osc = armed(0);
+    let start = 2_000_000_000u64;
+    let _ = osc.eval(start);
+    let mid = start + u64::from(DUR_MS) * 1_000_000 / 2;
+    let (pos, vel, acc) = osc.eval(mid).expect("active at midpoint");
+    assert!(pos.is_finite() && vel.is_finite() && acc.is_finite());
+    assert!(pos.abs() > 0.0, "flat-top motion is nonzero");
+}
+
+#[test]
+fn clear_stops_evaluation() {
+    let mut osc = armed(0);
+    osc.clear();
+    assert!(!osc.active());
+    assert!(osc.eval(1_000).is_none());
+}

--- a/rust/ethercat-rt/src/lib.rs
+++ b/rust/ethercat-rt/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod buzz;
 pub mod capture;
 pub mod claim;
 pub mod clock;

--- a/rust/ethercat-rt/src/wire.rs
+++ b/rust/ethercat-rt/src/wire.rs
@@ -2,10 +2,11 @@ use mcu_protocol::bootstrap::{IdentifyResponse, IDENTIFY_RESPONSE_BODY_LEN};
 use mcu_protocol::codec::{Decode, Encode};
 use mcu_protocol::messages::{
     ClaimHandshakeReply, MessageKind, MotorSample, MotorStateResponse, PushPieces,
-    PushPiecesResponse, RestoreDriveLimitsResponse, ResumeStreamResponse, RuntimeCapsResponse,
-    SdoRead, SdoReadResponse, SdoWrite, SdoWriteResponse, SeedServoHome, SeedServoHomeResponse,
-    SetDriveLimits, SetDriveLimitsResponse, SetTorque, SetTorqueResponse, StartCapture,
-    StartCaptureResponse, StatusHeartbeat, StopCaptureResponse, StopResponse,
+    PushPiecesResponse, ResonanceBuzz, ResonanceBuzzResponse, RestoreDriveLimitsResponse,
+    ResumeStreamResponse, RuntimeCapsResponse, SdoRead, SdoReadResponse, SdoWrite,
+    SdoWriteResponse, SeedServoHome, SeedServoHomeResponse, SetDriveLimits, SetDriveLimitsResponse,
+    SetTorque, SetTorqueResponse, StartCapture, StartCaptureResponse, StatusHeartbeat,
+    StopCaptureResponse, StopResponse,
 };
 use mcu_protocol::MCU_CHANNEL_PIECES;
 use mcu_transport::frame::{encode_frame, CHANNEL_CONTROL, CHANNEL_EVENTS};
@@ -59,6 +60,10 @@ pub enum Command {
     SeedServoHome {
         correlation_id: u32,
         home_q16: i32,
+    },
+    ResonanceBuzz {
+        correlation_id: u32,
+        msg: ResonanceBuzz,
     },
     SdoRead {
         correlation_id: u32,
@@ -147,6 +152,13 @@ pub fn decode_command(channel: u8, payload: &[u8]) -> Result<Command, DecodeCmdE
             Ok(Command::SeedServoHome {
                 correlation_id: cid,
                 home_q16: msg.home_q16,
+            })
+        }
+        Some(MessageKind::ResonanceBuzz) => {
+            let msg = ResonanceBuzz::decode(body).map_err(|_| DecodeCmdError::BadBody)?;
+            Ok(Command::ResonanceBuzz {
+                correlation_id: cid,
+                msg,
             })
         }
         Some(MessageKind::SdoRead) => {
@@ -260,6 +272,11 @@ pub fn restore_drive_limits_response_frame(cid: u32, result: i32) -> Vec<u8> {
 pub fn seed_servo_home_response_frame(cid: u32, result: i32) -> Vec<u8> {
     let body = SeedServoHomeResponse { result }.encoded_to_vec();
     control_frame(MessageKind::SeedServoHomeResponse, cid, &body)
+}
+
+pub fn resonance_buzz_response_frame(cid: u32, result: i32) -> Vec<u8> {
+    let body = ResonanceBuzzResponse { result }.encoded_to_vec();
+    control_frame(MessageKind::ResonanceBuzzResponse, cid, &body)
 }
 
 pub fn status_heartbeat_frame(

--- a/rust/ethercat-rt/src/wire/tests.rs
+++ b/rust/ethercat-rt/src/wire/tests.rs
@@ -1,9 +1,9 @@
 use super::*;
 use mcu_protocol::messages::{
-    MotorStateResponse, RestoreDriveLimitsResponse, ResumeStreamResponse, SdoRead, SdoReadResponse,
-    SdoWrite, SdoWriteResponse, SeedServoHome, SeedServoHomeResponse, SetDriveLimits,
-    SetDriveLimitsResponse, SlaveState, SlaveStatus, StartCapture, StartCaptureResponse,
-    StopCaptureResponse, StopResponse,
+    MotorStateResponse, ResonanceBuzz, RestoreDriveLimitsResponse, ResumeStreamResponse, SdoRead,
+    SdoReadResponse, SdoWrite, SdoWriteResponse, SeedServoHome, SeedServoHomeResponse,
+    SetDriveLimits, SetDriveLimitsResponse, SlaveState, SlaveStatus, StartCapture,
+    StartCaptureResponse, StopCaptureResponse, StopResponse,
 };
 use mcu_transport::demux::{Demuxer, Frame};
 use mcu_transport::frame::decode_frame;
@@ -126,6 +126,46 @@ fn decodes_set_torque_command() {
         }
         other => panic!("expected SetTorque, got {other:?}"),
     }
+}
+
+#[test]
+fn decodes_resonance_buzz_command() {
+    let msg = ResonanceBuzz {
+        axis_mask: 0b001,
+        sign_mask: 0b000,
+        freq_start_millihz: 5_000,
+        freq_end_millihz: 300_000,
+        amplitude_nm: 4_200,
+        duration_ms: 3_000,
+        ramp_ms: 300,
+    };
+    let payload = frame_payload(MessageKind::ResonanceBuzz, 42, &msg.encoded_to_vec());
+    match decode_command(0, &payload).expect("decode") {
+        Command::ResonanceBuzz {
+            correlation_id,
+            msg: m,
+        } => {
+            assert_eq!(correlation_id, 42);
+            assert_eq!(m, msg);
+        }
+        other => panic!("expected ResonanceBuzz, got {other:?}"),
+    }
+}
+
+#[test]
+fn resonance_buzz_response_frame_round_trips() {
+    let frame = resonance_buzz_response_frame(42, 0);
+    let mut demux = Demuxer::new();
+    let (frames, errs) = demux.feed_slice(&frame);
+    assert!(errs.is_empty());
+    let Frame::Kalico { payload, .. } = &frames[0] else {
+        panic!("expected kalico frame");
+    };
+    let (hdr, _body) = decode_message_header(payload).expect("header");
+    assert_eq!(
+        MessageKind::from_u16(hdr.kind_raw),
+        Some(MessageKind::ResonanceBuzzResponse)
+    );
 }
 
 #[test]

--- a/rust/ethercat-rt/tests/real_socket_streaming.rs
+++ b/rust/ethercat-rt/tests/real_socket_streaming.rs
@@ -85,6 +85,7 @@ fn run_endpoint(socket_path: String, faulted: Arc<AtomicBool>) {
                 Command::ResumeStream { .. } => {}
                 Command::SetDriveLimits { .. } | Command::RestoreDriveLimits { .. } => {}
                 Command::SeedServoHome { .. } => {}
+                Command::ResonanceBuzz { .. } => {}
                 Command::SdoRead { .. } | Command::SdoWrite { .. } => {
                     todo!("wired in the endpoint task")
                 }

--- a/rust/ethercat-rt/tests/stub_loop.rs
+++ b/rust/ethercat-rt/tests/stub_loop.rs
@@ -171,6 +171,7 @@ fn push_pieces_and_heartbeat_closes_the_loop() {
                     Command::ResumeStream { .. } => {}
                     Command::SetDriveLimits { .. } | Command::RestoreDriveLimits { .. } => {}
                     Command::SeedServoHome { .. } => {}
+                    Command::ResonanceBuzz { .. } => {}
                     Command::SdoRead { .. } | Command::SdoWrite { .. } => {
                         todo!("wired in the endpoint task")
                     }
@@ -200,6 +201,7 @@ fn push_pieces_and_heartbeat_closes_the_loop() {
                     | Command::SetDriveLimits { .. }
                     | Command::RestoreDriveLimits { .. }
                     | Command::SeedServoHome { .. }
+                    | Command::ResonanceBuzz { .. }
                     | Command::SdoRead { .. }
                     | Command::SdoWrite { .. }
                     | Command::PushPieces { .. } => {}

--- a/rust/mcu-protocol/src/messages.rs
+++ b/rust/mcu-protocol/src/messages.rs
@@ -22,6 +22,8 @@ pub enum MessageKind {
     StartCaptureResponse = 0x0069,
     StopCapture = 0x006A,
     StopCaptureResponse = 0x006B,
+    ResonanceBuzz = 0x006C,
+    ResonanceBuzzResponse = 0x006D,
     SetTorque = 0x0070,
     SetTorqueResponse = 0x0071,
     Stop = 0x0072,
@@ -63,6 +65,8 @@ impl MessageKind {
             0x0069 => Self::StartCaptureResponse,
             0x006A => Self::StopCapture,
             0x006B => Self::StopCaptureResponse,
+            0x006C => Self::ResonanceBuzz,
+            0x006D => Self::ResonanceBuzzResponse,
             0x0070 => Self::SetTorque,
             0x0071 => Self::SetTorqueResponse,
             0x0072 => Self::Stop,
@@ -627,6 +631,62 @@ impl Encode for SeedServoHomeResponse {
 }
 
 impl Decode for SeedServoHomeResponse {
+    fn decode_from(c: &mut Cursor<'_>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            result: get_i32(c)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResonanceBuzz {
+    pub axis_mask: u8,
+    pub sign_mask: u8,
+    pub freq_start_millihz: u32,
+    pub freq_end_millihz: u32,
+    pub amplitude_nm: u32,
+    pub duration_ms: u32,
+    pub ramp_ms: u32,
+}
+
+impl Encode for ResonanceBuzz {
+    fn encode(&self, out: &mut Vec<u8>) {
+        put_u8(out, self.axis_mask);
+        put_u8(out, self.sign_mask);
+        put_u32(out, self.freq_start_millihz);
+        put_u32(out, self.freq_end_millihz);
+        put_u32(out, self.amplitude_nm);
+        put_u32(out, self.duration_ms);
+        put_u32(out, self.ramp_ms);
+    }
+}
+
+impl Decode for ResonanceBuzz {
+    fn decode_from(c: &mut Cursor<'_>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            axis_mask: get_u8(c)?,
+            sign_mask: get_u8(c)?,
+            freq_start_millihz: get_u32(c)?,
+            freq_end_millihz: get_u32(c)?,
+            amplitude_nm: get_u32(c)?,
+            duration_ms: get_u32(c)?,
+            ramp_ms: get_u32(c)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResonanceBuzzResponse {
+    pub result: i32,
+}
+
+impl Encode for ResonanceBuzzResponse {
+    fn encode(&self, out: &mut Vec<u8>) {
+        put_i32(out, self.result);
+    }
+}
+
+impl Decode for ResonanceBuzzResponse {
     fn decode_from(c: &mut Cursor<'_>) -> Result<Self, DecodeError> {
         Ok(Self {
             result: get_i32(c)?,

--- a/rust/mcu-protocol/src/messages/tests.rs
+++ b/rust/mcu-protocol/src/messages/tests.rs
@@ -21,6 +21,8 @@ fn message_kind_round_trips_via_u16() {
         MessageKind::SdoReadResponse,
         MessageKind::SdoWrite,
         MessageKind::SdoWriteResponse,
+        MessageKind::ResonanceBuzz,
+        MessageKind::ResonanceBuzzResponse,
     ] {
         assert_eq!(MessageKind::from_u16(k.as_u16()), Some(k));
     }
@@ -51,6 +53,30 @@ fn configure_axes_roundtrip() {
     let r = ConfigureAxesResponse { result: -7 };
     assert_eq!(roundtrip(&r), r);
     assert_eq!(r.encoded_to_vec().len(), 4);
+}
+
+#[test]
+fn resonance_buzz_roundtrip() {
+    let v = ResonanceBuzz {
+        axis_mask: 0b001,
+        sign_mask: 0b010,
+        freq_start_millihz: 5_000,
+        freq_end_millihz: 300_000,
+        amplitude_nm: 4_200,
+        duration_ms: 3_000,
+        ramp_ms: 300,
+    };
+    assert_eq!(roundtrip(&v), v);
+    assert_eq!(v.encoded_to_vec().len(), 22);
+    let r = ResonanceBuzzResponse { result: -1 };
+    assert_eq!(roundtrip(&r), r);
+    assert_eq!(r.encoded_to_vec().len(), 4);
+}
+
+#[test]
+fn resonance_buzz_kind_is_not_event() {
+    assert!(!MessageKind::ResonanceBuzz.is_event());
+    assert!(!MessageKind::ResonanceBuzzResponse.is_event());
 }
 
 #[test]

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -1301,6 +1301,55 @@ impl PyMotionEngine {
         Ok((r.readback_size, u32::from_le_bytes(r.readback_data)))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn resonance_buzz(
+        &self,
+        py: Python<'_>,
+        mcu_handle: u32,
+        axis_mask: u8,
+        sign_mask: u8,
+        freq_start_millihz: u32,
+        freq_end_millihz: u32,
+        amplitude_nm: u32,
+        duration_ms: u32,
+        ramp_ms: u32,
+    ) -> PyResult<()> {
+        let conn = self.ethercat_conn(mcu_handle, "resonance_buzz")?;
+        tracing::info!(
+            subsystem = "engine",
+            event = "servo_resonance_buzz",
+            mcu_handle,
+            axis_mask,
+            sign_mask,
+            freq_start_millihz,
+            freq_end_millihz,
+            amplitude_nm,
+            duration_ms,
+            ramp_ms,
+            "servo resonance buzz"
+        );
+        let result = py
+            .detach(|| {
+                crate::servo_torque::send_resonance_buzz(
+                    &conn,
+                    axis_mask,
+                    sign_mask,
+                    freq_start_millihz,
+                    freq_end_millihz,
+                    amplitude_nm,
+                    duration_ms,
+                    ramp_ms,
+                )
+            })
+            .map_err(PyRuntimeError::new_err)?;
+        if result != 0 {
+            return Err(PyRuntimeError::new_err(format!(
+                "resonance_buzz: endpoint rejected (result {result})"
+            )));
+        }
+        Ok(())
+    }
+
     fn release_mcu(&self, handle: u32) -> PyResult<()> {
         let Some(mut conn) = ({
             let mut mcus = self.mcus.lock().unwrap_or_else(|p| p.into_inner());

--- a/rust/motion-engine/src/servo_torque.rs
+++ b/rust/motion-engine/src/servo_torque.rs
@@ -4,8 +4,8 @@ use host_rt::mcu_call::McuCall as _;
 use host_rt::mcu_serial_conn::McuSerialConn;
 use mcu_protocol::codec::{Decode as _, Encode as _};
 use mcu_protocol::messages::{
-    MessageKind, RestoreDriveLimitsResponse, SeedServoHome, SeedServoHomeResponse, SetDriveLimits,
-    SetDriveLimitsResponse, SetTorque, SetTorqueResponse,
+    MessageKind, ResonanceBuzz, ResonanceBuzzResponse, RestoreDriveLimitsResponse, SeedServoHome,
+    SeedServoHomeResponse, SetDriveLimits, SetDriveLimitsResponse, SetTorque, SetTorqueResponse,
 };
 
 const WORST_CASE_LADDER_ENABLE: Duration = Duration::from_secs(3);
@@ -99,6 +99,43 @@ pub fn send_seed_servo_home(
     }
     let r = SeedServoHomeResponse::decode(&resp)
         .map_err(|e| format!("SeedServoHomeResponse decode: {e:?}"))?;
+    Ok(r.result)
+}
+
+const RESONANCE_BUZZ_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[allow(clippy::too_many_arguments)]
+pub fn send_resonance_buzz(
+    conn: &McuSerialConn,
+    axis_mask: u8,
+    sign_mask: u8,
+    freq_start_millihz: u32,
+    freq_end_millihz: u32,
+    amplitude_nm: u32,
+    duration_ms: u32,
+    ramp_ms: u32,
+) -> Result<i32, String> {
+    let body = ResonanceBuzz {
+        axis_mask,
+        sign_mask,
+        freq_start_millihz,
+        freq_end_millihz,
+        amplitude_nm,
+        duration_ms,
+        ramp_ms,
+    }
+    .encoded_to_vec();
+    let (kind, resp) = conn
+        .mcu_call(MessageKind::ResonanceBuzz, body, RESONANCE_BUZZ_TIMEOUT)
+        .map_err(|e| format!("ResonanceBuzz transport: {e:?}"))?;
+    if kind != MessageKind::ResonanceBuzzResponse {
+        return Err(format!(
+            "ResonanceBuzz: unexpected response kind 0x{:04x}",
+            kind.as_u16()
+        ));
+    }
+    let r = ResonanceBuzzResponse::decode(&resp)
+        .map_err(|e| format!("ResonanceBuzzResponse decode: {e:?}"))?;
     Ok(r.result)
 }
 

--- a/rust/motion-engine/src/servo_torque/tests.rs
+++ b/rust/motion-engine/src/servo_torque/tests.rs
@@ -85,3 +85,69 @@ fn wrong_kind_response_is_rejected() {
     let err = send_set_torque(&conn, true, 42_000).expect_err("should error on wrong kind");
     assert!(err.contains("unexpected response kind"));
 }
+
+fn spawn_buzz_endpoint(
+    mut peer: UnixStream,
+    result: i32,
+) -> std::sync::mpsc::Receiver<ResonanceBuzz> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut demux = Demuxer::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = match peer.read(&mut buf) {
+                Ok(0) | Err(_) => return,
+                Ok(n) => n,
+            };
+            let (frames, _e) = demux.feed_slice(&buf[..n]);
+            for f in frames {
+                if let Frame::Kalico { payload, .. } = f {
+                    let (hdr, body) =
+                        decode_message_header(&payload).expect("valid message header");
+                    let msg = ResonanceBuzz::decode(body).expect("valid ResonanceBuzz body");
+                    let _ = tx.send(msg);
+                    let mut out = encode_message_header(
+                        MessageKind::ResonanceBuzzResponse,
+                        MESSAGE_VERSION_DEFAULT,
+                        hdr.correlation_id,
+                    )
+                    .to_vec();
+                    out.extend_from_slice(&ResonanceBuzzResponse { result }.encoded_to_vec());
+                    peer.write_all(&encode_frame(CHANNEL_CONTROL, &out))
+                        .unwrap();
+                    return;
+                }
+            }
+        }
+    });
+    rx
+}
+
+#[test]
+fn resonance_buzz_round_trips_args_and_result() {
+    let (client, server) = UnixStream::pair().unwrap();
+    let rx = spawn_buzz_endpoint(server, 0);
+    let conn = McuSerialConn::from_stream(client).expect("from_stream");
+    let result =
+        send_resonance_buzz(&conn, 0b001, 0b010, 5_000, 300_000, 4_200, 3_000, 300).expect("call");
+    assert_eq!(result, 0);
+    let seen = rx.recv().expect("endpoint saw the command");
+    assert_eq!(seen.axis_mask, 0b001);
+    assert_eq!(seen.sign_mask, 0b010);
+    assert_eq!(seen.freq_start_millihz, 5_000);
+    assert_eq!(seen.freq_end_millihz, 300_000);
+    assert_eq!(seen.amplitude_nm, 4_200);
+    assert_eq!(seen.duration_ms, 3_000);
+    assert_eq!(seen.ramp_ms, 300);
+}
+
+#[test]
+fn resonance_buzz_surfaces_nonzero_result() {
+    let (client, server) = UnixStream::pair().unwrap();
+    let _rx = spawn_buzz_endpoint(server, -1);
+    let conn = McuSerialConn::from_stream(client).expect("from_stream");
+    assert_eq!(
+        send_resonance_buzz(&conn, 0b001, 0, 5_000, 5_000, 100, 1_000, 100).expect("call"),
+        -1
+    );
+}

--- a/rust/runtime/src/buzz_gen.rs
+++ b/rust/runtime/src/buzz_gen.rs
@@ -114,6 +114,20 @@ fn amp_eff_rate(p: &ToneParams, t: f32) -> f32 {
 
 #[inline]
 #[must_use]
+fn amp_eff_accel(p: &ToneParams, t: f32) -> f32 {
+    if p.mu == 0.0 {
+        return 0.0;
+    }
+    let w = omega_inst(p, t);
+    if w.abs() <= f32::MIN_POSITIVE {
+        0.0
+    } else {
+        2.0 * p.amplitude_mm * p.omega * p.mu * p.mu / (w * w * w)
+    }
+}
+
+#[inline]
+#[must_use]
 fn position_rel(p: &ToneParams, t: f32) -> f32 {
     p.sign * envelope(t, p.total_seconds, p.ramp_seconds) * amp_eff(p, t) * libm::sinf(phase(p, t))
 }
@@ -139,6 +153,38 @@ fn velocity_rel(p: &ToneParams, t: f32) -> f32 {
     let s = libm::sinf(phi);
     let c = libm::cosf(phi);
     p.sign * (denv * a * s + env * da * s + env * a * omega_inst(p, t) * c)
+}
+
+#[inline]
+#[must_use]
+fn accel_rel(p: &ToneParams, t: f32) -> f32 {
+    let total = p.total_seconds;
+    let ramp = p.ramp_seconds.max(f32::MIN_POSITIVE);
+    let env = envelope(t, total, ramp);
+    let denv = if t <= 0.0 || t >= total {
+        0.0
+    } else if t < ramp {
+        1.0 / ramp
+    } else if t > total - ramp {
+        -1.0 / ramp
+    } else {
+        0.0
+    };
+    let a = amp_eff(p, t);
+    let da = amp_eff_rate(p, t);
+    let dda = amp_eff_accel(p, t);
+    let w = omega_inst(p, t);
+    let phi = phase(p, t);
+    let s = libm::sinf(phi);
+    let c = libm::cosf(phi);
+    let s_coeff = 2.0 * denv * da + env * dda - env * a * w * w;
+    let c_coeff = 2.0 * denv * a * w + 2.0 * env * da * w + env * a * p.mu;
+    p.sign * (s_coeff * s + c_coeff * c)
+}
+
+#[must_use]
+pub fn sample_rel(p: &ToneParams, t: f32) -> (f32, f32, f32) {
+    (position_rel(p, t), velocity_rel(p, t), accel_rel(p, t))
 }
 
 #[inline]

--- a/rust/runtime/src/buzz_gen/buzz_gen_tests.rs
+++ b/rust/runtime/src/buzz_gen/buzz_gen_tests.rs
@@ -149,6 +149,44 @@ fn analytic_sequence(p: &ToneParams) -> Vec<ToneCrossing> {
 }
 
 #[test]
+fn accel_matches_negative_omega_squared_position_for_pure_tone() {
+    let freq = 40.0;
+    let p = make_params(freq, NM_PER_MM, 1.0, 0.0, 64_000_000.0);
+    let omega = f64::from(p.omega);
+    for &t in &[0.03_f32, 0.05, 0.07] {
+        let (pos, _vel, acc) = sample_rel(&p, t);
+        let expected = -(omega * omega) * f64::from(pos);
+        let tol = (omega * omega) * f64::from(p.amplitude_mm) * 1.0e-3;
+        assert!(
+            (f64::from(acc) - expected).abs() <= tol,
+            "t={t} acc={acc} expected={expected}"
+        );
+    }
+}
+
+#[test]
+fn accel_and_velocity_match_finite_difference_for_chirp() {
+    let p = make_chirp(5.0, 300.0, NM_PER_MM, 1.0, 0.5, 0.05);
+    let h = 5.0e-5_f32;
+    for &t in &[0.15_f32, 0.25, 0.35] {
+        let (pos_lo, vel_lo, _) = sample_rel(&p, t - h);
+        let (pos_hi, vel_hi, _) = sample_rel(&p, t + h);
+        let (_pos, vel, acc) = sample_rel(&p, t);
+        let fd_vel = f64::from(pos_hi - pos_lo) / f64::from(2.0 * h);
+        let fd_acc = f64::from(vel_hi - vel_lo) / f64::from(2.0 * h);
+        let rel = |got: f64, want: f64| (got - want).abs() / want.abs().max(1.0e-9);
+        assert!(
+            rel(f64::from(vel), fd_vel) < 0.01,
+            "vel t={t} {vel} vs {fd_vel}"
+        );
+        assert!(
+            rel(f64::from(acc), fd_acc) < 0.01,
+            "acc t={t} {acc} vs {fd_acc}"
+        );
+    }
+}
+
+#[test]
 fn matches_brute_force_across_sweep() {
     let grid_hz = 2.0e6;
     let grid_dt = 1.0 / grid_hz;

--- a/test/test_resonance_buzz_mapping.py
+++ b/test/test_resonance_buzz_mapping.py
@@ -1,6 +1,6 @@
 import pytest
 
-from klippy.extras.resonance_tester import buzz_axis_to_motor_mask
+from klippy.extras.resonance_buzz import buzz_axis_to_motor_mask
 
 
 def test_corexy_x_drives_both_motors_in_phase():


### PR DESCRIPTION
## What

Makes `RESONANCE_BUZZ` / `RESONANCE_BUZZ_SWEEP` work on EtherCAT servo axes. The chirp is generated natively in the `ethercat-rt` daemon (the servo's "MCU"), mirroring the stepper-MCU arm-and-generate design — the host sends the same buzz arguments, only the transport differs.

Verified on the Neptune EtherCAT bench (A6-EC servo on X): buzz audibly excites the axis across 30–50 Hz.

## How it works

- **Excitation model:** CSP target position + velocity feedforward + torque feedforward each DC cycle. The feedforward channel that carries the tone shifts with frequency (position loop ~35 Hz → speed loop ~137 Hz → current loop above), so triple-FF is required for coverage across the band, not just resolution. Amplitude law is constant peak velocity (A ∝ 1/f), identical to the stepper path, so `ACCEL_PER_HZ` is respected.
- **Integration seam:** the buzz oscillator is an alternate source of the `(pos, vel, acc)` triplet that feeds the existing counts/FF/write path in the DC loop verbatim — no piece-streaming firehose, no duplicated feedforward math. Phase-anchored on the first cycle, centered on the rotor's current position, self-deactivating past the duration.
- **No drift with the stepper math:** the daemon arms `runtime::buzz::Buzz` so EtherCAT and stepper paths compute identical tones; the only new math is the analytic `accel_rel` (2nd derivative of the chirp) for the torque-FF term.

## Changes

- **Protocol** (`mcu-protocol`): `ResonanceBuzz` (0x006C) / `ResonanceBuzzResponse` (0x006D) message kinds + structs.
- **Daemon** (`ethercat-rt`): wire `Command::ResonanceBuzz` + handler with arm guards (torque enabled, ring empty, not already buzzing); native `BuzzOsc`; DC-loop triplet switch.
- **runtime**: `accel_rel` + `sample_rel` in `buzz_gen`.
- **Host**: `motion_engine.resonance_buzz` (pyo3) + `send_resonance_buzz`; `motion.submit_resonance_buzz` routes servo-axis bits to the node engine handle and broadcasts the rest to stepper MCUs (independent axis-index spaces).
- **Decoupling**: `RESONANCE_BUZZ` / `RESONANCE_BUZZ_SWEEP` moved into an always-loaded `extras/resonance_buzz.py` so excitation no longer requires `[resonance_tester]` or an accelerometer; `resonance_tester` keeps the measurement commands.
- Design record under `_bmad-output/brainstorming/`.

## Testing

- Rust: protocol round-trip, wire decode/response, `BuzzOsc` arm/anchor/deactivate, `accel_rel` vs the exact `a = -ω²x` identity and finite differences, host-rt arg round-trip. Full `ethercat-rt` + `mcu-protocol` + `motion-engine` + `runtime` suites pass; clippy `-D warnings` and `cargo fmt` clean.
- Python: ruff + format clean; klippy config-load tests pass.
- Bench: buzz confirmed working on the A6-EC X axis.

## Known / follow-up

- Audible clicking at some frequencies (likely CSP linear-interpolation velocity steps and/or torque-FF transitions) — needs the accelerometer/shaper graph to characterize. That's the next stage.
- Stages still ahead: climbing into the 137–300 Hz band (torque-FF coverage), raising the drive's 318 Hz FF-cutoff SDOs during buzz, and accelerometer-based verification.