### PR TITLE
Buzz-driven resonance testing + spectrogram graphing

### DIFF
--- a/klippy/extras/resonance_buzz.py
+++ b/klippy/extras/resonance_buzz.py
@@ -53,7 +53,7 @@ class ResonanceBuzz:
             desc=self.cmd_RESONANCE_BUZZ_SWEEP_help,
         )
 
-    def _submit_buzz(
+    def run_sweep(
         self,
         gcmd,
         axis_name,
@@ -123,6 +123,7 @@ class ResonanceBuzz:
         )
         reactor = self.printer.get_reactor()
         reactor.pause(reactor.monotonic() + duration + 0.1)
+        return duration
 
     cmd_RESONANCE_BUZZ_help = (
         "Excite a single resonance frequency on one axis via the engine-"
@@ -138,7 +139,7 @@ class ResonanceBuzz:
         ramp = gcmd.get_float(
             "RAMP", min(duration * 0.25, 3.0 / freq), above=0.0
         )
-        self._submit_buzz(
+        self.run_sweep(
             gcmd,
             axis_name,
             freq,
@@ -173,7 +174,7 @@ class ResonanceBuzz:
             min(tenth_of_sweep, three_periods_of_lowest),
             above=0.0,
         )
-        self._submit_buzz(
+        self.run_sweep(
             gcmd,
             axis_name,
             freq_start,

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -55,21 +55,6 @@ def _parse_axis(gcmd, raw_axis):
     raise gcmd.error("diagonal buzz is not implemented yet")
 
 
-class _VibrationGeneratorCompat:
-    def __init__(self, tester):
-        self.min_freq = tester.min_freq
-        self.max_freq = tester.max_freq
-        self.accel_per_hz = tester.accel_per_hz
-        self.hz_per_sec = tester.hz_per_sec
-
-
-class _ResonanceGeneratorCompat:
-    def __init__(self, tester):
-        self.vibration_generator = _VibrationGeneratorCompat(tester)
-        self.sweeping_period = 0.0
-        self.sweeping_accel = 0.0
-
-
 class ResonanceTester:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -87,7 +72,6 @@ class ResonanceTester:
         self.probe_points = config.getlists(
             "probe_points", None, seps=(",", "\n"), parser=float, count=3
         )
-        self.generator = _ResonanceGeneratorCompat(self)
 
         accel_chips = config.get("accel_chips", None)
         accel_chip = config.get("accel_chip", None)

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -341,12 +341,7 @@ class ResonanceTester:
         sweep = self._parse_sweep(gcmd)
 
         calibration_data = self._run_test(
-            gcmd,
-            calibrate_axes,
-            helper,
-            sweep,
-            raw_name_suffix=name_suffix,
-            accel_chips=accel_chips,
+            gcmd, calibrate_axes, helper, sweep, accel_chips=accel_chips
         )
 
         configfile = self.printer.lookup_object("configfile")

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -356,7 +356,12 @@ class ResonanceTester:
         sweep = self._parse_sweep(gcmd)
 
         calibration_data = self._run_test(
-            gcmd, calibrate_axes, helper, sweep, accel_chips=accel_chips
+            gcmd,
+            calibrate_axes,
+            helper,
+            sweep,
+            raw_name_suffix=name_suffix,
+            accel_chips=accel_chips,
         )
 
         configfile = self.printer.lookup_object("configfile")

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -4,18 +4,73 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
+import os
+import time
+from collections import namedtuple
 
 from . import shaper_calibrate
 
-NOT_IMPLEMENTED_MSG = (
-    "%s is not implemented in this build: the move-based resonance sweep "
-    "was removed. A buzz-based implementation is pending."
+MAX_BUZZ_FREQ = 300.0
+
+SweepParams = namedtuple(
+    "SweepParams",
+    "freq_start freq_end accel_per_hz duration ramp amplitude_mm",
 )
+
+
+class TestAxis:
+    def __init__(self, axis):
+        self._name = axis
+
+    def matches(self, chip_axis):
+        if self._name == "z":
+            return True
+        return self._name in chip_axis
+
+    def get_name(self):
+        return self._name
+
+    def buzz_axis(self):
+        return self._name
+
+
+def _parse_axis(gcmd, raw_axis):
+    if raw_axis is None:
+        raise gcmd.error("AXIS parameter is required")
+    raw_axis = raw_axis.lower()
+    if raw_axis in ("x", "y", "z"):
+        return TestAxis(raw_axis)
+    dirs = raw_axis.split(",")
+    if len(dirs) != 2:
+        raise gcmd.error("Invalid format of axis '%s'" % (raw_axis,))
+    try:
+        dir_x = float(dirs[0].strip())
+        dir_y = float(dirs[1].strip())
+    except ValueError:
+        raise gcmd.error("Unable to parse axis direction '%s'" % (raw_axis,))
+    if dir_x != 0.0 and dir_y == 0.0:
+        return TestAxis("x")
+    if dir_y != 0.0 and dir_x == 0.0:
+        return TestAxis("y")
+    raise gcmd.error("diagonal buzz is not implemented yet")
 
 
 class ResonanceTester:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.move_speed = config.getfloat("move_speed", 50.0, above=0.0)
+        self.min_freq = config.getfloat("min_freq", 5.0, minval=1.0)
+        self.max_freq = config.getfloat(
+            "max_freq", 135.0, minval=self.min_freq, maxval=MAX_BUZZ_FREQ
+        )
+        self.accel_per_hz = config.getfloat("accel_per_hz", 75.0, above=0.0)
+        self.hz_per_sec = config.getfloat(
+            "hz_per_sec", 1.0, minval=0.1, maxval=2.0
+        )
+        self.max_smoothing = config.getfloat("max_smoothing", None, minval=0.05)
+        self.probe_points = config.getlists(
+            "probe_points", None, seps=(",", "\n"), parser=float, count=3
+        )
 
         accel_chips = config.get("accel_chips", None)
         accel_chip = config.get("accel_chip", None)
@@ -72,17 +127,269 @@ class ResonanceTester:
                 )
                 raise
 
+    def _parse_chips(self, accel_chips):
+        if not accel_chips:
+            return None
+        parsed_chips = []
+        for chip_name in accel_chips.split(","):
+            chip = self.printer.lookup_object(chip_name.strip())
+            parsed_chips.append(chip)
+        return parsed_chips
+
+    def _parse_point(self, gcmd):
+        test_point = gcmd.get("POINT", None)
+        if test_point is None:
+            return None
+        coords = test_point.split(",")
+        if len(coords) != 3:
+            raise gcmd.error("Invalid POINT parameter, must be 'x,y,z'")
+        try:
+            return [float(p.strip()) for p in coords]
+        except ValueError:
+            raise gcmd.error(
+                "Invalid POINT parameter, must be 'x,y,z'"
+                " where x, y and z are valid floating point numbers"
+            )
+
+    def _parse_sweep(self, gcmd, test_accel_per_hz=None):
+        freq_start = gcmd.get_float("FREQ_START", self.min_freq, minval=1.0)
+        freq_end = gcmd.get_float(
+            "FREQ_END", self.max_freq, minval=freq_start, maxval=MAX_BUZZ_FREQ
+        )
+        if test_accel_per_hz is None:
+            accel_per_hz = gcmd.get_float(
+                "ACCEL_PER_HZ", self.accel_per_hz, above=0.0
+            )
+        else:
+            accel_per_hz = test_accel_per_hz
+        hz_per_sec = gcmd.get_float(
+            "HZ_PER_SEC", self.hz_per_sec, above=0.0, maxval=2.0
+        )
+        amplitude_mm = gcmd.get_float("AMPLITUDE", 0.0, minval=0.0)
+        duration = max(abs(freq_end - freq_start) / hz_per_sec, 0.1)
+        ramp = min(0.1 * duration, 3.0 / min(freq_start, freq_end))
+        return SweepParams(
+            freq_start, freq_end, accel_per_hz, duration, ramp, amplitude_mm
+        )
+
+    def _run_test(
+        self,
+        gcmd,
+        axes,
+        helper,
+        sweep,
+        raw_name_suffix=None,
+        accel_chips=None,
+        test_point=None,
+    ):
+        toolhead = self.printer.lookup_object("toolhead")
+        buzz = self.printer.lookup_object("resonance_buzz")
+        calibration_data = {axis: None for axis in axes}
+
+        test_points = (
+            [test_point] if test_point else (self.probe_points or [None])
+        )
+
+        for point in test_points:
+            if point is not None:
+                toolhead.manual_move(point, self.move_speed)
+                if len(test_points) > 1 or test_point is not None:
+                    gcmd.respond_info(
+                        "Probing point (%.3f, %.3f, %.3f)" % tuple(point)
+                    )
+            for axis in axes:
+                toolhead.wait_moves()
+                toolhead.dwell(0.500)
+                if len(axes) > 1:
+                    gcmd.respond_info("Testing axis %s" % axis.get_name())
+
+                raw_values = []
+                if accel_chips is None:
+                    for chip_axis, chip in self.accel_chips:
+                        if axis.matches(chip_axis):
+                            aclient = chip.start_internal_client()
+                            raw_values.append((chip_axis, aclient, chip.name))
+                else:
+                    for chip in accel_chips:
+                        aclient = chip.start_internal_client()
+                        raw_values.append((axis.get_name(), aclient, chip.name))
+
+                buzz.run_sweep(
+                    gcmd,
+                    axis.buzz_axis(),
+                    sweep.freq_start,
+                    sweep.freq_end,
+                    sweep.duration,
+                    sweep.ramp,
+                    sweep.accel_per_hz,
+                    sweep.amplitude_mm,
+                )
+
+                for chip_axis, aclient, chip_name in raw_values:
+                    aclient.finish_measurements()
+                    if raw_name_suffix is not None:
+                        raw_name = self.get_filename(
+                            "raw_data",
+                            raw_name_suffix,
+                            axis,
+                            point if len(test_points) > 1 else None,
+                            chip_name,
+                        )
+                        aclient.write_to_file(raw_name)
+                        gcmd.respond_info(
+                            "Writing raw accelerometer data to "
+                            "%s file" % (raw_name,)
+                        )
+                if helper is None:
+                    continue
+                for chip_axis, aclient, chip_name in raw_values:
+                    if not aclient.has_valid_samples():
+                        raise gcmd.error(
+                            "accelerometer '%s' measured no data" % (chip_name,)
+                        )
+                    new_data = helper.process_accelerometer_data(aclient)
+                    if calibration_data[axis] is None:
+                        calibration_data[axis] = new_data
+                    else:
+                        calibration_data[axis].add_data(new_data)
+        return calibration_data
+
     cmd_TEST_RESONANCES_help = "Runs the resonance test for a specifed axis"
 
     def cmd_TEST_RESONANCES(self, gcmd):
-        raise gcmd.error(NOT_IMPLEMENTED_MSG % ("TEST_RESONANCES",))
+        axis = _parse_axis(gcmd, gcmd.get("AXIS"))
+        chips_str = gcmd.get("CHIPS", None)
+        test_point = self._parse_point(gcmd)
+        test_accel_per_hz = gcmd.get_float("ACCEL_PER_HZ", None, above=0.0)
+        accel_chips = self._parse_chips(chips_str) if chips_str else None
+
+        outputs = gcmd.get("OUTPUT", "resonances").lower().split(",")
+        for output in outputs:
+            if output not in ("resonances", "raw_data"):
+                raise gcmd.error(
+                    "Unsupported output '%s', only 'resonances'"
+                    " and 'raw_data' are supported" % (output,)
+                )
+        if not outputs:
+            raise gcmd.error(
+                "No output specified, at least one of 'resonances'"
+                " or 'raw_data' must be set in OUTPUT parameter"
+            )
+        name_suffix = gcmd.get("NAME", time.strftime("%Y%m%d_%H%M%S"))
+        if not self.is_valid_name_suffix(name_suffix):
+            raise gcmd.error("Invalid NAME parameter")
+        csv_output = "resonances" in outputs
+        raw_output = "raw_data" in outputs
+
+        helper = (
+            shaper_calibrate.ShaperCalibrate(self.printer)
+            if csv_output
+            else None
+        )
+        sweep = self._parse_sweep(gcmd, test_accel_per_hz)
+
+        data = self._run_test(
+            gcmd,
+            [axis],
+            helper,
+            sweep,
+            raw_name_suffix=name_suffix if raw_output else None,
+            accel_chips=accel_chips,
+            test_point=test_point,
+        )[axis]
+        if csv_output:
+            csv_name = self.save_calibration_data(
+                "resonances",
+                name_suffix,
+                helper,
+                axis,
+                data,
+                point=test_point,
+                max_freq=1.5 * sweep.freq_end,
+                accel_per_hz=sweep.accel_per_hz,
+            )
+            gcmd.respond_info(
+                "Resonances data written to %s file" % (csv_name,)
+            )
 
     cmd_SHAPER_CALIBRATE_help = (
         "Simular to TEST_RESONANCES but suggest input shaper config"
     )
 
     def cmd_SHAPER_CALIBRATE(self, gcmd):
-        raise gcmd.error(NOT_IMPLEMENTED_MSG % ("SHAPER_CALIBRATE",))
+        axis = gcmd.get("AXIS", None)
+        if not axis:
+            calibrate_axes = [TestAxis("x"), TestAxis("y")]
+        elif axis.lower() not in ("x", "y"):
+            raise gcmd.error("Unsupported axis '%s'" % (axis,))
+        else:
+            calibrate_axes = [TestAxis(axis.lower())]
+        chips_str = gcmd.get("CHIPS", None)
+        accel_chips = self._parse_chips(chips_str) if chips_str else None
+
+        max_smoothing = gcmd.get_float(
+            "MAX_SMOOTHING", self.max_smoothing, minval=0.05
+        )
+
+        name_suffix = gcmd.get("NAME", time.strftime("%Y%m%d_%H%M%S"))
+        if not self.is_valid_name_suffix(name_suffix):
+            raise gcmd.error("Invalid NAME parameter")
+
+        input_shaper = self.printer.lookup_object("input_shaper", None)
+        helper = shaper_calibrate.ShaperCalibrate(self.printer)
+        sweep = self._parse_sweep(gcmd)
+
+        calibration_data = self._run_test(
+            gcmd, calibrate_axes, helper, sweep, accel_chips=accel_chips
+        )
+
+        configfile = self.printer.lookup_object("configfile")
+        max_freq = 1.5 * sweep.freq_end
+        for axis in calibrate_axes:
+            axis_name = axis.get_name()
+            gcmd.respond_info(
+                "Calculating the best input shaper parameters for %s axis"
+                % (axis_name,)
+            )
+            calibration_data[axis].normalize_to_frequencies()
+            systime = self.printer.get_reactor().monotonic()
+            toolhead = self.printer.lookup_object("toolhead")
+            scv = toolhead.get_status(systime)["square_corner_velocity"]
+            best_shaper, all_shapers = helper.find_best_shaper(
+                calibration_data[axis],
+                max_smoothing=max_smoothing,
+                scv=scv,
+                max_freq=max_freq,
+                logger=gcmd.respond_info,
+            )
+            gcmd.respond_info(
+                "Recommended shaper_type_%s = %s, shaper_freq_%s = %.1f Hz"
+                % (axis_name, best_shaper.name, axis_name, best_shaper.freq)
+            )
+            if input_shaper is not None:
+                helper.apply_params(
+                    input_shaper, axis_name, best_shaper.name, best_shaper.freq
+                )
+            helper.save_params(
+                configfile, axis_name, best_shaper.name, best_shaper.freq
+            )
+            csv_name = self.save_calibration_data(
+                "calibration_data",
+                name_suffix,
+                helper,
+                axis,
+                calibration_data[axis],
+                all_shapers,
+                max_freq=max_freq,
+                accel_per_hz=sweep.accel_per_hz,
+            )
+            gcmd.respond_info(
+                "Shaper calibration data written to %s file" % (csv_name,)
+            )
+        gcmd.respond_info(
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "with these parameters and restart the printer."
+        )
 
     cmd_MEASURE_AXES_NOISE_help = (
         "Measures noise of all enabled accelerometer chips"
@@ -111,6 +418,40 @@ class ResonanceTester:
                 "Axes noise for %s-axis accelerometer: "
                 "%.6f (x), %.6f (y), %.6f (z)" % (chip_axis, vx, vy, vz)
             )
+
+    def is_valid_name_suffix(self, name_suffix):
+        return name_suffix.replace("-", "").replace("_", "").isalnum()
+
+    def get_filename(
+        self, base, name_suffix, axis=None, point=None, chip_name=None
+    ):
+        name = base
+        if axis:
+            name += "_" + axis.get_name()
+        if chip_name:
+            name += "_" + chip_name.replace(" ", "_")
+        if point:
+            name += "_%.3f_%.3f_%.3f" % (point[0], point[1], point[2])
+        name += "_" + name_suffix
+        return os.path.join("/tmp", name + ".csv")
+
+    def save_calibration_data(
+        self,
+        base_name,
+        name_suffix,
+        helper,
+        axis,
+        calibration_data,
+        all_shapers=None,
+        point=None,
+        max_freq=None,
+        accel_per_hz=None,
+    ):
+        output = self.get_filename(base_name, name_suffix, axis, point)
+        helper.save_calibration_data(
+            output, calibration_data, all_shapers, max_freq, accel_per_hz
+        )
+        return output
 
 
 def load_config(config):

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -73,6 +73,7 @@ class _ResonanceGeneratorCompat:
 class ResonanceTester:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.printer.load_object(config, "resonance_buzz")
         self.move_speed = config.getfloat("move_speed", 50.0, above=0.0)
         self.min_freq = config.getfloat("min_freq", 5.0, minval=1.0)
         self.max_freq = config.getfloat(

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -55,6 +55,21 @@ def _parse_axis(gcmd, raw_axis):
     raise gcmd.error("diagonal buzz is not implemented yet")
 
 
+class _VibrationGeneratorCompat:
+    def __init__(self, tester):
+        self.min_freq = tester.min_freq
+        self.max_freq = tester.max_freq
+        self.accel_per_hz = tester.accel_per_hz
+        self.hz_per_sec = tester.hz_per_sec
+
+
+class _ResonanceGeneratorCompat:
+    def __init__(self, tester):
+        self.vibration_generator = _VibrationGeneratorCompat(tester)
+        self.sweeping_period = 0.0
+        self.sweeping_accel = 0.0
+
+
 class ResonanceTester:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -71,6 +86,7 @@ class ResonanceTester:
         self.probe_points = config.getlists(
             "probe_points", None, seps=(",", "\n"), parser=float, count=3
         )
+        self.generator = _ResonanceGeneratorCompat(self)
 
         accel_chips = config.get("accel_chips", None)
         accel_chip = config.get("accel_chip", None)

--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -209,7 +209,6 @@ class Motion:
             "manual_probe",
             "tuning_tower",
             "garbage_collection",
-            "resonance_buzz",
         ):
             printer.load_object(config, module_name)
 

--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -834,15 +834,12 @@ class Motion:
     cmd_SET_VELOCITY_LIMIT_help = "Set printer velocity limits"
 
     def cmd_SET_VELOCITY_LIMIT(self, gcmd):
-        for unsupported in (
+        accepted_legacy_noops = (
             "MINIMUM_CRUISE_RATIO",
             "ACCEL_TO_DECEL",
-        ):
-            if gcmd.get_float(unsupported, None) is not None:
-                raise gcmd.error(
-                    "%s is not supported: declare limits in [limit] config "
-                    "sections" % unsupported
-                )
+        )
+        for legacy in accepted_legacy_noops:
+            gcmd.get_float(legacy, None)
         v = gcmd.get_float("VELOCITY", None, above=0.0)
         a = gcmd.get_float("ACCEL", None, above=0.0)
         scv = gcmd.get_float("SQUARE_CORNER_VELOCITY", None, minval=0.0)

--- a/scripts/calibrate_shaper.py
+++ b/scripts/calibrate_shaper.py
@@ -61,6 +61,34 @@ def parse_accel_per_hz(logname):
     return data[0][5].item()
 
 
+def calc_specgram(data, axis):
+    N = data.shape[0]
+    Fs = N / (data[-1, 0] - data[0, 0])
+    M = 1 << int(0.5 * Fs - 1).bit_length()
+    window = np.kaiser(M, 6.0)
+
+    def _specgram(x):
+        return matplotlib.mlab.specgram(
+            x,
+            Fs=Fs,
+            NFFT=M,
+            noverlap=M // 2,
+            window=window,
+            mode="psd",
+            detrend="mean",
+            scale_by_freq=False,
+        )
+
+    d = {"x": data[:, 1], "y": data[:, 2], "z": data[:, 3]}
+    if axis != "all":
+        pdata, bins, t = _specgram(d[axis])
+    else:
+        pdata, bins, t = _specgram(d["x"])
+        for ax in "yz":
+            pdata += _specgram(d[ax])[0]
+    return pdata, bins, t
+
+
 ######################################################################
 # Shaper calibration
 ######################################################################
@@ -126,6 +154,7 @@ def plot_freq_response(
     selected_shaper,
     max_freq,
     accels_per_hz,
+    raw_data=None,
 ):
     freqs = calibration_data.freq_bins
     psd = calibration_data.psd_sum[freqs <= max_freq]
@@ -137,10 +166,19 @@ def plot_freq_response(
     fontP = matplotlib.font_manager.FontProperties()
     fontP.set_size("x-small")
 
-    fig, ax = matplotlib.pyplot.subplots()
-    ax.set_xlabel("Frequency, Hz")
+    if raw_data is not None:
+        fig, (ax, ax_spec) = matplotlib.pyplot.subplots(
+            nrows=2,
+            sharex=True,
+            gridspec_kw={"height_ratios": [3, 1]},
+        )
+    else:
+        fig, ax = matplotlib.pyplot.subplots()
+        ax_spec = None
     ax.set_xlim([0, max_freq])
     ax.set_ylabel("Power spectral density")
+    if ax_spec is None:
+        ax.set_xlabel("Frequency, Hz")
 
     ax.plot(freqs, psd, label="X+Y+Z", color="purple")
     ax.plot(freqs, px, label="X", color="red")
@@ -187,6 +225,20 @@ def plot_freq_response(
     ax.legend(loc="upper left", prop=fontP)
     ax2.legend(loc="upper right", prop=fontP)
 
+    if ax_spec is not None:
+        pdata, bins, t = calc_specgram(raw_data, "all")
+        ax_spec.pcolormesh(
+            bins,
+            t,
+            pdata.T,
+            norm=matplotlib.colors.LogNorm(),
+            cmap="inferno",
+            shading="auto",
+        )
+        ax_spec.set_xlim([0, max_freq])
+        ax_spec.set_ylabel("Time, s")
+        ax_spec.set_xlabel("Frequency, Hz")
+
     fig.tight_layout()
     return fig
 
@@ -201,8 +253,10 @@ def setup_matplotlib(output_to_file):
     if output_to_file:
         matplotlib.rcParams.update({"figure.autolayout": True})
         matplotlib.use("Agg")
+    import matplotlib.colors
     import matplotlib.dates
     import matplotlib.font_manager
+    import matplotlib.mlab
     import matplotlib.pyplot
     import matplotlib.ticker
 
@@ -362,6 +416,11 @@ def main():
         # Draw graph
         setup_matplotlib(options.output is not None)
 
+        raw_data = (
+            datas[0]
+            if not isinstance(datas[0], shaper_calibrate.CalibrationData)
+            else None
+        )
         fig = plot_freq_response(
             args,
             calibration_data,
@@ -369,13 +428,14 @@ def main():
             selected_shaper,
             max_freq,
             accels_per_hz,
+            raw_data=raw_data,
         )
 
         # Show graph
         if options.output is None:
             matplotlib.pyplot.show()
         else:
-            fig.set_size_inches(8, 6)
+            fig.set_size_inches(8, 8 if raw_data is not None else 6)
             fig.savefig(options.output)
 
 

--- a/test/test_resonance_tester_capture.py
+++ b/test/test_resonance_tester_capture.py
@@ -140,6 +140,25 @@ def test_registers_commands():
     assert "MEASURE_AXES_NOISE" in gcode.commands
 
 
+def test_shaketune_compat_generator_surface():
+    tester, _, _, _ = make_tester(
+        {
+            "min_freq": 70.0,
+            "max_freq": 133.0,
+            "accel_per_hz": 75.0,
+            "hz_per_sec": 1.0,
+        }
+    )
+    vg = tester.generator.vibration_generator
+    assert vg.min_freq == 70.0
+    assert vg.max_freq == 133.0
+    assert vg.accel_per_hz == 75.0
+    assert vg.hz_per_sec == 1.0
+    assert tester.generator.sweeping_period == 0.0
+    assert tester.generator.sweeping_accel == 0.0
+    assert not hasattr(tester, "test")
+
+
 def test_parse_axis_cardinal():
     gcmd = FakeGcmd()
     for name in ("x", "y", "z", "X", "Z"):

--- a/test/test_resonance_tester_capture.py
+++ b/test/test_resonance_tester_capture.py
@@ -143,25 +143,6 @@ def test_registers_commands():
     assert "MEASURE_AXES_NOISE" in gcode.commands
 
 
-def test_shaketune_compat_generator_surface():
-    tester, _, _, _ = make_tester(
-        {
-            "min_freq": 70.0,
-            "max_freq": 133.0,
-            "accel_per_hz": 75.0,
-            "hz_per_sec": 1.0,
-        }
-    )
-    vg = tester.generator.vibration_generator
-    assert vg.min_freq == 70.0
-    assert vg.max_freq == 133.0
-    assert vg.accel_per_hz == 75.0
-    assert vg.hz_per_sec == 1.0
-    assert tester.generator.sweeping_period == 0.0
-    assert tester.generator.sweeping_accel == 0.0
-    assert not hasattr(tester, "test")
-
-
 def test_parse_axis_cardinal():
     gcmd = FakeGcmd()
     for name in ("x", "y", "z", "X", "Z"):

--- a/test/test_resonance_tester_capture.py
+++ b/test/test_resonance_tester_capture.py
@@ -1,0 +1,217 @@
+import pytest
+
+from klippy.extras import resonance_tester
+
+
+class FakeGcmd:
+    error = RuntimeError
+
+    def __init__(self, **params):
+        self._params = params
+        self.responses = []
+
+    def get(self, name, default=None):
+        return self._params.get(name, default)
+
+    def get_float(self, name, default=None, **kw):
+        return self._params.get(name, default)
+
+    def respond_info(self, msg):
+        self.responses.append(msg)
+
+
+class FakeGcode:
+    def __init__(self):
+        self.commands = {}
+
+    def register_command(self, name, func, desc=None):
+        self.commands[name] = func
+
+
+class FakeAclient:
+    def __init__(self):
+        self.finished = False
+        self.written = []
+
+    def finish_measurements(self):
+        self.finished = True
+
+    def has_valid_samples(self):
+        return True
+
+    def write_to_file(self, name):
+        self.written.append(name)
+
+
+class FakeChip:
+    def __init__(self, name):
+        self.name = name
+        self.clients = []
+
+    def start_internal_client(self):
+        client = FakeAclient()
+        self.clients.append(client)
+        return client
+
+
+class FakeBuzz:
+    def __init__(self):
+        self.calls = []
+
+    def run_sweep(self, gcmd, axis_name, *args):
+        self.calls.append((axis_name, args))
+        return args[2]
+
+
+class FakeToolhead:
+    def __init__(self):
+        self.moves = []
+        self.dwells = []
+        self.waited = 0
+
+    def manual_move(self, point, speed):
+        self.moves.append((point, speed))
+
+    def wait_moves(self):
+        self.waited += 1
+
+    def dwell(self, t):
+        self.dwells.append(t)
+
+
+class FakePrinter:
+    config_error = RuntimeError
+
+    def __init__(self):
+        self._objs = {}
+        self.event_handlers = {}
+
+    def lookup_object(self, name, default="__raise__"):
+        if name in self._objs:
+            return self._objs[name]
+        if default == "__raise__":
+            raise KeyError(name)
+        return default
+
+    def register_event_handler(self, event, cb):
+        self.event_handlers[event] = cb
+
+
+class FakeConfig:
+    error = RuntimeError
+
+    def __init__(self, printer, values):
+        self._printer = printer
+        self._values = values
+
+    def get_printer(self):
+        return self._printer
+
+    def get(self, name, default=None):
+        return self._values.get(name, default)
+
+    def getfloat(self, name, default=None, **kw):
+        return self._values.get(name, default)
+
+    def getlists(self, name, default=None, **kw):
+        return self._values.get(name, default)
+
+
+def make_tester(values=None):
+    printer = FakePrinter()
+    gcode = FakeGcode()
+    buzz = FakeBuzz()
+    toolhead = FakeToolhead()
+    printer._objs["gcode"] = gcode
+    printer._objs["resonance_buzz"] = buzz
+    printer._objs["toolhead"] = toolhead
+    cfg_values = {"accel_chip": "adxl345"}
+    if values:
+        cfg_values.update(values)
+    tester = resonance_tester.ResonanceTester(FakeConfig(printer, cfg_values))
+    return tester, printer, buzz, toolhead
+
+
+def test_registers_commands():
+    _, printer, _, _ = make_tester()
+    gcode = printer._objs["gcode"]
+    assert "TEST_RESONANCES" in gcode.commands
+    assert "SHAPER_CALIBRATE" in gcode.commands
+    assert "MEASURE_AXES_NOISE" in gcode.commands
+
+
+def test_parse_axis_cardinal():
+    gcmd = FakeGcmd()
+    for name in ("x", "y", "z", "X", "Z"):
+        axis = resonance_tester._parse_axis(gcmd, name)
+        assert axis.buzz_axis() == name.lower()
+
+
+def test_parse_axis_pure_vectors_map_to_named_axes():
+    gcmd = FakeGcmd()
+    assert resonance_tester._parse_axis(gcmd, "1,0").buzz_axis() == "x"
+    assert resonance_tester._parse_axis(gcmd, "0,1").buzz_axis() == "y"
+
+
+def test_parse_axis_diagonal_not_implemented():
+    gcmd = FakeGcmd()
+    with pytest.raises(RuntimeError, match="diagonal buzz is not implemented"):
+        resonance_tester._parse_axis(gcmd, "1,1")
+
+
+def test_parse_axis_bad_format():
+    gcmd = FakeGcmd()
+    with pytest.raises(RuntimeError, match="Invalid format"):
+        resonance_tester._parse_axis(gcmd, "bogus")
+
+
+def test_parse_axis_missing_is_required():
+    gcmd = FakeGcmd()
+    with pytest.raises(RuntimeError, match="AXIS parameter is required"):
+        resonance_tester._parse_axis(gcmd, None)
+
+
+def test_run_test_excites_axis_and_captures():
+    tester, printer, buzz, toolhead = make_tester()
+    chip = FakeChip("adxl345")
+    tester.accel_chips = [("xy", chip)]
+    gcmd = FakeGcmd()
+    sweep = tester._parse_sweep(gcmd)
+    axes = [resonance_tester.TestAxis("x")]
+
+    tester._run_test(gcmd, axes, None, sweep)
+
+    assert len(buzz.calls) == 1
+    assert buzz.calls[0][0] == "x"
+    assert len(chip.clients) == 1
+    assert chip.clients[0].finished
+
+
+def test_run_test_skips_chip_that_does_not_match_axis():
+    tester, printer, buzz, toolhead = make_tester()
+    x_chip = FakeChip("adxl_x")
+    tester.accel_chips = [("x", x_chip)]
+    gcmd = FakeGcmd()
+    sweep = tester._parse_sweep(gcmd)
+
+    tester._run_test(gcmd, [resonance_tester.TestAxis("y")], None, sweep)
+
+    assert buzz.calls and buzz.calls[0][0] == "y"
+    assert x_chip.clients == []
+
+
+def test_run_test_moves_to_probe_point():
+    tester, printer, buzz, toolhead = make_tester()
+    tester.accel_chips = [("xy", FakeChip("adxl345"))]
+    gcmd = FakeGcmd()
+    sweep = tester._parse_sweep(gcmd)
+
+    tester._run_test(
+        gcmd,
+        [resonance_tester.TestAxis("x")],
+        None,
+        sweep,
+        test_point=[10.0, 20.0, 5.0],
+    )
+
+    assert toolhead.moves == [([10.0, 20.0, 5.0], tester.move_speed)]

--- a/test/test_resonance_tester_capture.py
+++ b/test/test_resonance_tester_capture.py
@@ -96,6 +96,9 @@ class FakePrinter:
     def register_event_handler(self, event, cb):
         self.event_handlers[event] = cb
 
+    def load_object(self, config, name, default="__raise__"):
+        return self.lookup_object(name, default)
+
 
 class FakeConfig:
     error = RuntimeError

--- a/test/test_resonance_tester_capture.py
+++ b/test/test_resonance_tester_capture.py
@@ -219,6 +219,25 @@ def test_run_test_skips_chip_that_does_not_match_axis():
     assert x_chip.clients == []
 
 
+def test_run_test_writes_raw_data_when_named():
+    tester, printer, buzz, toolhead = make_tester()
+    chip = FakeChip("adxl345")
+    tester.accel_chips = [("xy", chip)]
+    gcmd = FakeGcmd()
+    sweep = tester._parse_sweep(gcmd)
+
+    tester._run_test(
+        gcmd,
+        [resonance_tester.TestAxis("x")],
+        None,
+        sweep,
+        raw_name_suffix="probe1",
+    )
+
+    assert chip.clients[0].written
+    assert chip.clients[0].written[0].endswith("probe1.csv")
+
+
 def test_run_test_moves_to_probe_point():
     tester, printer, buzz, toolhead = make_tester()
     tester.accel_chips = [("xy", FakeChip("adxl345"))]


### PR DESCRIPTION
Reimplements `TEST_RESONANCES` / `SHAPER_CALIBRATE` on top of the engine-resident buzz oscillator (the move-based sweep was removed earlier), adds a spectrogram panel to the shaper graph, and tightens how the resonance commands are gated.

## Motivation

Our pipeline samples the planned trajectory on a fixed time grid rather than generating exact step edges. Move-based excitation (mainline `TEST_RESONANCES`, Shake&Tune) encodes a high-frequency oscillation as a stream of tiny moves, which aliases against the sample grid and never reaches the motor faithfully — so it cannot drive resonance testing here, on steppers or servo. The buzz oscillator writes the analytic `(pos, vel, acc)` at each sample tick, so the excitation is correct at the sampling rate. This wires the resonance/shaper commands onto that source.

## Changes

- **`resonance_tester`**: `TEST_RESONANCES` / `SHAPER_CALIBRATE` now run the buzz sweep and capture the accelerometer around it, then reuse the existing `process_accelerometer_data` / `find_best_shaper` analysis. No `suspend_limits` / `M204` / input-shaper-disable — buzz bypasses the planner. `AXIS` keeps the mainline `x`/`y`/`z` + vib-dir surface; pure-axis vectors map to `x`/`y`, and real diagonals raise `diagonal buzz is not implemented yet` (deferred pending per-motor-amplitude support).
- **`calibrate_shaper.py`**: when fed raw accelerometer data, stacks a time/frequency spectrogram below the frequency-response plot, sharing the frequency axis so resonance bands line up with the PSD peaks and shaper curves. Reuses the existing `matplotlib.mlab.specgram` path; no new dependency. Processed-PSD input is unchanged. Produce raw via `TEST_RESONANCES OUTPUT=raw_data` and point the script at the `raw_data_*` file.
- **Gating**: dropped the unconditional `resonance_buzz` force-load. Buzz registers only with `[resonance_buzz]` in the config (no accelerometer needed); `[resonance_tester]` `load_object`s buzz itself, so the accelerometer-backed tester pulls in the buzz commands automatically.
- **`SET_VELOCITY_LIMIT`**: accept legacy `MINIMUM_CRUISE_RATIO` / `ACCEL_TO_DECEL` params as no-ops (limits live in `[limit]` sections now) instead of hard-rejecting them, so external macros/tools that pass them don't abort.

## Tests

`test/test_resonance_tester_capture.py` covers axis parsing (cardinal, vector-maps, diagonal-not-implemented, required), the buzz-driven capture loop (right axis excited, clients started/finished, chip-axis matching, raw-data write, probe-point move). Full host suite green; `./scripts/ci.sh quick` green (ruff, rust-test, rust-clippy, rust-fmt, watchdog-canary).