### PR TITLE
Port input shapers to live post-processing path

### DIFF
--- a/_bmad-output/implementation-artifacts/review-acceptance-auditor-input-shaper-port.md
+++ b/_bmad-output/implementation-artifacts/review-acceptance-auditor-input-shaper-port.md
@@ -1,0 +1,45 @@
+# Acceptance Auditor Review Prompt — Input Shaper Port
+
+Use the acceptance-auditor role from `bmad-quick-dev`.
+
+Read these context files first:
+
+```text
+_bmad-output/implementation-artifacts/spec-input-shaper-port.md
+_bmad-output/specs/spec-input-shaper-port/SPEC.md
+_bmad-output/specs/spec-input-shaper-port/code-map.md
+```
+
+Then review the diff from baseline:
+
+```text
+bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6
+```
+
+Diff command:
+
+```sh
+git diff bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6
+```
+
+Also inspect these untracked artifacts:
+
+```text
+_bmad-output/implementation-artifacts/spec-input-shaper-port.md
+_bmad-output/specs/spec-input-shaper-port/.decision-log.md
+_bmad-output/specs/spec-input-shaper-port/SPEC.md
+_bmad-output/specs/spec-input-shaper-port/code-map.md
+```
+
+Do not use graphify.
+
+Audit whether the implementation satisfies every task, acceptance criterion, and frozen constraint. Pay special attention to:
+
+- PA-only byte identity and zero-support fit-grid reuse.
+- Smooth shaper output matching the `ShapedSignal` oracle.
+- Two-sided convolution windows: past history, future lookahead, live-edge hold-back, and no internal clamp.
+- Axis-agnostic processor application.
+- Runtime `frequency_hz` fail-loud validation.
+- Legacy stack marked but not deleted.
+
+Return findings first, ordered by severity. For each finding, classify whether it is likely `intent_gap`, `bad_spec`, `patch`, `defer`, or `reject`, with a short rationale.

--- a/_bmad-output/implementation-artifacts/review-blind-hunter-input-shaper-port.md
+++ b/_bmad-output/implementation-artifacts/review-blind-hunter-input-shaper-port.md
@@ -1,0 +1,38 @@
+# Blind Hunter Review Prompt — Input Shaper Port
+
+Use the `bmad-review-adversarial-general` skill.
+
+You receive only the diff, not the implementation spec or project context. Review for defects, regressions, suspicious logic, incomplete behavior, and test gaps visible from the patch alone.
+
+Baseline commit:
+
+```text
+bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6
+```
+
+Construct the diff from the workspace root:
+
+```sh
+git diff bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6 -- \
+  rust/motion-engine/src/config/tests.rs \
+  rust/motion-engine/src/lowering.rs \
+  rust/motion-engine/src/lowering/tests.rs \
+  rust/motion-engine/src/stream.rs \
+  rust/motion-engine/src/stream/tests.rs \
+  rust/motion-engine/src/stream_planner/tests.rs \
+  rust/trajectory/src/beta.rs \
+  rust/trajectory/src/emit_shaped.rs \
+  rust/trajectory/src/emit_shaped/tests.rs \
+  rust/trajectory/src/kernel/tests.rs \
+  rust/trajectory/src/lib.rs \
+  rust/trajectory/src/plan_velocity/tests.rs \
+  rust/trajectory/src/post_processor.rs \
+  rust/trajectory/src/post_processor/tests.rs \
+  rust/trajectory/src/shaper.rs \
+  rust/trajectory/src/streaming/state.rs \
+  rust/trajectory/src/streaming/tests.rs \
+  rust/trajectory/tests/binding_report.rs \
+  rust/trajectory/tests/follower_rows.rs
+```
+
+Do not inspect files outside this diff. Return findings only, ordered by severity, with file and line references when possible. If no findings, say so and mention residual risk.

--- a/_bmad-output/implementation-artifacts/review-edge-case-hunter-input-shaper-port.md
+++ b/_bmad-output/implementation-artifacts/review-edge-case-hunter-input-shaper-port.md
@@ -1,0 +1,28 @@
+# Edge Case Hunter Review Prompt — Input Shaper Port
+
+Use the `bmad-review-edge-case-hunter` skill.
+
+Review the implementation for unhandled edge cases and boundary conditions. You may inspect the project, but do not use graphify. Focus on stream boundaries, shaper support windows, history/lookahead availability, axis counts, PA/shaper ordering, numerical finiteness, and commit/force behavior.
+
+Baseline commit:
+
+```text
+bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6
+```
+
+Primary diff command:
+
+```sh
+git diff bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6
+```
+
+Untracked review artifacts:
+
+```text
+_bmad-output/implementation-artifacts/spec-input-shaper-port.md
+_bmad-output/specs/spec-input-shaper-port/.decision-log.md
+_bmad-output/specs/spec-input-shaper-port/SPEC.md
+_bmad-output/specs/spec-input-shaper-port/code-map.md
+```
+
+Return only edge-case findings. For each finding, include the concrete path, trigger condition, expected bad behavior, and a minimal test that would expose it.

