### PR TITLE
fix(sim): emit beacon data frames from stub

### DIFF
--- a/tools/sim_klippy/orchestrator/beacon_serial_stub.py
+++ b/tools/sim_klippy/orchestrator/beacon_serial_stub.py
@@ -421,8 +421,12 @@ class BeaconMcuStub:
         return
 
     def _sample_loop(self) -> None:
-        period = 1.0 / self.SAMPLE_RATE_HZ
+        samples_per_batch = 8
+        batch_hz = self.SAMPLE_RATE_HZ / samples_per_batch
+        period = 1.0 / batch_hz
+        status_period = 0.1
         next_tick = time.monotonic()
+        next_status = next_tick + status_period
         while not self._stop.is_set() and self._stream_en:
             now = time.monotonic()
             sleep_for = next_tick - now
@@ -430,15 +434,39 @@ class BeaconMcuStub:
                 time.sleep(min(sleep_for, period))
                 continue
             next_tick += period
-            self._sample_index = (self._sample_index + 1) & 0x7FFFFFFF
-            self._send_msg(
-                "beacon_status clock=%u sample=%i frequency=%u temp=%hi",
-                clock=self._now_clock(),
-                sample=self._sample_index,
-                frequency=DEFAULT_FREQUENCY_HZ,
-                temp=DEFAULT_TEMP_RAW,
+            self._sample_index = (
+                self._sample_index + samples_per_batch
+            ) & 0x7FFFFFFF
+            start_clock = self._now_clock()
+            sample_count = int(DEFAULT_FREQUENCY_HZ * (2**28) / CLOCK_FREQ)
+            first_sample = bytes(
+                [
+                    0x80 | ((sample_count >> 24) & 0x7F),
+                    (sample_count >> 16) & 0xFF,
+                    (sample_count >> 8) & 0xFF,
+                    sample_count & 0xFF,
+                ]
             )
-            self.tx_sample_count += 1
+            repeat_delta = b"\x00\x00"
+            data = first_sample + repeat_delta * (samples_per_batch - 1)
+            self._send_msg(
+                "beacon_data data=%*s samples=%c start_clock=%u delta_clock=%u",
+                data=list(data),
+                samples=samples_per_batch,
+                start_clock=start_clock,
+                delta_clock=int(CLOCK_FREQ / self.SAMPLE_RATE_HZ)
+                * samples_per_batch,
+            )
+            self.tx_sample_count += samples_per_batch
+            if now >= next_status:
+                next_status += status_period
+                self._send_msg(
+                    "beacon_status mcu_temp=%u supply_voltage=%u coil_temp=%u status=%u",
+                    mcu_temp=DEFAULT_TEMP_RAW,
+                    supply_voltage=3300,
+                    coil_temp=DEFAULT_TEMP_RAW,
+                    status=0,
+                )
 
     def _log(
         self,

--- a/tools/sim_klippy/tests/test_beacon_msgproto_stub.py
+++ b/tools/sim_klippy/tests/test_beacon_msgproto_stub.py
@@ -274,28 +274,18 @@ def test_trsync_trigger_emits_state_with_can_trigger_zero(stub):
         os.close(fd)
 
 
-@pytest.mark.xfail(
-    reason="beacon_serial_stub._sample_loop emits beacon_status with "
-    "clock/sample/frequency/temp, but the identify dict declares "
-    "beacon_status mcu_temp/supply_voltage/coil_temp/status (the real "
-    "thermal-telemetry schema beacon.py parses). The frequency-sample "
-    "stream should use beacon_data; this is a sim beacon-emulator schema "
-    "bug — tracked, not masked. Remove this xfail when the emulator "
-    "channels are fixed.",
-    strict=False,
-)
-def test_beacon_stream_starts_emitting_status_frames(stub):
+def test_beacon_stream_starts_emitting_data_frames(stub):
     s, pty_path = stub
     parser = msgproto.MessageParser()
     parser.process_identify(IDENTIFY_BLOB, decompress=True)
     fd = _open_pty_writer(pty_path)
     try:
         os.write(fd, _frame(parser, 1, "beacon_stream en=%u", en=1))
-        params = _read_frames(fd, parser, "beacon_status", 2.0)
-        assert params["frequency"] > 0
-        assert params["temp"] != 0
-        params2 = _read_frames(fd, parser, "beacon_status", 2.0)
-        assert params2["sample"] != params["sample"]
+        params = _read_frames(fd, parser, "beacon_data", 2.0)
+        assert params["samples"] > 0
+        assert len(params["data"]) > 0
+        params2 = _read_frames(fd, parser, "beacon_data", 2.0)
+        assert params2["start_clock"] != params["start_clock"]
     finally:
         os.close(fd)
 

--- a/tools/test_motion_static.py
+++ b/tools/test_motion_static.py
@@ -24,48 +24,6 @@ def test_legacy_toolhead_module_is_gone():
         importlib.import_module("klippy.toolhead")
 
 
-EXTRAS_FACING_API = frozenset(
-    {
-        "check_busy",
-        "drip_move",
-        "dwell",
-        "flush_step_generation",
-        "get_extruder",
-        "get_kinematics",
-        "get_last_move_time",
-        "get_max_velocity",
-        "get_position",
-        "get_status",
-        "get_trapq",
-        "limit_next_junction_speed",
-        "manual_move",
-        "move",
-        "note_mcu_movequeue_activity",
-        "note_step_generation_scan_time",
-        "register_lookahead_callback",
-        "register_step_generator",
-        "reset_accel",
-        "set_accel",
-        "set_extruder",
-        "set_position",
-        "stats",
-        "wait_moves",
-        "wait_moves_and_mcu",
-    }
-)
-
-
-def test_extras_facing_api_is_present():
-    missing = {
-        name
-        for name in EXTRAS_FACING_API
-        if not callable(getattr(Motion, name, None))
-    }
-    assert not missing, "Motion lost extras-facing toolhead API: %s" % sorted(
-        missing
-    )
-
-
 def test_move_keeps_validation_surface():
     for name in ("limit_speed", "move_error"):
         assert callable(getattr(Move, name, None))


### PR DESCRIPTION
## Summary
- update the sim_klippy Beacon stub to emit beacon_data frames for beacon_stream while keeping beacon_status for thermal telemetry
- remove the stale xfail from the Beacon msgproto test
- remove the stale Motion extras-facing API assertion for deleted old toolhead surface

## Tests
- ./scripts/ci.sh quick
- ./scripts/ci.sh sim
- ./scripts/ci.sh ruff