--- a/_bmad-output/implementation-artifacts/spec-input-shaper-port.md
+++ b/_bmad-output/implementation-artifacts/spec-input-shaper-port.md
@@ -1,0 +1,135 @@
+---
+title: 'Input shaper port to live post-processing path'
+type: 'feature'
+created: '2026-06-22T00:00:00+02:00'
+status: 'done'
+baseline_commit: 'bfdf06e2b5cb10b5b4a8d8e412c30d08731605a6'
+context:
+  - '{project-root}/_bmad-output/specs/spec-input-shaper-port/SPEC.md'
+  - '{project-root}/_bmad-output/specs/spec-input-shaper-port/code-map.md'
+---
+
+<frozen-after-approval reason="human-owned intent - do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** Configured `smooth_zv` and `smooth_mzv` post-processors are compiled and live-retunable, but the live `StreamState -> lower_move -> Sampler` path only consumes PA gain; spatial axes bypass post-processing and `CompiledChain.kernel` is not read. X/Y resonance compensation is therefore absent on the post-TOPP motion path.
+
+**Approach:** Replace the gain-only lowering hook with an ordered axis post-processor chain that evaluates an analytic unshaped `BaseSignal`, then applies PA and smooth shaper stages through one interface after limit computation. Reuse the existing smooth kernel builders and `ShapedSignal` convolution math, carry enough past history and future lookahead to avoid seams, and mark the superseded emit stack as legacy without deleting it.
+
+## Boundaries & Constraints
+
+**Always:** Shaping runs after velocity/limit planning and never feeds limit computation. Empty chains emit the unshaped base unchanged. PA remains exact through analytic base value/derivative/second-derivative evaluation, and zero-support stages reuse the incoming fit grid with no adaptive re-refinement. Smooth shapers reuse existing kernel math and fail loudly on missing history/lookahead, non-finite samples, or invalid frequency. Post-processors are axis-agnostic and apply in `[axis] post_processors:` declaration order.
+
+**Ask First:** Any change that alters planner limits, weakens throughput/trajectory optimality, deletes the legacy planner/streaming/emit stack, changes config syntax, or introduces a cheaper shaping algorithm instead of the existing convolution primitive.
+
+**Never:** Do not revive TOPP, legacy `[input_shaper]`, resonance calibration, or classic impulse shaper types. Do not silently pad missing convolution history or future lookahead with zeros, and do not clamp at internal batch seams. Do not special-case shapers to spatial axes or PA to follower axes.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|----------------------------|----------------|
+| Unconfigured axis | Axis chain is empty | Emitted NURBS is byte-identical to current unshaped output | None |
+| PA-only axis | Axis chain has `linear_pressure_advance` | Output matches current PA live path, including XYZ identity when PA is only on follower | None |
+| Smooth shaper axis | Axis chain has `smooth_zv` or `smooth_mzv` | Emitted trajectory matches `ShapedSignal` convolution of the same base signal to fit tolerance | Non-finite shaped sample returns a clear error |
+| Backward streaming seam | Shaper window reaches into already committed history | Two-batch output matches one-batch output to fit tolerance and velocity is continuous at the seam | Missing history returns a clear error |
+| Forward live edge | Shaper window reaches into not-yet-committed future base | Commit holds back affected shaped samples until the future base exists; internal seams never clamp | Missing lookahead returns a clear error |
+| Live retune | `SET_POST_PROCESSOR FREQUENCY_HZ=<value>` during streaming | Already committed output is unchanged; future plans use the new kernel | Non-finite or `<= 0` frequency is rejected without mutating the instance |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `rust/trajectory/src/post_processor.rs` -- Replace `CompiledChain { kernel, gain }`/`PlanAction` flattening with ordered post-processor chain members; add fail-loud frequency validation in `set_param`; keep `apply_derivative_gain` marked legacy.
+- `rust/trajectory/src/shaper.rs` -- Expose/reuse the existing `ShapedSignal` convolution math through an evaluator/closure-taking path or equivalent sampled-analytic adapter for live post-processing.
+- `rust/motion-engine/src/lowering.rs` -- Make `Sampler` provide the analytic unshaped base signal and remove `with_pa`/`follower_gains`; zero-support stages evaluate on the incoming fit grid.
+- `rust/motion-engine/src/stream.rs` -- Apply ordered per-axis post-processing at commit time with cross-batch history, forward lookahead, live-edge hold-back, and fail-loud seam checks.
+- `rust/motion-engine/src/config.rs` -- Keep `[post_processor]` syntax and live `set_param`/compile flow pointed at the new ordered chain representation.
+- `rust/motion-engine/src/lowering/tests.rs`, `rust/motion-engine/src/stream/tests.rs`, `rust/trajectory/src/post_processor/tests.rs` -- Cover PA parity, smooth-shaper oracle matching, live retune validation, and streaming seam equivalence.
+- `rust/trajectory/src/lib.rs`, `rust/trajectory/src/beta.rs`, `rust/trajectory/src/streaming/`, `rust/trajectory/src/emit_shaped.rs`, `rust/motion-engine/src/planner.rs` -- Mark old pipeline as legacy/deprecated without making the live path depend on it.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `rust/trajectory/src/post_processor.rs` -- Introduce an ordered chain representation capable of PA and smooth-shaper stages in declaration order -- removes the one-kernel-plus-one-gain flattening that loses composition semantics.
+- [x] `rust/trajectory/src/post_processor.rs` -- Reject non-finite or non-positive shaper `frequency_hz` at runtime and preserve the existing valid value after a rejected update -- closes the fail-loud gap; `config.rs` already delegates and build-time validation already exists.
+- [x] `rust/motion-engine/src/lowering.rs` -- Refactor `Sampler` into the exact base evaluator for spatial and follower axes, including value, derivative, and second derivative -- gives PA and shapers one axis-agnostic input contract.
+- [x] `rust/motion-engine/src/lowering.rs` and `rust/motion-engine/src/stream.rs` -- Ensure zero-support processors reuse the incoming fit grid with no adaptive re-refinement and read the analytic base instead of a re-differentiated fitted NURBS -- preserves PA byte-identity.
+- [x] `rust/motion-engine/src/stream.rs` -- Add the post-lowering fold over axis chains, with per-axis history, retained future lookahead, live-edge hold-back, and explicit errors for unavailable convolution windows -- enables live shaping without limit feedback.
+- [x] `rust/trajectory/src/shaper.rs` or a sibling module -- Reuse `ShapedSignal` kernel math through an evaluator/closure-compatible path rather than reimplementing convolution or forcing the first-stage base through NURBS -- keeps validated math intact.
+- [x] Legacy emit stack files -- Mark superseded planner/streaming/emit/NURBS post-processing code as legacy or deprecated, but do not delete it -- makes the boundary obvious until the maintainer removes the full old stack.
+- [x] Test files -- Add focused Rust unit/integration coverage for the matrix scenarios and keep tests separate from production modules -- proves behavior and fail-loud paths.
+
+**Acceptance Criteria:**
+- Given an empty post-processor chain, when a move is emitted through the live path, then every axis matches the previous unshaped output.
+- Given a PA-only follower chain, when the same move is emitted before and after the refactor, then the emitted output is byte-identical to the current PA live behavior because the incoming fit grid is reused and PA reads the analytic base.
+- Given a smooth shaper on any axis, when the live path emits the move, then the shaped output matches the `ShapedSignal` oracle for the unshaped base to fit tolerance.
+- Given a shaped move sequence split across two streaming commits, when compared with the same sequence committed as one batch, then position and velocity match at the seam to tolerance for both past-history and future-lookahead sides of the shaper window.
+- Given shaped samples near the live commit frontier, when the required future base is not yet planned, then the stream holds those samples back rather than clamping or padding at an internal seam.
+- Given `SET_POST_PROCESSOR FREQUENCY_HZ` with `NaN`, infinity, zero, or negative value, when the update is applied, then it returns the configured error and the previous kernel remains active.
+
+## Design Notes
+
+The first `BaseSignal` is analytic, built from velocity phases plus spatial geometry or follower demand. PA has zero support and evaluates locally as `value + k * deriv` and `deriv + k * deriv2` on the existing grid; it does not trigger a fresh adaptive fit. Nonzero-support shapers use the rescued convolution math over a two-sided window, then refit their result for later stages. This keeps processor behavior axis-agnostic: spatial and follower axes differ only in base evaluation, not in which processor types are allowed.
+
+## Verification
+
+**Commands:**
+- `cd rust && cargo nextest run -p trajectory -p motion-engine -E 'test(post_processor) | test(lowering) | test(stream)'` -- expected: targeted Rust tests pass.
+- `cd rust && cargo nextest run -p trajectory -p motion-engine` -- expected: affected crates pass.
+- `./scripts/ci.sh rust-clippy` -- expected: no warnings promoted to errors.
+- `./scripts/ci.sh rust-fmt` -- expected: formatting is clean.
+
+## Suggested Review Order
+
+**Chain Model**
+
+- Ordered stages preserve declared PA/shaper composition while legacy fields stay marked.
+  [`post_processor.rs:38`](../../../rust/trajectory/src/post_processor.rs#L38)
+
+- Runtime and compile-time validation close the direct-construction frequency gap.
+  [`post_processor.rs:98`](../../../rust/trajectory/src/post_processor.rs#L98)
+
+**Base Evaluation**
+
+- Analytic base state keeps PA exact before any nonzero-support stage.
+  [`lowering.rs:129`](../../../rust/motion-engine/src/lowering.rs#L129)
+
+- Zero-support stages apply on the incoming grid until the first shaper.
+  [`lowering.rs:162`](../../../rust/motion-engine/src/lowering.rs#L162)
+
+**Live Shaping**
+
+- Commit flow applies the post-lowering fold and stores committed base history.
+  [`stream.rs:240`](../../../rust/motion-engine/src/stream.rs#L240)
+
+- Forward support holds back live-edge output until required future base exists.
+  [`stream.rs:286`](../../../rust/motion-engine/src/stream.rs#L286)
+
+- Axis-chain folding validates ragged axes and reports fail-loud errors.
+  [`stream.rs:339`](../../../rust/motion-engine/src/stream.rs#L339)
+
+- Shaper window checks distinguish absolute stream edges from internal seams.
+  [`stream.rs:367`](../../../rust/motion-engine/src/stream.rs#L367)
+
+- Binary-search segment lookup tolerates tiny contiguous-segment gaps.
+  [`stream.rs:425`](../../../rust/motion-engine/src/stream.rs#L425)
+
+- Shaped refit rejects empty templates and samples derivatives inside domain.
+  [`stream.rs:468`](../../../rust/motion-engine/src/stream.rs#L468)
+
+- Trailing PA after a shaper uses a local primitive, not legacy emit code.
+  [`stream.rs:522`](../../../rust/motion-engine/src/stream.rs#L522)
+
+**Convolution Reuse**
+
+- Closure-backed construction lets live shaping read the analytic base directly.
+  [`shaper.rs:46`](../../../rust/trajectory/src/shaper.rs#L46)
+
+**Coverage**
+
+- Stream tests cover oracle matching, hold-back release, idle gaps, and seams.
+  [`stream/tests.rs:146`](../../../rust/motion-engine/src/stream/tests.rs#L146)
+
+- Post-processor tests cover order, duplicate rejection, and validation paths.
+  [`post_processor/tests.rs:30`](../../../rust/trajectory/src/post_processor/tests.rs#L30)

--- a/_bmad-output/specs/spec-input-shaper-port/.decision-log.md
+++ b/_bmad-output/specs/spec-input-shaper-port/.decision-log.md
@@ -1,0 +1,52 @@
+# Decision log — spec-input-shaper-port
+
+## 2026-06-22 — Create (express distill)
+
+Trigger: user — "we implemented the PA post-processor on the new (non-TOPP) pipeline; can we do the same for the input shaper?" Sparse one-line intent, but the surrounding context is rich: the sibling `spec-pressure-advance-port` (SPEC + code-map) and a direct read of the live source. Mode: **express** — distilled the five fields from code + the PA spec; genuine architecture decisions routed to Open Questions rather than invented.
+
+### Grounding (verified against the live tree, not just summaries)
+- `lowering.rs:217-218` — live `lower_move` extracts only `c.gain`; `c.kernel` is never read on the live path. `lowering.rs:125-129` — spatial axes (`axis<3`) return raw geometry, no post-processing. ⇒ input shaping is genuinely absent from the live path, exactly where PA was.
+- `post_processor.rs:8-13,77-87` — `SmoothZv`/`SmoothMzv` types + `action()`→`PlanAction::Kernel` already exist; `CompiledChain{kernel,gain}` carries the kernel; `compile` (`:123-157`) already enforces one-kernel-per-axis. So types/parse/retune rail are built.
+- Convolution math is alive only on the dead `emit_shaped.rs` path (`ShapedSignal`, `pad_segment_axis_with_history`, `PerAxisHistory`).
+- `post_processor.rs:94-103` — shaper `set_param` does NOT validate `frequency_hz` (PA's `k` does at `:104-118`). Recorded as a fail-loud gap, folded into CAP-2.
+
+### Key routing decisions
+- Five-field kernel in SPEC.md; file:line hook table + the locality analysis + test/oracle anchors routed to companion `code-map.md` (multi-item reference — would bloat the kernel).
+- **The load-bearing distinction from PA — non-locality — is stated in Why, made a Constraint (XYZ-byte-identical does NOT apply to shaped axes), and given its own code-map section.** This is the single most important thing differentiating this work from the PA port; PA was "confirm wiring," this is a real algorithmic addition (windowed convolution + cross-batch history).
+- Resonance measurement/calibration, classic impulse shapers, legacy `[input_shaper]`, and any limit-time coupling → Non-goals.
+- Four genuine architecture/scope decisions that the input did not settle and that I declined to invent → Open Questions: (1) convolution placement (in-lower_move vs post-lowering stage), (2) follower/extruder shaping yes/no, (3) shapeable axis set, (4) dead-path deletion vs keep-as-oracle.
+
+### Self-validate verdict
+**Pass 1 (coherence, rules 1–6, 8):** all four capabilities carry intent+success. Constraints each rule something out — shaping-never-feeds-limits, shaped-axes-are-not-byte-identical (the explicit inversion of PA's guarantee), verbatim-kernel-math reuse, one-kernel-per-axis, mandatory cross-batch history with fail-loud, throughput. Five non-goals. Success signal is demonstrable (live shaped output matches dead-path oracle + retune-future-only + batch-seam continuity + suite green). CAP-1 intent names "convolution … consuming `CompiledChain.kernel`" — borderline HOW, but load-bearing as the definition of the work and mirrored in Constraints/code-map; kept. No invented content; unresolved architecture is in Open Questions, not asserted.
+
+**Pass 2 (preservation):** every load-bearing source claim landed — shaping-absent-on-live-path, types/rail-already-built, kernel-field-unused, dead-path-is-only-convolution-home, the locality difference, the freq-validation gap, mainline post-process-shaper parity, same retune path as PA, one-kernel-per-axis. Wrapper-only content: none (the trigger was a single sentence; no ceremony to drop).
+
+Verdict: coherent and preservation-complete. The four Open Questions are genuine architecture/scope calls for the human, not distillation gaps — chief among them the convolution-placement decision, which determines the shape of the implementation.
+
+## 2026-06-22 — Update: unify the interface, resolve Q1, add dead-code removal
+
+Trigger: user — "PA just flips on code entangled with everything; how would you change PA to respect post-processor? add removal of unused NURBS post-processor code to the spec."
+
+### Investigation
+Dispatched an Explore agent to map two suspected planner stacks in `motion-engine`. Verdict (file:line in code-map "Live vs dead stacks"): the bridge drives ONLY `StreamPlannerHandle` (`bridge.rs:3285`); the entire `planner.rs` + `trajectory::streaming` + `emit_shaped` + `beta` stack is dead, and it is the sole consumer of `apply_derivative_gain`, `CompiledChain.kernel`, and `PlanAction::Kernel`. Corrected the agent on two points recorded in the spec: (1) `PlanAction` is only half-dead — the `DerivativeGain` arm sets the live `gain`; (2) `ShapedSignal` is "dead now but rescue" — it is the convolution primitive the live shaper reuses, so it must NOT be swept up in the deletion.
+
+### Decisions folded in
+- **Q1 resolved → Option B + unified interface.** A unified signature is only expressible as "post-processor consumes a windowed `BaseSignal` evaluator → value," which forces a single post-lowering stage (Option B); Option A can't host non-local convolution in per-move scope and would keep PA and shaping on two mechanisms. Removed the Q1 open question; the decision lives in new CAP-5 and is referenced from CAP-1/CAP-4.
+- **CAP-5 added** — unified `AxisPostProcessor::eval(base,t)` interface; PA migrated off the baked-in `Sampler.with_pa`/`follower_gains` mechanism, behavior-preserving (PA stays exact via `base.deriv2` == today's `phase.accel`, so `apply_derivative_gain` is obsoleted not relied on). Byte-identity for a PA-only plan is the success gate.
+- **Removal constraint added** — delete the dead old emission stack (sole consumer of the dead NURBS post-processor code), rescue `ShapedSignal` + kernel builders + `T_SM_PER_HZ` consts, migrate the dead tests. Mirrors PA spec's "delete the dead coupling so it cannot regress."
+- **Open questions retired:** Q1 (placement) and the old Q4 (dead-path disposition, now decided by the removal constraint). New Q4 added: confirm removal *breadth* — the deletion necessarily retires the whole old `PlannerHandle` pipeline because that stack is the only path to the dead post-processor code; `examples/plan_gcode.rs` needs porting or deletion. This is a genuine human scope call, not a distillation gap.
+
+### Self-validate verdict
+Pass 1 (coherence): five capabilities, each intent+success; CAP-5's success is concrete (with_pa/follower_gains deleted, PA-only byte-identity, single eval dispatch). Removal constraint rules out the dormant-dead-code state and names the rescue set so it can't over-delete. Pass 2 (preservation): every load-bearing claim from the investigation landed — single live emit path, the dead stack inventory, the PlanAction/ShapedSignal nuances, the BaseSignal/AxisPostProcessor shape, exact-PA-via-deriv2, the rescue list. No wrapper ceremony to drop. Verdict: coherent and preservation-complete; three open questions remain (follower shaping, shapeable-axis set, removal breadth), all genuine human calls.
+
+## 2026-06-22 — Axis-agnostic principle dissolves two open questions
+
+User correction: "post processors can be applied to any axis — the question misses the point." Both the follower-shaping question and the shapeable-axis-set question presumed a per-axis *policy* the architecture does not have. Resolution: added an "axis-agnostic" Constraint — any processor type applies to any axis that names it; the only per-axis variation is how `BaseSignal` is evaluated (spatial geometry vs follower `ratio·s`). No extruder special-case, no shapeable/non-shapeable axis class, the stage must not branch on type-vs-axis. Removed both open questions. One open question remains: removal breadth.
+
+## 2026-06-22 — Removal breadth resolved: mark dead, don't delete
+
+User: "leave the old code; I'll remove the entire old pipeline at once — just mark it unused so it's very clear." Changed the removal constraint to a **marking** constraint: the new live stage must not depend on dead-pipeline code, and the dead stack is marked unmistakably (relocate under `legacy`/`dead` module and/or `#[deprecated]`, compiler-enforced), but NOT deleted here. `ShapedSignal`/kernel builders/consts stay put as shared primitives. `examples/plan_gcode.rs` and the `apply_derivative_gain` tests ride with the old pipeline until the maintainer's separate retirement pass. Updated SPEC constraint + non-goal, code-map "Dead-code marking" section. Last open question retired — Open Questions section removed. Spec now has zero open questions and zero assumptions-in-doubt.
+
+## 2026-06-22 — Tighten PA exactness and two-sided streaming window
+
+Quick-dev review surfaced three genuine under-specifications. First, PA byte-identity requires zero-support stages to reuse the incoming fit grid and read the analytic base evaluator rather than triggering an independent adaptive refit or differentiating a fitted NURBS. Second, smooth shaping is a two-sided convolution: live streaming needs both carried history and retained future lookahead, and clamp-at-edge behavior is valid only at absolute print start/end, not at internal batch seams. Third, the first `BaseSignal` representation is now explicit: analytic from phases/geometry/follower demand. `ShapedSignal` math remains the oracle, but live use may require an evaluator/closure-taking constructor or sampled-analytic adapter instead of forcing the base through `ScalarNurbs`. Updated CAP-3, CAP-5, constraints, assumptions, and code-map implementation notes; synced the Quick Dev spec so implementation follows the tightened contract.

--- a/_bmad-output/specs/spec-input-shaper-port/SPEC.md
+++ b/_bmad-output/specs/spec-input-shaper-port/SPEC.md
@@ -1,0 +1,66 @@
+---
+id: SPEC-input-shaper-port
+companions: [code-map.md]
+sources: []
+---
+
+> **Canonical contract.** This SPEC and the files in `companions:` are the complete, preservation-validated contract for what to build, test, and validate. Source documents listed in frontmatter are for traceability only — consult them only if you need narrative rationale or prose color this contract intentionally omits.
+
+# Input Shaping on the new (post-TOPP) motion path
+
+## Why
+
+Input shaping (resonance compensation) was left off the live `temporal::multi` (Consolini-Locatelli) path when TOPP was removed — the same gap that just got closed for Pressure Advance ([[spec-pressure-advance-port]]). The shaper half of the post-processor rail is already built and tested: the `SmoothZv`/`SmoothMzv` types, the kernel builders, the `CompiledChain.kernel` field, the config parse, and the live `update_post_processor` retune path all exist. But the live emit path (`lower_move` → `Sampler::axis_state`) consumes **only** the PA `gain` field — it never reads `kernel`, and spatial axes pass through with no post-processing at all. So a configured `smooth_zv` does nothing on the live path; X/Y resonance is uncompensated. The convolution math itself is alive only in the dead `emit_shaped.rs` path. This is an **opportunity to capture**: wire the existing, validated shaper kernel onto the live emit path the way PA's gain was wired. The defining difference from PA — and the real work — is that shaping is **non-local convolution** (a ±half-support window plus cross-batch history), where PA was a purely local same-`t` correction. The anchor every trade-off resolves against: shaping is applied **after** limits and never feeds them, so it never makes the planner pick a slower algorithm; the trajectory-time it adds is the intrinsic smear of convolution, which is the whole point of shaping, not a throughput regression.
+
+## Capabilities
+
+- id: CAP-1
+  intent: System applies the configured input-shaper kernel as a convolution on the spatial trajectory in the unified post-processing stage (CAP-5), after the toolhead trajectory is planned.
+  success: A move planned with a `smooth_zv` post-processor on an axis emits a shaped trajectory for that axis equal (to fit tolerance) to the kernel convolution of the same move's unshaped trajectory — matched against the `ShapedSignal` convolution primitive as oracle; the same move with no shaper post-processor emits the unshaped trajectory unchanged. End-to-end test on the live emit path asserts both.
+
+- id: CAP-2
+  intent: Operator configures a shaper via `[post_processor]` (`type: smooth_zv` / `smooth_mzv`, `frequency_hz`) on an `[axis] post_processors:` list and retunes it live with `SET_POST_PROCESSOR NAME=<shaper> FREQUENCY_HZ=<value>`.
+  success: A live `SET_POST_PROCESSOR` changes `frequency_hz` and the new value applies only to plans produced after the command (reusing the PA-proven `update_post_processor` → `set_axis_chains` swap path); held output committed before the swap is unchanged. Non-finite or non-positive `frequency_hz` is rejected loudly at both config build and runtime, matching PA's `k` validation.
+
+- id: CAP-3
+  intent: Shaping convolution windows that cross a streaming batch boundary use both carried per-axis history and retained forward lookahead so the shaped trajectory has no seam.
+  success: A move sequence planned as two streamed batches emits the same shaped trajectory (to fit tolerance) as the identical sequence planned in a single batch, and velocity is continuous across the batch seam. Samples near the live commit frontier are held until the future base signal required by the shaper half-support is planned; internal batch seams never use clamp-at-edge padding. If a convolution window needs past history or future lookahead that the streaming state cannot supply, the planner fails loudly rather than truncating the kernel or padding with zeros.
+
+- id: CAP-4
+  intent: The shaper model is selected by the post-processor `type`, dispatched through the unified `AxisPostProcessor` seam (CAP-5), so additional smooth shapers can be added without touching the live convolution plumbing.
+  success: `smooth_zv` and `smooth_mzv` ship; the seam is demonstrable such that adding another smooth shaper requires only a new `AxisPostProcessor` implementer plus its `type` string and kernel builder — no change to the unified stage, the base-signal evaluator, or the streaming-history seam. Per-axis composition and application order follow the `[axis] post_processors:` declaration order, type-agnostic, exactly as for PA.
+
+- id: CAP-5
+  intent: PA and input shaping execute through a single unified post-processor interface — an `AxisPostProcessor::eval(base, t)` over a `BaseSignal` evaluator of the unshaped axis — run by one post-lowering stage; PA is migrated off the baked-in `Sampler` `with_pa`/`follower_gains` mechanism onto this interface.
+  success: The `with_pa` flag and `follower_gains` array are gone from `Sampler`; `lower_move` emits only the unshaped base, and a single stage applies each axis's ordered chain. PA re-homed this way emits byte-identical output to the pre-refactor live path for a PA-only plan: zero-support stages reuse the incoming fit grid with no adaptive re-refinement, and PA reads the analytic base evaluator's 1st/2nd derivative rather than a re-differentiated fitted NURBS. Adding shaping touches only a new chain member, not the stage. A PA chain and a shaper chain dispatch through the identical `eval` call.
+
+## Constraints
+
+- Shaping is applied **after** limit computation and **never** feeds back into limit calculation — the same rail as PA, and the same behavior as mainline's post-process ("smooth") shaper. The unshaped base signal is what drives limits and the fit grid.
+- **Input shaping modifies the spatial trajectory by design.** The PA "XYZ byte-identical" guarantee does NOT apply to shaped axes and is not a goal — convolution legitimately reshapes and lengthens motion. The byte-identity that still must hold is: an axis with *no* kernel configured is emitted unchanged.
+- Convolution must reuse the existing, validated kernel math verbatim — `build_smooth_zv_kernel` / `build_smooth_mzv_kernel`, the `SMOOTH_ZV_T_SM_PER_HZ` / `SMOOTH_MZV_T_SM_PER_HZ` constants, and the `ShapedSignal` convolution primitive. These are **rescued** from the dead stack (see removal constraint below), not rewritten. The only new thing is live wiring and the unified interface, not shaper math.
+- The unshaped `BaseSignal` is the analytic evaluator derived from the velocity phases and geometry/follower demand. Local zero-support stages, including PA, must evaluate this incoming signal on the already-selected grid and must not trigger a separate adaptive refit; this preserves the current PA knot placement and byte-identity guarantee.
+- An axis carries an **ordered chain** of post-processors applied in `[axis] post_processors:` declaration order; a shaper and a PA may coexist on one axis. PA and shaping are not special-cased relative to each other. (This replaces the current `CompiledChain { kernel, gain }` two-field flattening, which hardcodes exactly one-kernel-plus-one-gain.)
+- **Post-processors are axis-agnostic.** Any processor type attaches to any axis that names it; there is no extruder special-case and no "shapeable vs non-shapeable" axis class. A shaper on a follower axis is valid and shapes that follower's signal; PA on a spatial axis is valid. The only per-axis difference is how the `BaseSignal` is evaluated (spatial geometry for `axis < 3`, follower `ratio·s + start` for followers) — not whether a given processor is permitted. The unified stage must not reject or branch on processor-type-vs-axis-class.
+- Cross-batch convolution is two-sided. The live streaming state must carry per-axis history tails and retain enough not-yet-committed forward base signal for the shaper window. Clamp-at-edge behavior is valid only at the absolute print start/end, never at an internal batch seam. Fail loudly if a window needs unavailable history or lookahead rather than silently shortening the kernel, padding with zeros, or clamping at a seam.
+- Fail loudly per project rule: unexpected planner state (missing history, degenerate fit input, non-finite shaped sample) raises a clear error rather than silently recovering or padding.
+- Throughput is non-negotiable: shaping changes neither the planner algorithm nor the computed limits. The only trajectory-time effect permitted is the intrinsic convolution smear.
+- **The new live post-processor stage must not depend on any dead-pipeline code, and the dead code is marked unmistakably as unused — it is NOT deleted in this work.** The old emission pipeline (`motion-engine::planner.rs` `PlannerHandle`, `trajectory::streaming`, `trajectory::emit_shaped`, `trajectory::beta`, and the post-processor code they alone consume — `apply_derivative_gain`, `CompiledChain.kernel`, `PlanAction::Kernel`) is retired wholesale in a separate maintainer pass. Here, mark it dead **by expression** — relocate it under a clearly-named `legacy`/`dead` module and/or attach `#[deprecated]` — so its superseded status is obvious at a glance and the live path's independence from it is enforced by the compiler, not by convention. `ShapedSignal`, the kernel builders, and the `SMOOTH_*_T_SM_PER_HZ` constants are shared primitives (consumed by both the dead emit and the new live stage) and stay where they are.
+
+## Non-goals
+
+- Resonance **measurement / calibration** — `TEST_RESONANCES`, `SHAPER_CALIBRATE`, accelerometer ingestion. This spec applies an already-chosen shaper; choosing the frequency is out of scope.
+- Classic discrete-impulse shapers (ZV/ZVD/EI as impulse trains). Only the smooth convolution-kernel family that already exists on the rail rides this path; new shapers must be smooth-kernel.
+- The legacy `[input_shaper]` config section — it stays rejected; configuration is `[post_processor]` only.
+- Reviving OR deleting the dead `emit_shaped.rs` / `temporal::topp` pipeline. The live path gets its own convolution and does not touch the dead stack; this work only **marks** that stack unused (see the marking constraint). Retiring it wholesale is a separate maintainer pass, out of scope here.
+- Any plan-time or limit-time shaping coupling. Shaping never constrains velocity, acceleration, or jerk.
+
+## Success signal
+
+A representative print with a configured `smooth_zv` (or `smooth_mzv`) post-processor on X/Y runs on the live path: the emitted X/Y trajectory is the resonance-compensated convolution of the planned motion (matching the validated dead-path shaper output to tolerance), `SET_POST_PROCESSOR FREQUENCY_HZ=` retunes only future plans, the shaped motion is continuous across streaming batch boundaries, and the full Rust suite is green.
+
+## Assumptions
+
+- The shaper kernel math is real, correct, and tested (`build_smooth_*_kernel`, `ShapedSignal`, the `T_SM_PER_HZ` constants); the remaining work is wiring it onto the live emit path through the unified interface, not building the convolution — mirroring PA's `apply_derivative_gain`-is-already-correct assumption.
+- `ShapedSignal` currently takes a `ScalarNurbs`; live shaping may need an evaluator/closure-taking entry point or an equivalent sampled-analytic adapter so the convolution can consume the analytic `BaseSignal` without forcing PA onto a re-differentiated NURBS representation.
+- The config parse and live `update_post_processor` rail already compile `smooth_zv`/`smooth_mzv` and drive the live `set_axis_chains` swap, so CAP-2 is largely confirmation plus closing the `frequency_hz` fail-loud validation gap. The compiled per-axis representation changes from `CompiledChain { kernel, gain }` to an ordered chain (CAP-5), so this rail is re-pointed, not rebuilt.

--- a/_bmad-output/specs/spec-input-shaper-port/code-map.md
+++ b/_bmad-output/specs/spec-input-shaper-port/code-map.md
@@ -1,0 +1,197 @@
+# Code map — Input Shaping on the new path
+
+Load-bearing implementation reference for SPEC-input-shaper-port. File:line anchors verified against the live tree on 2026-06-22; re-confirm before editing. Read alongside [[spec-pressure-advance-port]]'s `code-map.md` — this work rides the same rail PA does.
+
+## Live path facts (verified)
+
+- Active solver is `temporal::multi` (Consolini-Locatelli SOCP). `temporal::topp` and the dead `emit_shaped.rs` emit path are NOT on the live path.
+- The live emit path is `StreamPlanner → StreamState::commit → lowering::lower_move → Sampler::axis_state`. It consumes **only** `CompiledChain.gain` (`rust/motion-engine/src/lowering.rs:217-218`, `follower_gains`). It **never reads `CompiledChain.kernel`**. Spatial axes (`axis < 3`) return raw geometry with zero post-processing (`lowering.rs:125-129`). So input shaping is entirely absent from the live path — the `kernel` field is dead weight there today.
+- The shaper TYPES, kernel math, config parse, and live retune rail already exist and are tested. The gap is purely the live convolution wiring.
+
+## The defining difference from PA — locality
+
+PA's correction is **local**: at sample time `t`, `pos' = pos + k·ė(t)`, `vel' = vel + k·ë(t)` — same `t`, no neighbors (`lowering.rs:130-143`). That is why PA dropped straight into the pointwise `Sampler`.
+
+Input shaping is **non-local convolution**: `shaped(t) = ∫ kernel(τ)·base(t−τ) dτ` over a window of half-support `h` around `t`. `ShapedSignal::new` samples `[t_start + k_lo, t_end + k_hi]`, so live shaping needs both past history and future lookahead. The current `Sampler::axis_state` is a pure pointwise evaluator with no window and no neighbor/history access. Bringing shaping onto the live path therefore is not a "confirm the wiring" job like PA was — it is a real algorithmic addition: supply each shaped sample a padded `[t−h, t+h]` window of the base signal, carry history from committed output, and hold back live-edge samples until enough future base is planned.
+
+## Work-item hooks
+
+| CAP | What | Where |
+|-----|------|-------|
+| CAP-1 | Live emit site — pointwise, gain-only today; shaping must be added here or just after | `rust/motion-engine/src/lowering.rs:121-147` `Sampler::axis_state`; fit loop `:243-255` |
+| CAP-1 | Kernel already compiled into the chain (unused on live path) | `rust/trajectory/src/post_processor.rs:35-39` `CompiledChain{ kernel, gain }`; `:77-87` `action()` → `PlanAction::Kernel` |
+| CAP-1 | Validated convolution model to reuse (dead path, reference oracle) | `rust/trajectory/src/shaper.rs` `ShapedSignal::new/eval`; applied at `emit_shaped.rs:227-238` (spatial), `:336-368` (follower) |
+| CAP-1 | Kernel builders + Hz→smooth-time constants (reuse verbatim) | `rust/trajectory/src/post_processor.rs:1-6` consts; `crate::kernel::build_smooth_zv_kernel` / `build_smooth_mzv_kernel` |
+| CAP-2 | Config parse / instance build for `smooth_zv`/`smooth_mzv` | `rust/motion-engine/src/config.rs` (`PostProcessorSet::try_new`/`compile`, ~`:148-191`) |
+| CAP-2 | Config sections (Python); legacy `[input_shaper]` rejected | `klippy/extras/post_processor.py`; `[post_processor NAME]` + `[axis x] post_processors:`; rejection at `klippy/motion.py:623-628` |
+| CAP-2 | Runtime tune command → live swap | `klippy/motion.py` `cmd_SET_POST_PROCESSOR` → `bridge.rs` `update_post_processor` (~`:3713-3737`) → `stream_planner.rs` `SetAxisChains` (~`:20-31`, `:442-444`) → `stream.rs` `set_axis_chains` (`:83-85`) |
+| CAP-2 | **Fail-loud gap**: shaper `set_param` does NOT validate `frequency_hz` finite/positive (PA's `k` does) | `rust/trajectory/src/post_processor.rs:94-103` (add the check PA has at `:104-118`) |
+| CAP-3 | Cross-batch history and forward-lookahead model to mirror onto the live streaming state | dead path `pad_segment_axis_with_history`, `PerAxisHistory`, and `ShapedSignal::new`'s `[t_start + k_lo, t_end + k_hi]` sampling interval in `emit_shaped.rs`/`shaper.rs`; live streaming state `rust/motion-engine/src/stream.rs` |
+| CAP-3 | Per-axis composition / one-kernel-per-axis already enforced | `rust/trajectory/src/post_processor.rs:123-157` `CompiledChain::compile` |
+| CAP-4 | Model seam — add smooth shaper = new `PostProcessorType` arm + `type` string + kernel builder | `post_processor.rs:8-13` enum, `:77-87` `action()` |
+
+## Why CAP-2 is mostly confirmation
+
+The chain compiled from a `smooth_zv` config already carries `kernel: Some(...)` (`post_processor.rs:140`, via `action()` → `PlanAction::Kernel`). The runtime swap path (`update_post_processor` → `SetAxisChains` → `set_axis_chains`) is the exact path PA proved with `update_post_processor_applies_to_new_plans_only`. So once the live emit consumes `kernel`, retune is inherited. The one real CAP-2 task beyond confirmation is the `frequency_hz` validation gap.
+
+## Live vs dead stacks (verified 2026-06-22)
+
+The bridge drives exactly ONE emit path. Everything in the dead column is compiled but never instantiated in production.
+
+| Live (bridge-driven) | Evidence |
+|----|----|
+| `bridge.rs init_planner` → `StreamPlannerHandle::spawn` | `bridge.rs:3285` |
+| `StreamState::commit` → `lower_move` → `Sampler` | `stream.rs:157`, `lowering.rs:194` |
+| `CompiledChain.gain` (PA coefficient) | read at `lowering.rs:218` |
+
+| Dead (superseded) | Only consumer |
+|----|----|
+| `motion-engine/src/planner.rs` (`PlannerHandle`, `PlannerMsg`) | nothing but `examples/plan_gcode.rs` |
+| `trajectory::streaming` (`mod`/`emit`/`state`) | dead `planner.rs` |
+| `trajectory::emit_shaped` (whole module) | dead `streaming` + `beta` |
+| `trajectory::beta` | experimental, off live path |
+| `post_processor::apply_derivative_gain` (NURBS PA) | dead `emit_shaped` (`:205`) |
+| `CompiledChain.kernel`, `PlanAction::Kernel` | dead `emit_shaped` only; never read live |
+
+Nuance: `PlanAction` is NOT fully dead — `CompiledChain::compile` runs live and the `DerivativeGain` arm sets the live `gain` (`post_processor.rs:142-152`). Only the `Kernel` arm is dead. The unified interface (CAP-5) replaces the whole enum.
+
+## CAP-5 — unified interface & PA re-homing hooks
+
+Target shape (replaces the `with_pa` flag + `{kernel,gain}` flattening):
+
+```
+trait BaseSignal { value(t); deriv(t); deriv2(t); }      // exact unshaped axis evaluator
+trait AxisPostProcessor { half_support()->(f64,f64); eval(&self, base:&dyn BaseSignal, t)->(f64,f64); }
+```
+
+- `BaseSignal`: the first-stage base is analytic, derived from `Phase` + spatial segment or follower demand. Do not make the unshaped base a fitted NURBS just to satisfy `ShapedSignal::new`; that would put PA's byte-identity at risk.
+- `LinearPa{k}`: `eval = (value + k·deriv, deriv + k·deriv2)`, support `(0,0)`. `deriv2` == today's `phase.accel` used at `lowering.rs:141`. Exact ⇒ `apply_derivative_gain` (`post_processor.rs:214`) no longer needed. Zero-support stages reuse the incoming fit grid and do not run a fresh adaptive residual pass.
+- Shaper: convolution over `value(·)` via the rescued `ShapedSignal` math (`shaper.rs:36-77`); `half_support = kernel.support()`. Add a closure/evaluator-taking constructor or equivalent sampled-analytic adapter so the convolution consumes `BaseSignal` directly instead of forcing the whole fold through a NURBS input.
+
+| What | Where to change |
+|----|----|
+| Drop `with_pa`/`follower_gains`; make `Sampler` the `BaseSignal` | `lowering.rs:113-147`, `:217-219`, `:251-252` |
+| `lower_move` emits unshaped base only | `lowering.rs:194-269` |
+| New post-lowering stage over the batch (holds history and future lookahead, with live-edge hold-back) | wrap at `StreamState::commit`, `stream.rs:157-184` |
+| Per-axis ordered chain replaces `CompiledChain{kernel,gain}` | `post_processor.rs:35-39`, `:123-157`; build at `config.rs:89-105` |
+| Live swap re-points to the new chain repr | `stream.rs:83-85`, `stream_planner.rs:442-444`, `bridge.rs:3713-3737` |
+
+## Reference syntax
+
+### Config (already exists — unchanged; input shaping needs no new surface)
+
+Param names per `config.rs:126-174`: `type` ∈ `smooth_zv | smooth_mzv | linear_pressure_advance`; required param is `frequency_hz` for shapers, `k` for PA. Attachment to an axis is by name in `post_processors:`; the list order is the application order. There is no extruder concept — a "PA on the extruder" is just a processor attached to a follower axis.
+
+```ini
+[post_processor my_pa]
+type: linear_pressure_advance
+k: 0.04
+
+[post_processor xy_shaper]
+type: smooth_zv
+frequency_hz: 52.0
+
+[axis x]
+motors: stepper_x
+post_processors: xy_shaper
+
+[axis y]
+motors: stepper_y
+post_processors: xy_shaper
+
+[axis e]
+follows: x, y
+motors: extruder_stepper
+post_processors: my_pa
+```
+
+Composing on one axis — declaration order is application order (shape first, then PA on the shaped motion):
+
+```ini
+[axis e]
+follows: x, y
+motors: extruder_stepper
+post_processors: xy_shaper, my_pa
+```
+
+Live retune (identical to PA; the runtime `set_param` at `post_processor.rs:96-102` must gain the `frequency_hz > 0` check that config-build already has at `config.rs:150`):
+
+```gcode
+SET_POST_PROCESSOR NAME=xy_shaper FREQUENCY_HZ=48.5
+SET_POST_PROCESSOR NAME=my_pa K=0.035
+```
+
+### Proposed Rust interface (CAP-5 — the new code)
+
+```rust
+/// The unshaped axis, evaluable exactly anywhere — including into the padding
+/// window a shaper reaches past the segment edge.
+trait BaseSignal {
+    fn value(&self, t: f64) -> f64;
+    fn deriv(&self, t: f64) -> f64;   // 1st (velocity)
+    fn deriv2(&self, t: f64) -> f64;  // 2nd (acceleration)
+}
+
+/// Every post-processor is one of these — PA, shaping, anything later.
+trait AxisPostProcessor {
+    fn half_support(&self) -> (f64, f64);                          // PA: (0.0, 0.0)
+    fn eval(&self, base: &dyn BaseSignal, t: f64) -> (f64, f64);   // (value, velocity)
+}
+
+// PA — local, exact, no NURBS pass (obsoletes apply_derivative_gain):
+struct LinearPa { k: f64 }
+impl AxisPostProcessor for LinearPa {
+    fn half_support(&self) -> (f64, f64) { (0.0, 0.0) }
+    fn eval(&self, b: &dyn BaseSignal, t: f64) -> (f64, f64) {
+        ( b.value(t) + self.k * b.deriv(t),     // p + k·p'
+          b.deriv(t) + self.k * b.deriv2(t) )   // p' + k·p''  (p'' == today's phase.accel, lowering.rs:141)
+    }
+}
+
+// Shaper — non-local, reuses the rescued ShapedSignal convolution:
+struct Shaper { kernel: PiecewisePolynomialKernel<f64> }
+impl AxisPostProcessor for Shaper {
+    fn half_support(&self) -> (f64, f64) { self.kernel.support() }
+    fn eval(&self, b: &dyn BaseSignal, t: f64) -> (f64, f64) {
+        // ShapedSignal's discrete convolution of b.value(·) over [t − k_hi, t − k_lo]
+        // (+ its derivative for the velocity) — shaper.rs math, but reading b.value(·)
+        // instead of sampling a baked NURBS curve.
+    }
+}
+```
+
+The stage (runs at `StreamState::commit`, where the batch + cross-batch history and forward lookahead live):
+
+```rust
+let mut signal: Box<dyn BaseSignal> = analytic_base_for_axis(axis);
+let mut grid = unshaped_fit_grid;
+for pp in &chains[axis] {
+    if pp.half_support() == (0.0, 0.0) {
+        signal = evaluate_on_existing_grid(pp, &*signal, grid);
+    } else {
+        require_history_and_lookahead(pp.half_support());
+        signal = refit_with_padding(pp, &*signal);
+        grid = signal.fit_grid();
+    }
+}
+emit(signal);
+```
+
+Composition note: nonzero-support stages are re-fit to a curve that becomes the next stage's `BaseSignal`, so a later PA sees the *shaped* signal's derivative. Zero-support stages preserve the incoming grid; this is what keeps a PA-only plan byte-identical while still allowing `xy_shaper, my_pa` to mean "PA on already-shaped motion."
+
+## Dead-code marking (do NOT delete here)
+
+Decision: the old pipeline is left in place and retired wholesale by the maintainer in a separate pass. This work only (a) keeps the new live stage free of any dependency on it, and (b) marks it unmistakably dead by expression — relocate under a `legacy`/`dead` module and/or `#[deprecated]`, so the compiler flags any live-path use.
+
+Mark as dead: `motion-engine/src/planner.rs` (`PlannerHandle`, `PlannerMsg`), `trajectory/src/streaming/`, `trajectory/src/emit_shaped.rs`, `trajectory/src/beta.rs`, `post_processor::apply_derivative_gain`, `CompiledChain.kernel`, `PlanAction::Kernel`. `examples/plan_gcode.rs` (its only live user) goes with the old pipeline at retirement, not now.
+
+Stays put (shared primitives, used by BOTH dead emit and the new live stage): `trajectory/src/shaper.rs` (`ShapedSignal`, `eval_kernel`), `crate::kernel::build_smooth_*`, the `SMOOTH_*_T_SM_PER_HZ` consts.
+
+Tests: add a live PA `eval` value-test (don't touch the existing `apply_derivative_gain` tests at `post_processor/tests.rs:92,100` — they ride with the dead pipeline until it's retired).
+
+## Test anchors
+
+- `rust/trajectory/src/post_processor/tests.rs` — `SmoothZv`/`zv()` instances already exist; extend for live-path equivalence.
+- The dead `ShapedSignal` output is the natural **oracle**: a live-path shaped axis must equal `ShapedSignal::eval` for the same base signal and kernel (to fit tolerance). This is the CAP-1 cross-check and an argument for keeping the dead code until the test exists.
+- `rust/motion-engine/src/lowering/tests.rs` — holds PA live-path tests; live shaping tests belong here.
+- Streaming seam: mirror PA's `streaming_replan` / `update_post_processor_commits_held_output_before_swap` for the freq-retune-mid-stream case; add two-batch-vs-one-batch shaped-trajectory equality tests for both past-history and future-lookahead sides of CAP-3. Add a live-edge test proving shaped samples inside the shaper's future half-support are held back until future base exists, and clamp-at-edge is used only at absolute print start/end.

--- a/rust/motion-engine/examples/piece_stream_diff.rs
+++ b/rust/motion-engine/examples/piece_stream_diff.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::{Arc, Mutex};
 
 use _motion_engine::classify::classify_and_build;

--- a/rust/motion-engine/examples/plan_gcode.rs
+++ b/rust/motion-engine/examples/plan_gcode.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::env;
 use std::fs;
 use std::process;

--- a/rust/motion-engine/src/anchor/tests.rs
+++ b/rust/motion-engine/src/anchor/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 
 #[test]

--- a/rust/motion-engine/src/binding_report.rs
+++ b/rust/motion-engine/src/binding_report.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use temporal::BindingConstraint;

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;

--- a/rust/motion-engine/src/config/tests.rs
+++ b/rust/motion-engine/src/config/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 
 #[test]

--- a/rust/motion-engine/src/lib.rs
+++ b/rust/motion-engine/src/lib.rs
@@ -26,6 +26,10 @@ pub mod motion_node;
 #[doc(hidden)]
 pub mod nudge;
 #[doc(hidden)]
+#[cfg_attr(
+    not(test),
+    deprecated(note = "legacy planner stack only; live path uses stream_planner")
+)]
 pub mod planner;
 #[doc(hidden)]
 pub mod position_query;

--- a/rust/motion-engine/src/lowering.rs
+++ b/rust/motion-engine/src/lowering.rs
@@ -2,7 +2,7 @@ use geometry::path::lowering::PositionProfile;
 use geometry::{Move, MoveVelocity, VelSample};
 use nurbs::ScalarNurbs;
 use nurbs::bezier::{BezierPiece, bezier_pieces_to_nurbs};
-use trajectory::{CompiledChain, ShapedSegment};
+use trajectory::{ChainStage, CompiledChain, ShapedSegment};
 
 const MIN_PIECE_DURATION_S: f64 = 1e-9;
 const MAX_SUBDIVISION_DEPTH: u32 = 22;
@@ -90,7 +90,14 @@ fn build_phases(samples: &[VelSample]) -> Result<(Vec<Phase>, f64), LoweringErro
     Ok((phases, t_acc))
 }
 
-fn hermite_cubic(u_start: f64, u_end: f64, p0: f64, v0: f64, p1: f64, v1: f64) -> BezierPiece<f64> {
+pub(crate) fn hermite_cubic(
+    u_start: f64,
+    u_end: f64,
+    p0: f64,
+    v0: f64,
+    p1: f64,
+    v1: f64,
+) -> BezierPiece<f64> {
     let h = u_end - u_start;
     if h <= 0.0 {
         return BezierPiece {
@@ -115,35 +122,60 @@ struct Sampler<'a> {
     spatial: Option<&'a geometry::path::Segment>,
     start_pos: &'a [f64],
     followers: &'a [geometry::FollowerDemand],
-    follower_gains: &'a [f64],
+    axis_chains: &'a [CompiledChain],
 }
 
 impl Sampler<'_> {
-    fn axis_state(&self, axis: usize, t: f64, with_pa: bool) -> (f64, f64) {
+    fn axis_base_state(&self, axis: usize, t: f64) -> (f64, f64, f64) {
         let phase = locate(self.phases, t);
         let (s, v) = phase.s_v_at(t);
         if axis < 3 {
             match self.spatial {
-                Some(seg) => (seg.point_at(s)[axis], seg.heading_at(s)[axis] * v),
-                None => (self.start_pos.get(axis).copied().unwrap_or(0.0), 0.0),
+                Some(seg) => {
+                    let h = (phase.dt * 1e-4).clamp(1e-9, 1e-4);
+                    let t_lo = (t - h).max(phase.t0);
+                    let t_hi = (t + h).min(phase.t0 + phase.dt);
+                    let (s_lo, v_lo) = phase.s_v_at(t_lo);
+                    let (s_hi, v_hi) = phase.s_v_at(t_hi);
+                    let vel_lo = seg.heading_at(s_lo)[axis] * v_lo;
+                    let vel_hi = seg.heading_at(s_hi)[axis] * v_hi;
+                    let denom = t_hi - t_lo;
+                    let accel = if denom > 0.0 {
+                        (vel_hi - vel_lo) / denom
+                    } else {
+                        0.0
+                    };
+                    (seg.point_at(s)[axis], seg.heading_at(s)[axis] * v, accel)
+                }
+                None => (self.start_pos.get(axis).copied().unwrap_or(0.0), 0.0, 0.0),
             }
         } else if let Some(f) = self.followers.iter().find(|f| f.axis_index == axis) {
             let pos = f.ratio.mul_add(s, self.start_pos[axis]);
             let e_dot = f.ratio * v;
-            let k = if with_pa {
-                self.follower_gains.get(axis).copied().unwrap_or(0.0)
-            } else {
-                0.0
-            };
-            if k == 0.0 {
-                (pos, e_dot)
-            } else {
-                let e_ddot = f.ratio * phase.accel;
-                (k.mul_add(e_dot, pos), k.mul_add(e_ddot, e_dot))
-            }
+            let e_ddot = f.ratio * phase.accel;
+            (pos, e_dot, e_ddot)
         } else {
-            (self.start_pos.get(axis).copied().unwrap_or(0.0), 0.0)
+            (self.start_pos.get(axis).copied().unwrap_or(0.0), 0.0, 0.0)
         }
+    }
+
+    fn axis_state(&self, axis: usize, t: f64, apply_zero_support: bool) -> (f64, f64) {
+        let (mut pos, mut vel, mut accel) = self.axis_base_state(axis, t);
+        if apply_zero_support {
+            if let Some(chain) = self.axis_chains.get(axis) {
+                for stage in &chain.stages {
+                    match stage {
+                        ChainStage::LinearPressureAdvance { k } => {
+                            pos = k.mul_add(vel, pos);
+                            vel = k.mul_add(accel, vel);
+                            accel = 0.0;
+                        }
+                        ChainStage::SmoothKernel(_) => break,
+                    }
+                }
+            }
+        }
+        (pos, vel)
     }
 
     fn span_residual(&self, driven: &[usize], ta: f64, tb: f64) -> f64 {
@@ -214,16 +246,12 @@ pub fn lower_move(
         }
     }
 
-    let follower_gains: Vec<f64> = (0..n_axes)
-        .map(|axis| axis_chains.get(axis).map_or(0.0, |c| c.gain))
-        .collect();
-
     let sampler = Sampler {
         phases: &phases,
         spatial,
         start_pos,
         followers: &gm.segment.followers,
-        follower_gains: &follower_gains,
+        axis_chains,
     };
     let mut driven: Vec<usize> = (0..3).collect();
     driven.extend(gm.segment.followers.iter().map(|f| f.axis_index));

--- a/rust/motion-engine/src/lowering/tests.rs
+++ b/rust/motion-engine/src/lowering/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use geometry::segment::SourceRange;
 use geometry::{
@@ -204,6 +206,10 @@ fn source_mismatch_is_rejected() {
 fn linear_pa_chains(extruder_axis: usize, k: f64) -> Vec<CompiledChain> {
     let mut chains = vec![CompiledChain::default(); extruder_axis + 1];
     chains[extruder_axis] = CompiledChain {
+        stages: (k != 0.0)
+            .then_some(trajectory::ChainStage::LinearPressureAdvance { k })
+            .into_iter()
+            .collect(),
         kernel: None,
         gain: k,
     };

--- a/rust/motion-engine/src/planner.rs
+++ b/rust/motion-engine/src/planner.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};

--- a/rust/motion-engine/src/planner/tests.rs
+++ b/rust/motion-engine/src/planner/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use crate::classify::classify_and_build;
 use std::sync::atomic::AtomicUsize;

--- a/rust/motion-engine/src/stream.rs
+++ b/rust/motion-engine/src/stream.rs
@@ -5,9 +5,12 @@ use geometry::{
     ChainFitConfig, FitError, Move, VelocityConfig, VelocityError, VelocityLimits, fit_chain,
     plan_velocity_warm_start,
 };
-use trajectory::{AxisChainSet, ShapedSegment};
+use nurbs::bezier::{BezierPiece, bezier_pieces_to_nurbs, extract_bezier_pieces};
+use trajectory::{AxisChainSet, ChainStage, CompiledChain, ShapedSegment, ShapedSignal};
 
 use crate::lowering::{LoweringError, lower_move};
+
+const SEGMENT_TIME_EPS_S: f64 = 1e-9;
 
 #[derive(Debug, Clone, Copy)]
 pub struct StreamConfig {
@@ -23,6 +26,7 @@ pub enum StreamError {
     Fit(FitError),
     Velocity(VelocityError),
     Lowering(LoweringError),
+    PostProcess(PostProcessError),
 }
 
 impl std::fmt::Display for StreamError {
@@ -31,6 +35,7 @@ impl std::fmt::Display for StreamError {
             Self::Fit(e) => write!(f, "chain fit: {e:?}"),
             Self::Velocity(e) => write!(f, "velocity plan: {e:?}"),
             Self::Lowering(e) => write!(f, "lowering: {e}"),
+            Self::PostProcess(e) => write!(f, "post-processing: {e}"),
         }
     }
 }
@@ -52,6 +57,25 @@ impl From<LoweringError> for StreamError {
         Self::Lowering(e)
     }
 }
+impl From<PostProcessError> for StreamError {
+    fn from(e: PostProcessError) -> Self {
+        Self::PostProcess(e)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PostProcessError {
+    #[error("segment axis count mismatch: expected {expected}, got {got}")]
+    AxisCountMismatch { expected: usize, got: usize },
+    #[error("axis {axis}: cannot fit shaped signal on an empty template track")]
+    DegenerateAxisTrack { axis: usize },
+    #[error("axis {axis}: shaping window needs unavailable history at t={t}")]
+    MissingHistory { axis: usize, t: f64 },
+    #[error("axis {axis}: shaping window needs unavailable lookahead at t={t}")]
+    MissingLookahead { axis: usize, t: f64 },
+    #[error("axis {axis}: shaped sample is non-finite at t={t}")]
+    NonFiniteSample { axis: usize, t: f64 },
+}
 
 pub struct StreamState {
     buffer: VecDeque<Move>,
@@ -60,6 +84,7 @@ pub struct StreamState {
     t_committed: f64,
     config: StreamConfig,
     axis_chains: AxisChainSet,
+    post_history: VecDeque<ShapedSegment>,
 }
 
 impl StreamState {
@@ -77,6 +102,7 @@ impl StreamState {
             t_committed: t_start,
             config,
             axis_chains,
+            post_history: VecDeque::new(),
         }
     }
 
@@ -89,6 +115,7 @@ impl StreamState {
         self.entry_v = 0.0;
         self.odometer = home_pos.to_vec();
         self.t_committed = t_start;
+        self.post_history.clear();
     }
 
     pub fn push(&mut self, m: Move) {
@@ -103,6 +130,7 @@ impl StreamState {
         debug_assert_eq!(self.entry_v, 0.0, "advance_time requires rest at the seam");
         if dt > 0.0 {
             self.t_committed += dt;
+            self.post_history.clear();
         }
     }
 
@@ -114,6 +142,7 @@ impl StreamState {
         debug_assert_eq!(self.entry_v, 0.0, "advance_idle requires rest at the seam");
         if target_t > self.t_committed {
             self.t_committed = target_t;
+            self.post_history.clear();
         }
     }
 
@@ -127,6 +156,7 @@ impl StreamState {
             "restart_idle_timeline requires rest at the seam"
         );
         self.t_committed = 0.0;
+        self.post_history.clear();
     }
 
     #[must_use]
@@ -207,7 +237,19 @@ impl StreamState {
             return Ok(Vec::new());
         }
 
-        let committed: Vec<ShapedSegment> = segs.into_iter().take(commit_count).collect();
+        let commit_count = self.post_commit_count(commit_count, force, &segs);
+
+        if commit_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let committed = apply_axis_chains(
+            &self.post_history,
+            &segs,
+            commit_count,
+            force,
+            &self.axis_chains.chains,
+        )?;
 
         let mut seam_pos = self.odometer.clone();
         for gm in outcome.moves.iter().take(commit_count) {
@@ -234,7 +276,48 @@ impl StreamState {
             }
         }
 
+        self.post_history
+            .extend(segs.into_iter().take(commit_count));
+        self.trim_post_history();
+
         Ok(committed)
+    }
+
+    fn post_commit_count(&self, commit_count: usize, force: bool, segs: &[ShapedSegment]) -> usize {
+        if force || commit_count == 0 {
+            return commit_count;
+        }
+        let forward_support = self
+            .axis_chains
+            .chains
+            .iter()
+            .map(|chain| chain.max_half_support().1)
+            .fold(0.0, f64::max);
+        if forward_support <= 0.0 {
+            return commit_count;
+        }
+        let latest_safe_t = segs.last().map_or(0.0, |seg| seg.t_end - forward_support);
+        segs.iter()
+            .take(commit_count)
+            .take_while(|seg| seg.t_end <= latest_safe_t + 1e-12)
+            .count()
+    }
+
+    fn trim_post_history(&mut self) {
+        let back_support = self
+            .axis_chains
+            .chains
+            .iter()
+            .map(|chain| chain.max_half_support().0.abs())
+            .fold(0.0, f64::max);
+        let keep_after = self.t_committed - back_support;
+        while self
+            .post_history
+            .front()
+            .is_some_and(|seg| seg.t_end < keep_after)
+        {
+            self.post_history.pop_front();
+        }
     }
 }
 
@@ -251,6 +334,231 @@ fn advance_odometer(pos: &mut [f64], gm: &Move) {
             *slot += f.ratio * s_len;
         }
     }
+}
+
+fn apply_axis_chains(
+    history: &VecDeque<ShapedSegment>,
+    base: &[ShapedSegment],
+    commit_count: usize,
+    force: bool,
+    chains: &[CompiledChain],
+) -> Result<Vec<ShapedSegment>, PostProcessError> {
+    let mut out: Vec<ShapedSegment> = base.iter().take(commit_count).cloned().collect();
+    if chains.iter().all(CompiledChain::is_empty) {
+        return Ok(out);
+    }
+    let n_axes = out.iter().map(|seg| seg.axes.len()).max().unwrap_or(0);
+    for seg in history.iter().chain(base.iter()) {
+        if seg.axes.len() != n_axes {
+            return Err(PostProcessError::AxisCountMismatch {
+                expected: n_axes,
+                got: seg.axes.len(),
+            });
+        }
+    }
+    let default_chain = CompiledChain::default();
+    for axis in 0..n_axes {
+        let chain = chains.get(axis).unwrap_or(&default_chain);
+        apply_axis_chain(history, base, &mut out, axis, force, chain)?;
+    }
+    Ok(out)
+}
+
+fn apply_axis_chain(
+    history: &VecDeque<ShapedSegment>,
+    base: &[ShapedSegment],
+    out: &mut [ShapedSegment],
+    axis: usize,
+    force: bool,
+    chain: &CompiledChain,
+) -> Result<(), PostProcessError> {
+    let Some(kernel) = chain.stages.iter().find_map(|stage| match stage {
+        ChainStage::SmoothKernel(kernel) => Some(kernel),
+        ChainStage::LinearPressureAdvance { .. } => None,
+    }) else {
+        return Ok(());
+    };
+    let (k_lo, k_hi) = kernel.support();
+    let first_t = history
+        .front()
+        .or_else(|| base.first())
+        .map_or(0.0, |seg| seg.t_start);
+    let last_t = base.last().map_or(first_t, |seg| seg.t_end);
+    let at_stream_boundary = history.is_empty();
+    let signal_segments: Vec<&ShapedSegment> = history.iter().chain(base.iter()).collect();
+    for seg in out.iter_mut() {
+        let need_lo = seg.t_start + k_lo;
+        let need_hi = seg.t_end + k_hi;
+        if need_lo < first_t && !at_stream_boundary {
+            return Err(PostProcessError::MissingHistory { axis, t: need_lo });
+        }
+        if need_hi > last_t && !force {
+            return Err(PostProcessError::MissingLookahead { axis, t: need_hi });
+        }
+        let sig = ShapedSignal::new_from_evaluator(kernel, seg.t_start, seg.t_end, |t| {
+            eval_axis_with_edges(
+                &signal_segments,
+                axis,
+                t,
+                first_t,
+                last_t,
+                at_stream_boundary,
+                force,
+            )
+        });
+        let shaped = fit_axis_from_signal(axis, &seg.axes[axis], &sig)?;
+        seg.axes[axis] = apply_trailing_zero_support(chain, shaped);
+        if !seg.axes[axis]
+            .control_points()
+            .iter()
+            .all(|v| v.is_finite())
+        {
+            return Err(PostProcessError::NonFiniteSample {
+                axis,
+                t: seg.t_start,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn eval_axis_with_edges(
+    segments: &[&ShapedSegment],
+    axis: usize,
+    t: f64,
+    first_t: f64,
+    last_t: f64,
+    at_stream_boundary: bool,
+    force: bool,
+) -> f64 {
+    if t < first_t {
+        if !at_stream_boundary {
+            return f64::NAN;
+        }
+        return eval_segment_axis(segments.first().expect("non-empty base"), axis, first_t);
+    }
+    if t > last_t {
+        if !force {
+            return f64::NAN;
+        }
+        return eval_segment_axis(segments.last().expect("non-empty base"), axis, last_t);
+    }
+
+    let mut idx = segments.partition_point(|seg| seg.t_end + SEGMENT_TIME_EPS_S < t);
+    if idx >= segments.len() {
+        idx = segments.len().saturating_sub(1);
+    }
+    let start = idx.saturating_sub(1);
+    let end = (idx + 2).min(segments.len());
+    for seg in &segments[start..end] {
+        if t >= seg.t_start - SEGMENT_TIME_EPS_S && t <= seg.t_end + SEGMENT_TIME_EPS_S {
+            return eval_segment_axis(seg, axis, t);
+        }
+    }
+    if force && (t - last_t).abs() <= SEGMENT_TIME_EPS_S {
+        return eval_segment_axis(segments.last().expect("non-empty base"), axis, last_t);
+    }
+    f64::NAN
+}
+
+fn eval_segment_axis(seg: &ShapedSegment, axis: usize, t: f64) -> f64 {
+    nurbs::eval::eval(&seg.axes[axis], t.clamp(seg.t_start, seg.t_end))
+}
+
+fn fit_axis_from_signal(
+    axis: usize,
+    template: &nurbs::ScalarNurbs<f64>,
+    sig: &ShapedSignal<'_>,
+) -> Result<nurbs::ScalarNurbs<f64>, PostProcessError> {
+    let template_pieces = extract_bezier_pieces(template);
+    if template_pieces.is_empty() {
+        return Err(PostProcessError::DegenerateAxisTrack { axis });
+    }
+    let domain_lo = template_pieces.first().expect("checked non-empty").u_start;
+    let domain_hi = template_pieces.last().expect("checked non-empty").u_end;
+    let pieces = template_pieces
+        .iter()
+        .map(|piece| {
+            let t0 = piece.u_start;
+            let t1 = piece.u_end;
+            let p0 = finite_sample(axis, sig, t0)?;
+            let p1 = finite_sample(axis, sig, t1)?;
+            let v0 = finite_derivative(axis, sig, t0, t1, domain_lo, domain_hi)?;
+            let v1 = finite_derivative(axis, sig, t1, t0, domain_lo, domain_hi)?;
+            Ok(super::lowering::hermite_cubic(t0, t1, p0, v0, p1, v1))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(bezier_pieces_to_nurbs(&pieces))
+}
+
+fn finite_sample(axis: usize, sig: &ShapedSignal<'_>, t: f64) -> Result<f64, PostProcessError> {
+    let value = sig.eval(t);
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(PostProcessError::NonFiniteSample { axis, t })
+    }
+}
+
+fn finite_derivative(
+    axis: usize,
+    sig: &ShapedSignal<'_>,
+    t: f64,
+    other: f64,
+    domain_lo: f64,
+    domain_hi: f64,
+) -> Result<f64, PostProcessError> {
+    let h = ((t - other).abs() * 1e-5).clamp(1e-7, 1e-4);
+    let lo = (t - h).max(domain_lo);
+    let hi = (t + h).min(domain_hi);
+    if hi <= lo {
+        return Err(PostProcessError::DegenerateAxisTrack { axis });
+    }
+    let dlo = finite_sample(axis, sig, lo)?;
+    let dhi = finite_sample(axis, sig, hi)?;
+    Ok((dhi - dlo) / (hi - lo))
+}
+
+fn apply_trailing_zero_support(
+    chain: &CompiledChain,
+    mut track: nurbs::ScalarNurbs<f64>,
+) -> nurbs::ScalarNurbs<f64> {
+    let mut seen_kernel = false;
+    for stage in &chain.stages {
+        match stage {
+            ChainStage::SmoothKernel(_) => seen_kernel = true,
+            ChainStage::LinearPressureAdvance { k } if seen_kernel => {
+                track = apply_derivative_gain_to_track(&track, *k);
+            }
+            ChainStage::LinearPressureAdvance { .. } => {}
+        }
+    }
+    track
+}
+
+fn apply_derivative_gain_to_track(
+    track: &nurbs::ScalarNurbs<f64>,
+    k: f64,
+) -> nurbs::ScalarNurbs<f64> {
+    let pieces = extract_bezier_pieces(track);
+    let out_pieces: Vec<BezierPiece<f64>> = pieces
+        .iter()
+        .map(|piece| {
+            let derivative = piece.differentiate();
+            let coeffs: Vec<f64> = piece
+                .coeffs
+                .iter()
+                .enumerate()
+                .map(|(i, c)| c + k * derivative.coeffs.get(i).copied().unwrap_or(0.0))
+                .collect();
+            BezierPiece {
+                u_start: piece.u_start,
+                u_end: piece.u_end,
+                coeffs,
+            }
+        })
+        .collect();
+    bezier_pieces_to_nurbs(&out_pieces)
 }
 
 #[cfg(test)]

--- a/rust/motion-engine/src/stream/tests.rs
+++ b/rust/motion-engine/src/stream/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use geometry::segment::SourceRange;
 use geometry::{ChainFitConfig, MoveContext, VelocityConfig, VelocityLimits, line_move};
 use nurbs::eval::eval;
+use trajectory::PostProcessorType;
 
 fn cfg(keep_secs: f64) -> StreamConfig {
     StreamConfig {
@@ -131,4 +132,140 @@ fn advance_idle_reanchors_committed_time_after_a_gap() {
     );
     s.advance_idle(0.0);
     assert!(s.t_committed() >= second.last().unwrap().t_end - 1e-9);
+}
+
+fn smooth_x_chains(frequency_hz: f64) -> AxisChainSet {
+    AxisChainSet::spatial(
+        PostProcessorType::SmoothZv { frequency_hz }.into_chain(),
+        trajectory::CompiledChain::default(),
+        trajectory::CompiledChain::default(),
+    )
+}
+
+#[test]
+fn smooth_shaper_live_path_matches_shaped_signal_oracle() {
+    let moves = [
+        line(1, [0.0, 0.0, 0.0], [80.0, 0.0, 0.0], 0.0),
+        line(2, [80.0, 0.0, 0.0], [160.0, 0.0, 0.0], 0.0),
+    ];
+    let mut base = StreamState::new(cfg(1.0), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
+    let mut shaped = StreamState::new(cfg(1.0), smooth_x_chains(18.0), &[0.0, 0.0, 0.0], 0.0);
+    for m in moves {
+        base.push(m.clone());
+        shaped.push(m);
+    }
+
+    let base_out = base.commit(true).unwrap();
+    let shaped_out = shaped.commit(true).unwrap();
+    assert_eq!(base_out.len(), shaped_out.len());
+
+    let oracle_chains = smooth_x_chains(18.0);
+    let trajectory::ChainStage::SmoothKernel(kernel) = &oracle_chains.chains[0].stages[0] else {
+        panic!("expected smooth kernel");
+    };
+    let first = base_out.first().unwrap().t_start;
+    let last = base_out.last().unwrap().t_end;
+
+    for (base_seg, shaped_seg) in base_out.iter().zip(&shaped_out) {
+        let sig = trajectory::ShapedSignal::new_from_evaluator(
+            kernel,
+            base_seg.t_start,
+            base_seg.t_end,
+            |t| {
+                let clamped = t.clamp(first, last);
+                base_out
+                    .iter()
+                    .find(|seg| clamped >= seg.t_start && clamped <= seg.t_end)
+                    .map_or_else(
+                        || eval(&base_out.last().unwrap().axes[0], clamped),
+                        |seg| eval(&seg.axes[0], clamped),
+                    )
+            },
+        );
+        for frac in [0.1_f64, 0.3, 0.5, 0.7, 0.9] {
+            let t = frac.mul_add(base_seg.t_end - base_seg.t_start, base_seg.t_start);
+            let got = eval(&shaped_seg.axes[0], t);
+            let want = sig.eval(t);
+            assert!(
+                (got - want).abs() < 5e-2,
+                "shaped x at t={t}: got {got}, want {want}"
+            );
+        }
+    }
+}
+
+#[test]
+fn smooth_shaper_holds_back_live_edge_inside_future_support() {
+    let mut s = StreamState::new(cfg(0.0), smooth_x_chains(0.5), &[0.0, 0.0, 0.0], 0.0);
+    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0));
+    s.push(line(2, [20.0, 0.0, 0.0], [40.0, 0.0, 0.0], 0.0));
+
+    assert!(
+        s.commit(false).unwrap().is_empty(),
+        "future support should hold back live-edge shaped samples"
+    );
+    assert!(
+        !s.commit(true).unwrap().is_empty(),
+        "force flush must release held shaped samples"
+    );
+}
+
+#[test]
+fn smooth_shaper_first_commit_after_nonzero_start_time_is_valid() {
+    let mut s = StreamState::new(cfg(0.0), smooth_x_chains(18.0), &[0.0, 0.0, 0.0], 5.0);
+    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0));
+
+    let committed = s.commit(true).unwrap();
+    assert_eq!(committed[0].t_start, 5.0);
+}
+
+#[test]
+fn smooth_shaper_after_idle_gap_resumes_from_rest_edge() {
+    let mut s = StreamState::new(cfg(0.0), smooth_x_chains(18.0), &[0.0, 0.0, 0.0], 0.0);
+    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0));
+    let first = s.commit(true).unwrap();
+    let idle_end = first.last().unwrap().t_end + 5.0;
+
+    s.advance_idle(idle_end);
+    s.push(line(2, [20.0, 0.0, 0.0], [40.0, 0.0, 0.0], 0.0));
+    let second = s.commit(true).unwrap();
+
+    assert!(second[0].t_start >= idle_end - 1e-9);
+}
+
+#[test]
+fn smooth_shaper_two_batch_output_matches_one_batch() {
+    let moves = [
+        line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0),
+        line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0),
+    ];
+    let chains = smooth_x_chains(18.0);
+    let mut one = StreamState::new(cfg(0.0), chains.clone(), &[0.0, 0.0, 0.0], 0.0);
+    let mut two = StreamState::new(cfg(0.0), chains, &[0.0, 0.0, 0.0], 0.0);
+    for m in moves {
+        one.push(m.clone());
+        two.push(m);
+    }
+
+    let one_batch = one.commit(true).unwrap();
+    let mut two_batch = two.commit(false).unwrap();
+    two_batch.extend(two.commit(true).unwrap());
+
+    assert_eq!(one_batch.len(), two_batch.len());
+    for (one_seg, two_seg) in one_batch.iter().zip(&two_batch) {
+        for frac in [0.1_f64, 0.3, 0.5, 0.7, 0.9] {
+            let t = frac.mul_add(one_seg.t_end - one_seg.t_start, one_seg.t_start);
+            let dx = (eval(&one_seg.axes[0], t) - eval(&two_seg.axes[0], t)).abs();
+            let dv = {
+                let h = 1e-5 * (one_seg.t_end - one_seg.t_start);
+                let v_one =
+                    (eval(&one_seg.axes[0], t + h) - eval(&one_seg.axes[0], t - h)) / (2.0 * h);
+                let v_two =
+                    (eval(&two_seg.axes[0], t + h) - eval(&two_seg.axes[0], t - h)) / (2.0 * h);
+                (v_one - v_two).abs()
+            };
+            assert!(dx < 5e-2, "position mismatch at t={t}: {dx}");
+            assert!(dv < 5e-2, "velocity mismatch at t={t}: {dv}");
+        }
+    }
 }

--- a/rust/motion-engine/src/stream_planner.rs
+++ b/rust/motion-engine/src/stream_planner.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};

--- a/rust/motion-engine/src/stream_planner/tests.rs
+++ b/rust/motion-engine/src/stream_planner/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::{Arc, Mutex};
 
 use super::*;
@@ -257,6 +259,7 @@ fn live_retune_pressure_advance_applies_to_plans_after_the_swap() {
 
     let mut chains = vec![trajectory::CompiledChain::default(); 4];
     chains[3] = trajectory::CompiledChain {
+        stages: vec![trajectory::ChainStage::LinearPressureAdvance { k: 0.2 }],
         kernel: None,
         gain: 0.2,
     };

--- a/rust/motion-engine/tests/binding_report_e2e.rs
+++ b/rust/motion-engine/tests/binding_report_e2e.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::path::PathBuf;
 
 use _motion_engine::binding_report::BindingAccumulator;

--- a/rust/motion-engine/tests/follower_lane_e2e.rs
+++ b/rust/motion-engine/tests/follower_lane_e2e.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::{Arc, Mutex};
 
 use _motion_engine::classify::classify_and_build;

--- a/rust/motion-engine/tests/streaming_replan.rs
+++ b/rust/motion-engine/tests/streaming_replan.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::{Arc, Mutex};
 
 use _motion_engine::classify::classify_and_build;

--- a/rust/motion-engine/tests/z_hop_cold_boot.rs
+++ b/rust/motion-engine/tests/z_hop_cold_boot.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::sync::{Arc, Mutex};
 
 use _motion_engine::classify::classify_and_build;

--- a/rust/trajectory/src/beta.rs
+++ b/rust/trajectory/src/beta.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::emit_shaped::{emit_shaped, EmitSegmentMeta, PerAxisHistory};
 use crate::fit::FittedSegment;
 use crate::plan_velocity::SafetyMode;

--- a/rust/trajectory/src/emit_shaped.rs
+++ b/rust/trajectory/src/emit_shaped.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use nurbs::bezier::{bezier_pieces_to_nurbs, extract_bezier_pieces, BezierPiece};
 use nurbs::eval::eval as nurbs_eval;
 use nurbs::ScalarNurbs;

--- a/rust/trajectory/src/emit_shaped/tests.rs
+++ b/rust/trajectory/src/emit_shaped/tests.rs
@@ -536,9 +536,14 @@ fn e_follower_chains(
     kernels: &[Option<PiecewisePolynomialKernel<f64>>; 4],
 ) -> AxisChainSet {
     let mut chains = AxisChainSet::spatial_from_kernels(kernels);
-    chains
-        .chains
-        .push(crate::CompiledChain { kernel: None, gain });
+    chains.chains.push(crate::CompiledChain {
+        stages: (gain != 0.0)
+            .then_some(crate::ChainStage::LinearPressureAdvance { k: gain })
+            .into_iter()
+            .collect(),
+        kernel: None,
+        gain,
+    });
     chains.followers.push((3, vec![0, 1, 2]));
     chains
 }

--- a/rust/trajectory/src/kernel/tests.rs
+++ b/rust/trajectory/src/kernel/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 
 #[test]

--- a/rust/trajectory/src/lib.rs
+++ b/rust/trajectory/src/lib.rs
@@ -1,4 +1,8 @@
+#![allow(deprecated)]
+
+#[deprecated(note = "legacy planner stack only; live path must not depend on beta")]
 mod beta;
+#[deprecated(note = "legacy planner stack only; live path must not depend on emit_shaped")]
 pub mod emit_shaped;
 pub mod fit;
 mod kernel;
@@ -11,6 +15,7 @@ pub mod post_processor;
 mod reparam;
 mod shaper;
 mod smooth_fit;
+#[deprecated(note = "legacy planner stack only; live path must not depend on streaming")]
 pub mod streaming;
 pub mod utilization;
 
@@ -18,8 +23,10 @@ pub use beta::{ReplanBindingSummary, ReplanWorstBinding};
 pub use emit_shaped::{emit_shaped, EmitSegmentMeta, PerAxisHistory, ShapeEmission};
 pub use plan_velocity::{plan_velocity, PlanInput, PlanOutput, PlanSegment, PlanStats, SafetyMode};
 pub use post_processor::{
-    AxisChainSet, CompiledChain, PostProcessorError, PostProcessorInstance, PostProcessorType,
+    apply_derivative_gain, AxisChainSet, ChainStage, CompiledChain, PostProcessorError,
+    PostProcessorInstance, PostProcessorType,
 };
+pub use shaper::ShapedSignal;
 pub use streaming::ReplanReport;
 
 #[derive(Debug)]

--- a/rust/trajectory/src/plan_velocity.rs
+++ b/rust/trajectory/src/plan_velocity.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::fit::FittedSegment;
 use crate::post_processor::AxisChainSet;
 use crate::{ShapeBatchInput, ShapeError, ShapeSegmentInput};

--- a/rust/trajectory/src/plan_velocity/tests.rs
+++ b/rust/trajectory/src/plan_velocity/tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use geometry::segment::FollowerDemand;
 

--- a/rust/trajectory/src/post_processor.rs
+++ b/rust/trajectory/src/post_processor.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::kernel::{build_smooth_mzv_kernel, build_smooth_zv_kernel};
 use nurbs::algebra::PiecewisePolynomialKernel;
 use nurbs::ScalarNurbs;
@@ -27,14 +29,34 @@ pub struct PostProcessorInstance {
 }
 
 #[derive(Debug, Clone)]
+#[deprecated(note = "legacy emit stack only; live path must use ordered ChainStage values")]
 pub enum PlanAction {
     Kernel(PiecewisePolynomialKernel<f64>),
     DerivativeGain { k: f64 },
 }
 
+#[derive(Debug, Clone)]
+pub enum ChainStage {
+    SmoothKernel(PiecewisePolynomialKernel<f64>),
+    LinearPressureAdvance { k: f64 },
+}
+
+impl ChainStage {
+    #[must_use]
+    pub fn half_support(&self) -> (f64, f64) {
+        match self {
+            Self::SmoothKernel(kernel) => kernel.support(),
+            Self::LinearPressureAdvance { .. } => (0.0, 0.0),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct CompiledChain {
+    pub stages: Vec<ChainStage>,
+    #[deprecated(note = "legacy emit stack only; live path must use ordered stages")]
     pub kernel: Option<PiecewisePolynomialKernel<f64>>,
+    #[deprecated(note = "legacy emit stack only; live path must use ordered stages")]
     pub gain: f64,
 }
 
@@ -73,6 +95,34 @@ impl PostProcessorInstance {
         &self.ty
     }
 
+    pub fn validate(&self) -> Result<(), PostProcessorError> {
+        match self.ty {
+            PostProcessorType::SmoothZv { frequency_hz }
+            | PostProcessorType::SmoothMzv { frequency_hz } => {
+                if frequency_hz.is_finite() && frequency_hz > 0.0 {
+                    Ok(())
+                } else {
+                    Err(PostProcessorError::BadParam {
+                        name: self.name.clone(),
+                        key: "frequency_hz".to_string(),
+                        value: frequency_hz,
+                    })
+                }
+            }
+            PostProcessorType::LinearPressureAdvance { k } => {
+                if k.is_finite() && k >= 0.0 {
+                    Ok(())
+                } else {
+                    Err(PostProcessorError::BadParam {
+                        name: self.name.clone(),
+                        key: "k".to_string(),
+                        value: k,
+                    })
+                }
+            }
+        }
+    }
+
     #[must_use]
     pub fn action(&self) -> PlanAction {
         match self.ty {
@@ -95,6 +145,13 @@ impl PostProcessorInstance {
             PostProcessorType::SmoothZv { frequency_hz }
             | PostProcessorType::SmoothMzv { frequency_hz } => {
                 if key == "frequency_hz" {
+                    if !(value.is_finite() && value > 0.0) {
+                        return Err(PostProcessorError::BadParam {
+                            name: self.name.clone(),
+                            key: key.to_string(),
+                            value,
+                        });
+                    }
                     *frequency_hz = value;
                     Ok(())
                 } else {
@@ -126,6 +183,7 @@ impl CompiledChain {
         let mut kernel_source: Option<&str> = None;
         let mut gain_source: Option<&str> = None;
         for inst in chain {
+            inst.validate()?;
             match inst.action() {
                 PlanAction::Kernel(kernel) => {
                     if let Some(prev) = kernel_source {
@@ -138,6 +196,13 @@ impl CompiledChain {
                     }
                     kernel_source = Some(inst.name());
                     compiled.kernel = Some(kernel);
+                    compiled.stages.push(ChainStage::SmoothKernel(
+                        compiled
+                            .kernel
+                            .as_ref()
+                            .expect("kernel was just stored")
+                            .clone(),
+                    ));
                 }
                 PlanAction::DerivativeGain { k } => {
                     if let Some(prev) = gain_source {
@@ -150,10 +215,26 @@ impl CompiledChain {
                     }
                     gain_source = Some(inst.name());
                     compiled.gain = k;
+                    compiled
+                        .stages
+                        .push(ChainStage::LinearPressureAdvance { k });
                 }
             }
         }
         Ok(compiled)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.stages.is_empty()
+    }
+
+    #[must_use]
+    pub fn max_half_support(&self) -> (f64, f64) {
+        self.stages.iter().fold((0.0, 0.0), |(lo, hi), stage| {
+            let (stage_lo, stage_hi) = stage.half_support();
+            (lo.min(stage_lo), hi.max(stage_hi))
+        })
     }
 }
 
@@ -191,6 +272,7 @@ impl AxisChainSet {
             chains: kernels[..3]
                 .iter()
                 .map(|k| CompiledChain {
+                    stages: k.iter().cloned().map(ChainStage::SmoothKernel).collect(),
                     kernel: k.clone(),
                     gain: 0.0,
                 })
@@ -211,6 +293,7 @@ impl AxisChainSet {
 }
 
 #[must_use]
+#[deprecated(note = "legacy emit stack only; live path must use ordered stage evaluation")]
 pub fn apply_derivative_gain(track: &ScalarNurbs<f64>, k: f64) -> ScalarNurbs<f64> {
     let pieces = nurbs::bezier::extract_bezier_pieces(track);
     let out_pieces: Vec<nurbs::bezier::BezierPiece<f64>> = pieces

--- a/rust/trajectory/src/post_processor/tests.rs
+++ b/rust/trajectory/src/post_processor/tests.rs
@@ -12,6 +12,7 @@ fn compile_empty_chain_is_identity() {
     let c = CompiledChain::compile(&[]).unwrap();
     assert!(c.kernel.is_none());
     assert_eq!(c.gain, 0.0);
+    assert!(c.stages.is_empty());
 }
 
 #[test]
@@ -19,14 +20,29 @@ fn compile_kernel_plus_gain() {
     let c = CompiledChain::compile(&[zv(50.0), pa(0.04)]).unwrap();
     assert!(c.kernel.is_some());
     assert_eq!(c.gain, 0.04);
+    assert!(matches!(c.stages[0], ChainStage::SmoothKernel(_)));
+    assert!(matches!(
+        c.stages[1],
+        ChainStage::LinearPressureAdvance { k } if k == 0.04
+    ));
 }
 
 #[test]
-fn compile_order_irrelevant_for_linear_ops() {
+fn compile_preserves_declaration_order() {
     let a = CompiledChain::compile(&[zv(50.0), pa(0.04)]).unwrap();
     let b = CompiledChain::compile(&[pa(0.04), zv(50.0)]).unwrap();
     assert_eq!(a.gain, b.gain);
     assert_eq!(a.kernel.is_some(), b.kernel.is_some());
+    assert!(matches!(a.stages[0], ChainStage::SmoothKernel(_)));
+    assert!(matches!(
+        a.stages[1],
+        ChainStage::LinearPressureAdvance { .. }
+    ));
+    assert!(matches!(
+        b.stages[0],
+        ChainStage::LinearPressureAdvance { .. }
+    ));
+    assert!(matches!(b.stages[1], ChainStage::SmoothKernel(_)));
 }
 
 #[test]
@@ -76,6 +92,40 @@ fn set_param_rejects_negative_and_non_finite_gain() {
     let c = CompiledChain::compile(std::slice::from_ref(&inst)).unwrap();
     assert_eq!(c.gain, 0.04, "rejected updates must not mutate the gain");
     inst.set_param("k", 0.0).expect("k=0 is a valid no-op gain");
+}
+
+#[test]
+fn set_param_rejects_non_positive_and_non_finite_shaper_frequency() {
+    let mut inst = zv(50.0);
+    for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        assert!(
+            matches!(
+                inst.set_param("frequency_hz", bad),
+                Err(PostProcessorError::BadParam { .. })
+            ),
+            "frequency_hz={bad} should be rejected"
+        );
+    }
+    let c = CompiledChain::compile(std::slice::from_ref(&inst)).unwrap();
+    let ChainStage::SmoothKernel(kernel) = &c.stages[0] else {
+        panic!("expected smooth kernel stage");
+    };
+    assert_eq!(
+        kernel.support(),
+        build_smooth_zv_kernel(SMOOTH_ZV_T_SM_PER_HZ / 50.0).support()
+    );
+}
+
+#[test]
+fn compile_rejects_directly_constructed_bad_params() {
+    for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        let err = CompiledChain::compile(&[zv(bad)]).unwrap_err();
+        assert!(matches!(err, PostProcessorError::BadParam { .. }));
+    }
+    for bad in [-0.01, f64::NAN, f64::INFINITY] {
+        let err = CompiledChain::compile(&[pa(bad)]).unwrap_err();
+        assert!(matches!(err, PostProcessorError::BadParam { .. }));
+    }
 }
 
 fn t_squared_cubic() -> nurbs::ScalarNurbs<f64> {

--- a/rust/trajectory/src/shaper.rs
+++ b/rust/trajectory/src/shaper.rs
@@ -40,15 +40,31 @@ impl<'a> ShapedSignal<'a> {
         t_start: f64,
         t_end: f64,
     ) -> Self {
+        Self::new_from_evaluator(kernel, t_start, t_end, |t| eval_clamped(padded, t))
+    }
+
+    pub fn new_from_evaluator<F>(
+        kernel: &'a PiecewisePolynomialKernel<f64>,
+        t_start: f64,
+        t_end: f64,
+        eval: F,
+    ) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
         let (k_lo, k_hi) = kernel.support();
         let kernel_width = k_hi - k_lo;
+        assert!(
+            kernel_width.is_finite() && kernel_width > 0.0,
+            "shaper kernel support width must be finite and positive"
+        );
         let dt_in = kernel_width / (INPUT_SAMPLES_PER_KERNEL_WIDTH as f64);
         let input_lo = t_start + k_lo;
         let input_hi = t_end + k_hi;
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let n_input = ((input_hi - input_lo) / dt_in).ceil() as usize + 1;
         let input_samples = (0..n_input)
-            .map(|i| eval_clamped(padded, input_lo + (i as f64) * dt_in))
+            .map(|i| eval(input_lo + (i as f64) * dt_in))
             .collect();
         Self {
             input_samples,

--- a/rust/trajectory/src/streaming/emit.rs
+++ b/rust/trajectory/src/streaming/emit.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use nurbs::bezier::BezierPiece;
 
 use super::{EmitContext, ShaperState};

--- a/rust/trajectory/src/streaming/mod.rs
+++ b/rust/trajectory/src/streaming/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::collections::VecDeque;
 
 use geometry::segment::CubicSegment;

--- a/rust/trajectory/src/streaming/state.rs
+++ b/rust/trajectory/src/streaming/state.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::collections::VecDeque;
 
 use geometry::segment::{split_cubic_bezier, CubicSegment};

--- a/rust/trajectory/src/streaming/tests.rs
+++ b/rust/trajectory/src/streaming/tests.rs
@@ -4,7 +4,8 @@
     clippy::too_many_lines,
     clippy::items_after_statements,
     clippy::float_cmp,
-    clippy::unreadable_literal
+    clippy::unreadable_literal,
+    deprecated
 )]
 
 use geometry::segment::CubicSegment;
@@ -1559,6 +1560,10 @@ fn follower_chains(kernel_hz: Option<f64>, pa_gain: f64) -> AxisChainSet {
         None => AxisChainSet::passthrough_spatial(),
     };
     chains.chains.push(crate::CompiledChain {
+        stages: (pa_gain != 0.0)
+            .then_some(crate::ChainStage::LinearPressureAdvance { k: pa_gain })
+            .into_iter()
+            .collect(),
         kernel: None,
         gain: pa_gain,
     });

--- a/rust/trajectory/tests/binding_report.rs
+++ b/rust/trajectory/tests/binding_report.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use geometry::segment::{CubicSegment, FollowerDemand, SourceRange};
 use nurbs::VectorNurbs;
 use trajectory::plan_velocity::SafetyMode;
@@ -7,6 +9,7 @@ use trajectory::{AxisChainSet, CompiledChain};
 fn extruder_chains() -> AxisChainSet {
     let mut chains = AxisChainSet::passthrough_spatial();
     chains.chains.push(CompiledChain {
+        stages: Vec::new(),
         kernel: None,
         gain: 0.0,
     });

--- a/rust/trajectory/tests/continuous_throughput_repro.rs
+++ b/rust/trajectory/tests/continuous_throughput_repro.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use geometry::segment::{CubicSegment, SourceRange};
 use nurbs::VectorNurbs;
 use trajectory::streaming::{ReplanContext, ShaperState};

--- a/rust/trajectory/tests/follower_rows.rs
+++ b/rust/trajectory/tests/follower_rows.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use geometry::segment::FollowerDemand;
 use nurbs::algebra::PiecewisePolynomialKernel;
 use nurbs::VectorNurbs;
@@ -51,6 +53,10 @@ fn solve(pa_k: f64) -> ShapeBatchOutput {
         trajectory::CompiledChain::default(),
     );
     chains.chains.push(trajectory::CompiledChain {
+        stages: (pa_k != 0.0)
+            .then_some(trajectory::ChainStage::LinearPressureAdvance { k: pa_k })
+            .into_iter()
+            .collect(),
         kernel: None,
         gain: pa_k,
     });

--- a/rust/trajectory/tests/live_jog_velocity_probe.rs
+++ b/rust/trajectory/tests/live_jog_velocity_probe.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use geometry::segment::{CubicSegment, SourceRange};
 use nurbs::VectorNurbs;
 use trajectory::plan_velocity::SafetyMode;


### PR DESCRIPTION
## Summary
- add ordered post-processor stages for PA and smooth shapers while keeping legacy fields marked
- apply live input shaping after lowering with history, forward lookahead hold-back, and seam error handling
- add closure-backed ShapedSignal reuse plus PA/order/frequency/streaming seam coverage

## Verification
- ./scripts/ci.sh rust-fmt
- ./scripts/ci.sh rust-clippy
- cargo nextest run -p trajectory -p motion-engine

Note: graphify was intentionally not used per request.