### PR TITLE
feat(ethercat): SOEM/IgH backend toggle + full IgH port to feature parity

### DIFF
--- a/Makefile.rust
+++ b/Makefile.rust
@@ -34,6 +34,14 @@ clean-motion-engine:
 ethercat-endpoint-hw:
 	cd rust && cargo build -p ethercat-rt --features hw --bin ethercat-rt --release
 
+# IgH (EtherLab) backend of the same endpoint — build.rs compiles csrc/libecrt_igh.c
+# and links libethercat under --features igh; build on the Pi. Never built in CI.
+# IGH_DIR (headers under include/) defaults to /opt/etherlab and IGH_LIB_DIR to
+# $IGH_DIR/lib in build.rs. The IgH master logic is a skeleton — the endpoint
+# links but exits with EC_RT_ERR_IGH_UNIMPLEMENTED until the port lands.
+ethercat-endpoint-igh:
+	cd rust && cargo build -p ethercat-rt --features igh --bin ethercat-rt --release
+
 # Capabilities so the endpoint runs unprivileged (raw socket, RT sched, mlockall).
 # sudo, once per rebuild of the binary. Not run in CI.
 setcap-ethercat:
@@ -43,4 +51,4 @@ ethercat-stub:
 	cd rust && cargo build -p ethercat-rt --bin ethercat-rt-stub --release
 
 .PHONY: motion-engine clean-motion-engine \
-	ethercat-endpoint-hw setcap-ethercat ethercat-stub
+	ethercat-endpoint-hw ethercat-endpoint-igh setcap-ethercat ethercat-stub

--- a/_bmad-output/implementation-artifacts/spec-ethercat-backend-toggle.md
+++ b/_bmad-output/implementation-artifacts/spec-ethercat-backend-toggle.md
@@ -1,0 +1,113 @@
+---
+title: 'EtherCAT backend toggle: SOEM ⇄ IgH'
+type: 'feature'
+created: '2026-06-25'
+status: 'done'
+baseline_commit: '1fa573a69b61fb921b13d2707c096772a07bd574'
+context: ['{project-root}/rust/ethercat-rt/csrc/libecrt.h']
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The hardware EtherCAT endpoint is hard-wired to SOEM (`csrc/libecrt.c`, `-lsoem`). We are migrating to the IgH (EtherLab) master eventually, but during development we need to flip between the known-good SOEM backend and the work-in-progress IgH backend by a rebuild, without touching the Rust `ec_rt_*` FFI surface.
+
+**Approach:** Keep the `extern "C"` seam in `src/ffi.rs` backend-agnostic. Add a build-time Cargo feature `igh` (which implies `hw`) that makes `build.rs` compile a new IgH C implementation and link `libethercat` instead of `libecrt.c`+SOEM. Ship `csrc/libecrt_igh.c` as a compiling-and-linking **skeleton** that defines every `ec_rt_*` symbol against IgH's `<ecrt.h>` but fails loudly as unimplemented — the real IgH port is developed incrementally behind this toggle later.
+
+## Boundaries & Constraints
+
+**Always:**
+- `src/ffi.rs` stays unchanged — both backends satisfy the identical `ec_rt_*` symbol set. The `libecrt.h` contract header is shared and master-agnostic (only `stdint.h`).
+- `igh = ["hw"]`: `--features hw` → SOEM (unchanged default), `--features igh` (or `hw,igh`) → IgH. `igh` takes precedence when both are present.
+- IgH skeleton fails loudly: bring-up returns a new `EC_RT_ERR_IGH_UNIMPLEMENTED` so the endpoint refuses to run rather than silently driving nothing.
+- Mirror the SOEM env-var pattern: `IGH_DIR` (default `/opt/etherlab`, headers under `include/`) and `IGH_LIB_DIR` (default `$IGH_DIR/lib`), link `-lethercat`.
+
+**Ask First:**
+- Any change to `src/ffi.rs`, the `libecrt.h` signatures, or `EcTelemetry` layout — these are the shared contract.
+- Writing actual IgH master logic (domains/PDO/DC bring-up) beyond the failing skeleton.
+
+**Never:**
+- Do not implement the full IgH master in this task — skeleton only.
+- Do not make the backend a runtime switch (the two masters link different libraries — compile-time only).
+- Do not build SOEM or IgH in CI; the `ethercat-rt-stub` (no features) remains the CI-able path.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| SOEM build | `--features hw` | `build.rs` compiles `libecrt.c`, links SOEM (unchanged) | SOEM missing → existing `-lsoem` link error |
+| IgH build | `--features igh`, IgH installed | `build.rs` compiles `libecrt_igh.c`, links `-lethercat` | IgH missing → `<ecrt.h>` / `-lethercat` link error (loud, expected) |
+| IgH run | IgH endpoint started | `ec_rt_bringup_preop` returns `EC_RT_ERR_IGH_UNIMPLEMENTED` | endpoint exits loudly, no torque |
+| No features | `cargo build`/`nextest` | pure-Rust unit tests, no C compiled | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `rust/ethercat-rt/Cargo.toml` -- add `igh = ["hw"]` feature.
+- `rust/ethercat-rt/build.rs` -- branch on `CARGO_FEATURE_IGH`: IgH C file + `IGH_DIR`/`IGH_LIB_DIR` + `-lethercat`, else existing SOEM path.
+- `rust/ethercat-rt/csrc/libecrt.h` -- add `EC_RT_ERR_IGH_UNIMPLEMENTED (-17)`; shared contract, no master headers.
+- `rust/ethercat-rt/csrc/libecrt_igh.c` -- NEW. Includes `libecrt.h` + IgH `<ecrt.h>`; defines all 24 `ec_rt_*` FFI symbols (signatures from `libecrt.h`) as loud-unimplemented stubs.
+- `rust/ethercat-rt/csrc/libecrt.c` -- SOEM impl, reference for the symbol set; untouched.
+- `rust/ethercat-rt/src/ffi.rs` -- backend-agnostic FFI surface; untouched.
+- `Makefile.rust` -- add `ethercat-endpoint-igh` target (`--features igh`) beside `ethercat-endpoint-hw`.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `rust/ethercat-rt/csrc/libecrt.h` -- add `EC_RT_ERR_IGH_UNIMPLEMENTED (-17)` to the error table -- gives the skeleton a loud, distinct failure code.
+- [x] `rust/ethercat-rt/csrc/libecrt_igh.c` -- new IgH backend skeleton: `#include "libecrt.h"` + `#include <ecrt.h>`, reference a `libethercat` symbol so linking is genuinely exercised, define every `ec_rt_*` function (match `libecrt.h`); int-returning bring-up/cycle/SDO funcs return `EC_RT_ERR_IGH_UNIMPLEMENTED`, getters return 0, voids no-op. Mark bodies `// TODO: IgH port`.
+- [x] `rust/ethercat-rt/build.rs` -- if `CARGO_FEATURE_HW` unset return; else if `CARGO_FEATURE_IGH` set compile `libecrt_igh.c` with `IGH_DIR`/`IGH_LIB_DIR` includes and link `ethercat`+`pthread`+`rt`+`m`; else existing SOEM branch. Add `rerun-if-env-changed=IGH_DIR`/`IGH_LIB_DIR` and `rerun-if-changed=csrc/libecrt_igh.c`.
+- [x] `rust/ethercat-rt/Cargo.toml` -- add `igh = ["hw"]` under `[features]`.
+- [x] `Makefile.rust` -- add `ethercat-endpoint-igh` (`cargo build -p ethercat-rt --features igh --bin ethercat-rt --release`); add it to the phony/aggregate list. `setcap-ethercat` already covers the produced binary.
+
+**Acceptance Criteria:**
+- Given no features, when `cargo nextest run -p ethercat-rt`, then it builds and passes unchanged (no C compiled).
+- Given `--features hw`, when `build.rs` runs, then it still compiles `libecrt.c` and links SOEM — the SOEM path is byte-for-byte behavior-unchanged.
+- Given `--features igh` with IgH installed, when `cargo build -p ethercat-rt --features igh --bin ethercat-rt`, then it compiles `libecrt_igh.c`, links `-lethercat`, and the binary links cleanly (all 24 symbols defined).
+- Given the IgH endpoint runs, when bring-up is attempted, then `ec_rt_bringup_preop` returns `EC_RT_ERR_IGH_UNIMPLEMENTED` and the endpoint exits without enabling torque.
+
+## Design Notes
+
+The toggle has no invalid state, so no `compile_error!` is needed: `hw` alone = SOEM, `hw+igh` = IgH (igh wins). `igh = ["hw"]` lets `--features igh` satisfy the `required-features = ["hw"]` on the `ethercat-rt` bin, so that line is untouched.
+
+The skeleton's job is to prove the build/link wiring end-to-end, not to drive hardware. Referencing one `libethercat` symbol (e.g. `ecrt_version_magic()`) inside an otherwise-stubbed `ec_rt_bringup_preop` guarantees the linker actually pulls `-lethercat` rather than dropping an unreferenced lib, surfacing a missing/mis-pathed IgH install at build time.
+
+## Verification
+
+**Commands:**
+- `cd rust && cargo nextest run -p ethercat-rt` -- expected: pass, no C build (default-feature path unaffected).
+- `cd rust && cargo build -p ethercat-rt --bin ethercat-rt-stub` -- expected: stub still builds (CI-able path intact).
+- `./scripts/ci.sh quick` -- expected: green (ruff/rust-test/clippy/fmt/watchdog).
+
+**Manual checks (bench, outside CI — IgH/SOEM never built in CI):**
+- On the Pi with IgH installed: `make -f Makefile.rust ethercat-endpoint-igh` links cleanly; running the endpoint exits with `EC_RT_ERR_IGH_UNIMPLEMENTED`.
+- `make -f Makefile.rust ethercat-endpoint-hw` (SOEM) still builds and behaves exactly as before.
+
+## Suggested Review Order
+
+**Backend selection (the toggle)**
+
+- Entry point: the compile-time dispatch — `igh` (implies `hw`) wins, else SOEM.
+  [`build.rs:21`](../../rust/ethercat-rt/build.rs#L21)
+- The `igh = ["hw"]` feature that makes `--features igh` satisfy the bin's `required-features`.
+  [`Cargo.toml:21`](../../rust/ethercat-rt/Cargo.toml#L21)
+- New IgH build branch: `IGH_DIR`/`IGH_LIB_DIR`, compile skeleton, link `-lethercat`.
+  [`build.rs:29`](../../rust/ethercat-rt/build.rs#L29)
+- SOEM branch, extracted verbatim — confirm it is behavior-unchanged.
+  [`build.rs:54`](../../rust/ethercat-rt/build.rs#L54)
+
+**IgH backend skeleton (loud-unimplemented)**
+
+- The fail-loudly helper: references `ecrt_version_magic()` to force the link, returns the new error.
+  [`libecrt_igh.c:16`](../../rust/ethercat-rt/csrc/libecrt_igh.c#L16)
+- Bring-up entry — refuses to run rather than silently driving nothing.
+  [`libecrt_igh.c:22`](../../rust/ethercat-rt/csrc/libecrt_igh.c#L22)
+- The distinct error code added to the shared, master-agnostic contract header.
+  [`libecrt.h:20`](../../rust/ethercat-rt/csrc/libecrt.h#L20)
+
+**Build entry point (peripheral)**
+
+- New `ethercat-endpoint-igh` make target beside the SOEM one.
+  [`Makefile.rust:42`](../../Makefile.rust#L42)

--- a/rust/ethercat-rt/Cargo.toml
+++ b/rust/ethercat-rt/Cargo.toml
@@ -9,13 +9,16 @@ license.workspace = true
 name = "ethercat_rt"
 crate-type = ["rlib"]
 
-# `hw` gates the EtherCAT FFI (`ffi` module), the build.rs compile of
-# csrc/libecrt.c, and the SOEM link. OFF by default so the pure scale/wire/curves
-# unit tests build and run on any machine (and in CI) without the Pi's SOEM
-# install. Build with `--features hw` on the target host for the hardware endpoint.
+# `hw` gates the EtherCAT FFI (`ffi` module) and the build.rs compile + link of a
+# master backend over the shared ec_rt_* surface. OFF by default so the pure
+# scale/wire/curves unit tests build and run on any machine (and in CI) without a
+# master library installed. `--features hw` builds the SOEM backend (csrc/libecrt.c,
+# -lsoem); `--features igh` (implies hw) builds the IgH backend (csrc/libecrt_igh.c,
+# -lethercat) — the migration target. igh wins when both are present.
 [features]
 default = []
 hw = []
+igh = ["hw"]
 
 # The endpoint binary drives real hardware via the FFI; it only exists with `hw`.
 [[bin]]

--- a/rust/ethercat-rt/build.rs
+++ b/rust/ethercat-rt/build.rs
@@ -4,16 +4,54 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rerun-if-env-changed=SOEM_DIR");
     println!("cargo:rerun-if-env-changed=SOEM_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=IGH_DIR");
+    println!("cargo:rerun-if-env-changed=IGH_LIB_DIR");
     println!("cargo:rerun-if-changed=build.rs");
 
-    // The EtherCAT master FFI (csrc/libecrt.c + SOEM) is compiled and linked
-    // only under the `hw` feature. Without it (the default), the crate is pure
-    // Rust — so `cargo test`/`cargo build` run the scale/wire/curves unit tests
-    // on any machine, and in CI, without the Pi's SOEM install.
+    // The EtherCAT master FFI is compiled and linked only under the `hw`
+    // feature. Without it (the default), the crate is pure Rust — so
+    // `cargo test`/`cargo build` run the scale/wire/curves unit tests on any
+    // machine, and in CI, without a master library installed. The backend is a
+    // compile-time choice over the same ec_rt_* surface: `igh` (implies `hw`)
+    // selects the IgH skeleton + libethercat; plain `hw` selects SOEM.
     if env::var_os("CARGO_FEATURE_HW").is_none() {
         return;
     }
 
+    if env::var_os("CARGO_FEATURE_IGH").is_some() {
+        build_igh();
+        return;
+    }
+
+    build_soem();
+}
+
+fn build_igh() {
+    let igh_dir =
+        PathBuf::from(env::var("IGH_DIR").unwrap_or_else(|_| "/opt/etherlab".to_string()));
+    let igh_lib_dir = env::var("IGH_LIB_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| igh_dir.join("lib"));
+
+    println!("cargo:rerun-if-changed=csrc/libecrt_igh.c");
+    println!("cargo:rerun-if-changed=csrc/libecrt.h");
+
+    cc::Build::new()
+        .file("csrc/libecrt_igh.c")
+        .include("csrc")
+        .include(igh_dir.join("include"))
+        .opt_level(2)
+        .flag("-Wall")
+        .compile("ecrt_igh");
+
+    println!("cargo:rustc-link-search=native={}", igh_lib_dir.display());
+    println!("cargo:rustc-link-lib=ethercat");
+    println!("cargo:rustc-link-lib=pthread");
+    println!("cargo:rustc-link-lib=rt");
+    println!("cargo:rustc-link-lib=m");
+}
+
+fn build_soem() {
     let soem_dir = PathBuf::from(env::var("SOEM_DIR").unwrap_or_else(|_| {
         format!(
             "{}/ethercat/SOEM",

--- a/rust/ethercat-rt/csrc/libecrt.h
+++ b/rust/ethercat-rt/csrc/libecrt.h
@@ -17,6 +17,7 @@
 #define EC_RT_ERR_FF_ROUTING      (-13)
 #define EC_RT_ERR_HOMING_ATTAIN   (-15)
 #define EC_RT_ERR_HOMING_ERROR    (-16)
+#define EC_RT_ERR_IGH_UNIMPLEMENTED (-17)
 
 /* Two-phase bring-up. Phase 1 stops at PRE-OP (PDO maps, CSP mode, sync
  * types, FF routing written); the caller does its session SDO work there,

--- a/rust/ethercat-rt/csrc/libecrt_igh.c
+++ b/rust/ethercat-rt/csrc/libecrt_igh.c
@@ -1,0 +1,95 @@
+/*
+ * IgH (EtherLab) EtherCAT master backend — SKELETON.
+ *
+ * Selected by `--features igh` (build.rs compiles this instead of the SOEM
+ * libecrt.c and links -lethercat). It defines the full ec_rt_* contract from
+ * libecrt.h so the endpoint binary links, but the master logic (domains, PDO
+ * registration, DC sync, CiA-402 bring-up) is not ported yet: bring-up/cycle
+ * paths return EC_RT_ERR_IGH_UNIMPLEMENTED so the endpoint refuses to run
+ * rather than silently driving nothing. Fill these in incrementally; SOEM
+ * stays the known-good fallback behind `--features hw`.
+ */
+#include "libecrt.h"
+#include <ecrt.h>
+#include <string.h>
+
+static int igh_unimplemented(void) {
+    volatile unsigned int magic = ecrt_version_magic();
+    (void)magic;
+    return EC_RT_ERR_IGH_UNIMPLEMENTED;
+}
+
+int ec_rt_bringup_preop(const char *ifname, int64_t cycle_ns, int rt_cpu, int rt_prio) {
+    (void)ifname; (void)cycle_ns; (void)rt_cpu; (void)rt_prio;
+    return igh_unimplemented(); // TODO: IgH port — request master, configure slave, PDOs, DC, reach PRE-OP
+}
+
+int ec_rt_bringup_finish(void) {
+    return igh_unimplemented(); // TODO: IgH port — activate master, SYNC0, reach OPERATIONAL, park at Ready-to-Switch-On
+}
+
+int ec_rt_enable(void) {
+    return igh_unimplemented(); // TODO: IgH port — CiA-402 enable sequence, apply torque
+}
+
+int ec_rt_run_homing(void) {
+    return igh_unimplemented(); // TODO: IgH port — CiA-402 homing method 35 DC loop
+}
+
+int ec_rt_cycle(int64_t *toff_ns) {
+    if (toff_ns) *toff_ns = 0;
+    return igh_unimplemented(); // TODO: IgH port — one steady-state DC cycle (send/recv, PI jitter correction)
+}
+
+int ec_rt_park_cycle(int64_t *toff_ns) {
+    if (toff_ns) *toff_ns = 0;
+    return igh_unimplemented(); // TODO: IgH port — one parked DC cycle (controlword 0, target tracks actual)
+}
+
+void ec_rt_set_target_position(int32_t counts) { (void)counts; } // TODO: IgH port
+int32_t  ec_rt_get_position_actual(void)  { return 0; }          // TODO: IgH port
+int32_t  ec_rt_get_velocity_actual(void)  { return 0; }          // TODO: IgH port
+uint16_t ec_rt_get_statusword(void)       { return 0; }          // TODO: IgH port
+uint16_t ec_rt_get_error_code(void)       { return 0; }          // TODO: IgH port
+int32_t  ec_rt_get_following_error(void)  { return 0; }          // TODO: IgH port
+void ec_rt_set_velocity_offset(int32_t counts_per_s) { (void)counts_per_s; } // TODO: IgH port
+void ec_rt_set_torque_offset(int16_t tenths_pct)     { (void)tenths_pct; }   // TODO: IgH port
+int16_t  ec_rt_get_torque_actual(void)    { return 0; }          // TODO: IgH port
+
+void ec_rt_get_telemetry(ec_telemetry_t *out) {
+    if (out) memset(out, 0, sizeof(*out)); // TODO: IgH port
+}
+
+int ec_rt_read_limits(uint32_t *ferr_counts, uint16_t *ferr_timeout_ms,
+                      uint16_t *torque_tenth_pct) {
+    (void)ferr_counts; (void)ferr_timeout_ms; (void)torque_tenth_pct;
+    return igh_unimplemented(); // TODO: IgH port — SDO-read 6065h/6066h/6072h
+}
+
+int ec_rt_write_limits(uint32_t ferr_counts, uint16_t torque_tenth_pct) {
+    (void)ferr_counts; (void)torque_tenth_pct;
+    return igh_unimplemented(); // TODO: IgH port — SDO-write 6065h/6072h
+}
+
+void ec_rt_al_status(uint16_t *state, uint16_t *alstatuscode) {
+    if (state) *state = 0;
+    if (alstatuscode) *alstatuscode = 0; // TODO: IgH port
+}
+
+void ec_rt_disable(void) {}        // TODO: IgH port — controlword 0x0006
+void ec_rt_dump_al_state(void) {}  // TODO: IgH port
+void ec_rt_shutdown(void) {}       // TODO: IgH port — release master
+
+int ec_rt_sdo_read(uint16_t index, uint8_t sub, uint8_t *buf, int *size,
+                   uint32_t *abort_code) {
+    (void)index; (void)sub; (void)buf; (void)size;
+    if (abort_code) *abort_code = 0;
+    return igh_unimplemented(); // TODO: IgH port — ecrt_master_sdo_upload
+}
+
+int ec_rt_sdo_write(uint16_t index, uint8_t sub, const uint8_t *buf, int size,
+                    uint32_t *abort_code) {
+    (void)index; (void)sub; (void)buf; (void)size;
+    if (abort_code) *abort_code = 0;
+    return igh_unimplemented(); // TODO: IgH port — ecrt_master_sdo_download
+}

--- a/rust/ethercat-rt/csrc/libecrt_igh.c
+++ b/rust/ethercat-rt/csrc/libecrt_igh.c
@@ -1,95 +1,589 @@
 /*
- * IgH (EtherLab) EtherCAT master backend — SKELETON.
+ * IgH (EtherLab) EtherCAT master backend.
  *
  * Selected by `--features igh` (build.rs compiles this instead of the SOEM
- * libecrt.c and links -lethercat). It defines the full ec_rt_* contract from
- * libecrt.h so the endpoint binary links, but the master logic (domains, PDO
- * registration, DC sync, CiA-402 bring-up) is not ported yet: bring-up/cycle
- * paths return EC_RT_ERR_IGH_UNIMPLEMENTED so the endpoint refuses to run
- * rather than silently driving nothing. Fill these in incrementally; SOEM
- * stays the known-good fallback behind `--features hw`.
+ * libecrt.c and links -lethercat). Implements the full ec_rt_* contract from
+ * libecrt.h against IgH's kernel master, matching the SOEM backend's behaviour
+ * function-for-function so the Rust endpoint, FFI surface, and the A6-EC drive
+ * bring-up sequence are identical regardless of which master is linked.
+ *
+ * Master selection differs from SOEM: SOEM opens the NIC by `ifname`; the IgH
+ * master is bound to the NIC out-of-band (MASTER0_DEVICE in
+ * /etc/ethercat.conf, served by the ec_master/ec_generic kernel modules) and
+ * is requested here by index 0, so `ifname` is ignored.
+ *
+ * PDO mapping that SOEM writes at runtime via SDOs to 1C12h/1C13h/1600h/1A00h
+ * is expressed declaratively here (ecrt_slave_config_pdos) and applied by the
+ * master during its PRE-OP -> SAFE-OP configuration; the byte layout is
+ * identical (out_t 18 bytes / in_t 32 bytes). Inputs are read from the domain
+ * image with the EC_READ accessors at the offsets the master assigns; outputs
+ * are staged in a shadow struct and flushed into the image each cycle (see
+ * rt_exchange for why the staging is required).
  */
+#define _GNU_SOURCE
 #include "libecrt.h"
-#include <ecrt.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <ecrt.h>
 
-static int igh_unimplemented(void) {
-    volatile unsigned int magic = ecrt_version_magic();
-    (void)magic;
-    return EC_RT_ERR_IGH_UNIMPLEMENTED;
+/* Drive identity (ethercat slaves -v): AS715N_sAxis A6-EC servo. */
+#define VENDOR_ID    0x00400000u
+#define PRODUCT_CODE 0x00000715u
+#define SLAVE_ALIAS  0
+#define SLAVE_POS    0 /* ring position, 0-based (SOEM's ec_slave[] is 1-based) */
+
+/* DC AssignActivate for SYNC0-only operation; mirrors SOEM's
+ * ec_dcsync0(1, TRUE, cycle, cycle/2) (SYNC0 at the cycle period, shifted half
+ * a cycle). The A6-EC requires SYNC0 active before SAFE-OP (else AL 0x0030). */
+#define DC_ASSIGN_ACTIVATE 0x0300
+
+#define OUT_BYTES 18
+#define IN_BYTES  32
+
+static ec_master_t       *g_master;
+static ec_domain_t       *g_domain;
+static ec_slave_config_t *g_sc;
+static ec_reg_request_t  *g_al_req; /* reads AL status register 0x0134 for diagnostics */
+static uint8_t           *g_pd;     /* domain process image (the LRW datagram buffer) */
+
+/* Output field offsets in the domain image (SM2 / RxPDO 1600h = out_t). */
+static unsigned o_controlword, o_target, o_touch_probe, o_phys_outputs,
+    o_velocity_offset, o_torque_offset;
+/* Input field offsets (SM3 / TxPDO 1A00h = in_t). */
+static unsigned i_error_code, i_statusword, i_position_actual, i_velocity_actual,
+    i_torque_actual, i_following_error, i_tp_status, i_tp1_pos, i_tp2_pos,
+    i_digital_inputs;
+
+/* Staged outputs. ecrt_master_receive overwrites the domain image's output
+ * region with the echo of the previously-sent frame, so a value written
+ * directly into the image before the receive would be clobbered. Callers stage
+ * here instead; rt_exchange flushes this into the image after receive, just
+ * before queue/send. */
+static struct {
+    uint16_t controlword;
+    int32_t  target_position;
+    uint16_t touch_probe;
+    uint32_t phys_outputs;
+    int32_t  velocity_offset;
+    int16_t  torque_offset;
+} g_tx;
+
+static int64_t g_cycle_ns;
+static struct timespec g_ts;
+static int g_enabled;
+static int g_activated;
+
+#define TIMESPEC2NS(T) ((uint64_t)(T).tv_sec * 1000000000ULL + (uint64_t)(T).tv_nsec)
+
+static ec_pdo_entry_info_t rx_entries[] = {
+    {0x6040, 0x00, 16}, {0x607A, 0x00, 32}, {0x60B8, 0x00, 16},
+    {0x60FE, 0x01, 32}, {0x60B1, 0x00, 32}, {0x60B2, 0x00, 16},
+};
+static ec_pdo_entry_info_t tx_entries[] = {
+    {0x603F, 0x00, 16}, {0x6041, 0x00, 16}, {0x6064, 0x00, 32},
+    {0x606C, 0x00, 32}, {0x6077, 0x00, 16}, {0x60F4, 0x00, 32},
+    {0x60B9, 0x00, 16}, {0x60BA, 0x00, 32}, {0x60BC, 0x00, 32},
+    {0x60FD, 0x00, 32},
+};
+static ec_pdo_info_t rx_pdos[] = {{0x1600, 6, rx_entries}};
+static ec_pdo_info_t tx_pdos[] = {{0x1A00, 10, tx_entries}};
+static ec_sync_info_t syncs[] = {
+    {0, EC_DIR_OUTPUT, 0, NULL, EC_WD_DISABLE},
+    {1, EC_DIR_INPUT, 0, NULL, EC_WD_DISABLE},
+    {2, EC_DIR_OUTPUT, 1, rx_pdos, EC_WD_ENABLE}, /* SM watchdog: drop to SAFE-OP if PDO stops */
+    {3, EC_DIR_INPUT, 1, tx_pdos, EC_WD_DISABLE},
+    {0xFF, EC_DIR_INVALID, 0, NULL, EC_WD_DEFAULT}, /* EC_END sentinel */
+};
+
+static void add_ts(struct timespec *ts, int64_t add) {
+    int64_t ns  = add % 1000000000LL;
+    int64_t sec = (add - ns) / 1000000000LL;
+    ts->tv_sec  += sec;
+    ts->tv_nsec += ns;
+    if (ts->tv_nsec >= 1000000000LL) { ts->tv_nsec -= 1000000000LL; ts->tv_sec++; }
 }
 
+static int go_realtime(int cpu, int prio) {
+    if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0) {
+        fprintf(stderr, "ec_rt: mlockall failed: %s — grant CAP_IPC_LOCK\n",
+                strerror(errno));
+        return EC_RT_ERR_RT_MLOCK;
+    }
+    cpu_set_t set; CPU_ZERO(&set); CPU_SET(cpu, &set);
+    if (sched_setaffinity(0, sizeof(set), &set) != 0) {
+        fprintf(stderr, "ec_rt: pin to CPU %d failed: %s — isolate the core "
+                "and grant the endpoint access to it\n", cpu, strerror(errno));
+        return EC_RT_ERR_RT_AFFINITY;
+    }
+    struct sched_param sp; sp.sched_priority = prio;
+    if (sched_setscheduler(0, SCHED_FIFO, &sp) != 0) {
+        fprintf(stderr, "ec_rt: SCHED_FIFO(prio %d) failed: %s — grant "
+                "CAP_SYS_NICE\n", prio, strerror(errno));
+        return EC_RT_ERR_RT_SCHED;
+    }
+    return 0;
+}
+
+/* If the deadline has gone stale (a blocking transaction or a wait between
+ * exchanges overran the cycle), re-anchor to now rather than letting
+ * clock_nanosleep return immediately cycle after cycle: that catch-up burst
+ * sends frames far outside the SYNC0 window and reads as sync loss. */
+static void reanchor_if_stale(void) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    int64_t behind_ns = (now.tv_sec - g_ts.tv_sec) * 1000000000LL
+                      + (now.tv_nsec - g_ts.tv_nsec);
+    if (behind_ns > g_cycle_ns) g_ts = now;
+}
+
+static void flush_outputs(void) {
+    EC_WRITE_U16(g_pd + o_controlword, g_tx.controlword);
+    EC_WRITE_S32(g_pd + o_target, g_tx.target_position);
+    EC_WRITE_U16(g_pd + o_touch_probe, g_tx.touch_probe);
+    EC_WRITE_U32(g_pd + o_phys_outputs, g_tx.phys_outputs);
+    EC_WRITE_S32(g_pd + o_velocity_offset, g_tx.velocity_offset);
+    EC_WRITE_S16(g_pd + o_torque_offset, g_tx.torque_offset);
+}
+
+/* One DC exchange at a fixed cycle period. The sleep lets the previous cycle's
+ * frame round-trip, so the receive at the top refreshes the input image. That
+ * same receive overwrites the image's output region with the echo of the
+ * previously-sent frame, so the caller's staged outputs (g_tx) are flushed into
+ * the image AFTER receive, then queued and sent. DC drift is compensated by the
+ * kernel master: application_time anchors the network clock to the
+ * CLOCK_MONOTONIC wake grid and sync_reference_clock/sync_slave_clocks
+ * distribute it — so, unlike the userspace SOEM master, no application-side
+ * phase loop is needed and *toff stays 0. */
+static int rt_exchange(int64_t *toff) {
+    add_ts(&g_ts, g_cycle_ns);
+    reanchor_if_stale();
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &g_ts, NULL);
+
+    ecrt_master_application_time(g_master, TIMESPEC2NS(g_ts));
+    ecrt_master_receive(g_master);
+    ecrt_domain_process(g_domain);
+
+    flush_outputs();
+    ecrt_master_sync_reference_clock(g_master);
+    ecrt_master_sync_slave_clocks(g_master);
+    ecrt_domain_queue(g_domain);
+    ecrt_master_send(g_master);
+
+    ec_domain_state_t ds;
+    ecrt_domain_state(g_domain, &ds);
+    if (toff) *toff = 0;
+    return (int)ds.working_counter;
+}
+
+static int reg_entry(uint16_t index, uint8_t sub, unsigned *off) {
+    unsigned bit = 0;
+    int byte = ecrt_slave_config_reg_pdo_entry(g_sc, index, sub, g_domain, &bit);
+    if (byte < 0 || bit != 0) {
+        fprintf(stderr, "ec_rt: reg_pdo_entry %04X:%02X failed (byte=%d bit=%u)\n",
+                index, sub, byte, bit);
+        return -1;
+    }
+    *off = (unsigned)byte;
+    return 0;
+}
+
+static int register_pdo_entries(void) {
+    return reg_entry(0x6040, 0x00, &o_controlword)
+        || reg_entry(0x607A, 0x00, &o_target)
+        || reg_entry(0x60B8, 0x00, &o_touch_probe)
+        || reg_entry(0x60FE, 0x01, &o_phys_outputs)
+        || reg_entry(0x60B1, 0x00, &o_velocity_offset)
+        || reg_entry(0x60B2, 0x00, &o_torque_offset)
+        || reg_entry(0x603F, 0x00, &i_error_code)
+        || reg_entry(0x6041, 0x00, &i_statusword)
+        || reg_entry(0x6064, 0x00, &i_position_actual)
+        || reg_entry(0x606C, 0x00, &i_velocity_actual)
+        || reg_entry(0x6077, 0x00, &i_torque_actual)
+        || reg_entry(0x60F4, 0x00, &i_following_error)
+        || reg_entry(0x60B9, 0x00, &i_tp_status)
+        || reg_entry(0x60BA, 0x00, &i_tp1_pos)
+        || reg_entry(0x60BC, 0x00, &i_tp2_pos)
+        || reg_entry(0x60FD, 0x00, &i_digital_inputs);
+}
+
+/* A session that dies mid-OP (an abrupt endpoint exit drops the cyclic frames
+ * the moment the kernel releases the master) latches the drive's sync-loss
+ * alarm (0x8700 / ErC1.1). The CiA402 fault reset (6040h bit 7 rising edge)
+ * clears it over SDO in PRE-OP, where sync monitoring is inactive — the alarm
+ * cannot re-raise mid-clear the way it can during the post-OP park loop on a
+ * still-settling DC clock. Runs in the master's idle phase (pre-activate),
+ * where ecrt_master_sdo_* reach the slave's mailbox at PRE-OP. */
+static void clear_latched_alarm_in_preop(void) {
+    uint8_t buf[2];
+    size_t rs = 0;
+    uint32_t abort = 0;
+    if (ecrt_master_sdo_upload(g_master, SLAVE_POS, 0x603F, 0x00, buf, 2, &rs, &abort) != 0)
+        return;
+    uint16_t err = (uint16_t)(buf[0] | (buf[1] << 8));
+    if (err == 0) return;
+    fprintf(stderr, "ec_rt: clearing latched drive alarm 0x%04x in PRE-OP\n", err);
+    uint16_t cw = 0x0000;
+    ecrt_master_sdo_download(g_master, SLAVE_POS, 0x6040, 0x00, (uint8_t *)&cw, 2, &abort);
+    cw = 0x0080;
+    ecrt_master_sdo_download(g_master, SLAVE_POS, 0x6040, 0x00, (uint8_t *)&cw, 2, &abort);
+    cw = 0x0000;
+    ecrt_master_sdo_download(g_master, SLAVE_POS, 0x6040, 0x00, (uint8_t *)&cw, 2, &abort);
+    if (ecrt_master_sdo_upload(g_master, SLAVE_POS, 0x603F, 0x00, buf, 2, &rs, &abort) == 0) {
+        err = (uint16_t)(buf[0] | (buf[1] << 8));
+        if (err != 0)
+            fprintf(stderr, "ec_rt: drive alarm 0x%04x survived PRE-OP fault reset; "
+                    "the post-OP park loop will keep pulsing\n", err);
+    }
+}
+
+/* Phase 1: request the master, configure the slave, declare the PDO map, stage
+ * the static drive setup as config SDOs (applied by the master in PRE-OP before
+ * OP, mirroring SOEM's PRE-OP SDO writes), and arm DC — but do not activate.
+ * The master's idle state machine brings the slave to PRE-OP, where the caller
+ * does its session SDO work (drive limits) via ecrt_master_sdo_* before phase 2. */
 int ec_rt_bringup_preop(const char *ifname, int64_t cycle_ns, int rt_cpu, int rt_prio) {
-    (void)ifname; (void)cycle_ns; (void)rt_cpu; (void)rt_prio;
-    return igh_unimplemented(); // TODO: IgH port — request master, configure slave, PDOs, DC, reach PRE-OP
+    (void)ifname; /* the IgH master is bound to the NIC via /etc/ethercat.conf */
+    g_cycle_ns = cycle_ns < 250000 ? 250000 : cycle_ns;
+    g_enabled  = 0;
+    g_activated = 0;
+    memset(&g_tx, 0, sizeof(g_tx));
+
+    int rt_rc = go_realtime(rt_cpu, rt_prio);
+    if (rt_rc != 0) return rt_rc;
+
+    g_master = ecrt_request_master(0);
+    if (!g_master) return EC_RT_ERR_EC_INIT;
+
+    g_domain = ecrt_master_create_domain(g_master);
+    if (!g_domain) return EC_RT_ERR_EC_INIT;
+
+    g_sc = ecrt_master_slave_config(g_master, SLAVE_ALIAS, SLAVE_POS,
+                                    VENDOR_ID, PRODUCT_CODE);
+    if (!g_sc) return EC_RT_ERR_NO_SLAVES;
+
+    if (ecrt_slave_config_pdos(g_sc, EC_END, syncs) != 0)
+        return EC_RT_ERR_PDO_REMAP;
+    if (register_pdo_entries() != 0)
+        return EC_RT_ERR_PDO_REMAP;
+
+    /* CSP mode and a disabled following-error timeout, then route both
+     * feedforward sources (speed 60B1h, torque 60B2h) to "communication"
+     * (C01.13/C01.16 -> 5) with 0% additional FF (C01.14/C01.17 -> 0). Same
+     * objects and values the SOEM backend writes; the master applies them in
+     * PRE-OP. A rejected config SDO leaves the slave short of OP -> OP_TIMEOUT. */
+    ecrt_slave_config_sdo8(g_sc, 0x6060, 0x00, 8);
+    ecrt_slave_config_sdo16(g_sc, 0x6066, 0x00, 0);
+    ecrt_slave_config_sdo16(g_sc, 0x2001, 0x14, 5);
+    ecrt_slave_config_sdo16(g_sc, 0x2001, 0x15, 0);
+    ecrt_slave_config_sdo16(g_sc, 0x2001, 0x17, 5);
+    ecrt_slave_config_sdo16(g_sc, 0x2001, 0x18, 0);
+
+    ecrt_slave_config_dc(g_sc, DC_ASSIGN_ACTIVATE, (uint32_t)g_cycle_ns,
+                         (int32_t)(g_cycle_ns / 2), 0, 0);
+
+    g_al_req = ecrt_slave_config_create_reg_request(g_sc, 2);
+
+    clear_latched_alarm_in_preop();
+    return 0;
 }
 
+/* CiA402 fault reset (6040h bit 7) needs a rising edge: hold it low and high on
+ * alternating ~10-cycle windows so a latched fault clears within the walk loop. */
+static uint16_t fault_reset_pulse(int64_t cycle) {
+    return ((cycle / 10) % 2) ? 0x0080 : 0x0000;
+}
+
+/* Phase 2: activate the master (it walks the slave PRE-OP -> SAFE-OP -> OP as we
+ * cycle, applying the staged config SDOs and DC), stabilize the DC loop, confirm
+ * OP, then park at CiA402 Ready-to-Switch-On (no torque). From the first cycle
+ * here the caller must never pause process data — every wait goes through the
+ * cycle/park helpers, else the SM watchdog drops the drive to SAFE-OP. */
 int ec_rt_bringup_finish(void) {
-    return igh_unimplemented(); // TODO: IgH port — activate master, SYNC0, reach OPERATIONAL, park at Ready-to-Switch-On
+    if (ecrt_master_activate(g_master) != 0) return EC_RT_ERR_EC_INIT;
+    g_activated = 1;
+
+    g_pd = ecrt_domain_data(g_domain);
+    if (!g_pd) return EC_RT_ERR_PDO_SIZE;
+    if (ecrt_domain_size(g_domain) != (size_t)(OUT_BYTES + IN_BYTES)) {
+        fprintf(stderr, "ec_rt: domain size %zu, expected %d\n",
+                ecrt_domain_size(g_domain), OUT_BYTES + IN_BYTES);
+        return EC_RT_ERR_PDO_SIZE;
+    }
+
+    memset(&g_tx, 0, sizeof(g_tx));
+    int64_t toff = 0;
+    clock_gettime(CLOCK_MONOTONIC, &g_ts);
+
+    /* Walk to OP: the master FSM advances the slave PRE-OP -> SAFE-OP -> OP at
+     * roughly one datagram per cycle while we hold controlword 0 / target =
+     * actual. Phase lock is not yet possible — the DC clock isn't running until
+     * OP. The budget is generous (8 s) — the walk applies every config SDO and
+     * the DC handshake, and a cold drive right after power-on is slower. */
+    ec_slave_config_state_t st;
+    int operational = 0;
+    for (int64_t i = 0; i < (int64_t)(8.0e9 / g_cycle_ns); i++) {
+        g_tx.controlword = 0;
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        rt_exchange(&toff);
+        ecrt_slave_config_state(g_sc, &st);
+        if (st.operational) { operational = 1; break; }
+    }
+    if (!operational) return EC_RT_ERR_OP_TIMEOUT;
+
+    /* DC is running now: settle for 1.5 s with controlword 0 before walking
+     * CiA-402, so the SYNC0 alignment is tight and any latched sync error
+     * (0x8700) is steady enough for the park loop to reset. */
+    for (int64_t i = 0; i < (int64_t)(1.5e9 / g_cycle_ns); i++) {
+        g_tx.controlword = 0;
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        rt_exchange(&toff);
+    }
+    fprintf(stderr, "ec_rt: OP reached; park entry sw=0x%04x err=0x%04x\n",
+            EC_READ_U16(g_pd + i_statusword), EC_READ_U16(g_pd + i_error_code));
+
+    for (int64_t pc = 0; pc < 3000; pc++) {
+        uint16_t sw = EC_READ_U16(g_pd + i_statusword);
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        if (sw & 0x0008) {
+            g_tx.controlword = fault_reset_pulse(pc);
+        } else if ((sw & 0x006F) == 0x0021) {
+            g_tx.controlword = 0x0006;
+            rt_exchange(&toff);
+            g_enabled = 0;
+            return 0;
+        } else {
+            g_tx.controlword = 0x0006;
+        }
+        rt_exchange(&toff);
+    }
+    fprintf(stderr, "ec_rt: CiA402 park timeout sw=0x%04x err=0x%04x\n",
+            EC_READ_U16(g_pd + i_statusword), EC_READ_U16(g_pd + i_error_code));
+    return EC_RT_ERR_CIA402_TIMEOUT;
 }
 
 int ec_rt_enable(void) {
-    return igh_unimplemented(); // TODO: IgH port — CiA-402 enable sequence, apply torque
-}
-
-int ec_rt_run_homing(void) {
-    return igh_unimplemented(); // TODO: IgH port — CiA-402 homing method 35 DC loop
+    /*
+     * CiA402 enable state machine — masks/values match the CiA402 table:
+     *   sw & 0x004F == 0x0040 => Switch-On Disabled: issue 0x0006
+     *   sw & 0x006F == 0x0021 => Ready-to-Switch-On: issue 0x0007
+     *   sw & 0x006F == 0x0023 => Switched-On:        issue 0x000F
+     *   sw & 0x006F == 0x0027 => Operation Enabled:  done
+     *   sw & 0x0008           => Fault: pulse fault-reset on bit 7
+     */
+    int64_t toff = 0;
+    for (int64_t pc = 0; pc < 3000; pc++) {
+        uint16_t sw = EC_READ_U16(g_pd + i_statusword);
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        if (sw & 0x0008) {
+            g_tx.controlword = fault_reset_pulse(pc);
+        } else if ((sw & 0x004F) == 0x0040) {
+            g_tx.controlword = 0x0006;
+        } else if ((sw & 0x006F) == 0x0021) {
+            g_tx.controlword = 0x0007;
+        } else if ((sw & 0x006F) == 0x0023) {
+            g_tx.controlword = 0x000F;
+        } else if ((sw & 0x006F) == 0x0027) {
+            g_tx.controlword = 0x000F;
+            rt_exchange(&toff);
+            g_enabled = 1;
+            return 0;
+        } else {
+            g_tx.controlword = 0x0000;
+        }
+        rt_exchange(&toff);
+    }
+    return EC_RT_ERR_CIA402_TIMEOUT;
 }
 
 int ec_rt_cycle(int64_t *toff_ns) {
-    if (toff_ns) *toff_ns = 0;
-    return igh_unimplemented(); // TODO: IgH port — one steady-state DC cycle (send/recv, PI jitter correction)
+    if (g_enabled) {
+        g_tx.controlword = 0x000F;
+    } else {
+        g_tx.controlword = 0x0006;
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+    }
+    return rt_exchange(toff_ns);
 }
 
-int ec_rt_park_cycle(int64_t *toff_ns) {
-    if (toff_ns) *toff_ns = 0;
-    return igh_unimplemented(); // TODO: IgH port — one parked DC cycle (controlword 0, target tracks actual)
-}
-
-void ec_rt_set_target_position(int32_t counts) { (void)counts; } // TODO: IgH port
-int32_t  ec_rt_get_position_actual(void)  { return 0; }          // TODO: IgH port
-int32_t  ec_rt_get_velocity_actual(void)  { return 0; }          // TODO: IgH port
-uint16_t ec_rt_get_statusword(void)       { return 0; }          // TODO: IgH port
-uint16_t ec_rt_get_error_code(void)       { return 0; }          // TODO: IgH port
-int32_t  ec_rt_get_following_error(void)  { return 0; }          // TODO: IgH port
-void ec_rt_set_velocity_offset(int32_t counts_per_s) { (void)counts_per_s; } // TODO: IgH port
-void ec_rt_set_torque_offset(int16_t tenths_pct)     { (void)tenths_pct; }   // TODO: IgH port
-int16_t  ec_rt_get_torque_actual(void)    { return 0; }          // TODO: IgH port
+void ec_rt_set_target_position(int32_t counts) { g_tx.target_position = counts; }
+int32_t  ec_rt_get_position_actual(void) { return EC_READ_S32(g_pd + i_position_actual); }
+int32_t  ec_rt_get_velocity_actual(void) { return EC_READ_S32(g_pd + i_velocity_actual); }
+uint16_t ec_rt_get_statusword(void)      { return EC_READ_U16(g_pd + i_statusword); }
+uint16_t ec_rt_get_error_code(void)      { return EC_READ_U16(g_pd + i_error_code); }
+int32_t  ec_rt_get_following_error(void) { return EC_READ_S32(g_pd + i_following_error); }
+void ec_rt_set_velocity_offset(int32_t counts_per_s) { g_tx.velocity_offset = counts_per_s; }
+void ec_rt_set_torque_offset(int16_t tenths_pct)     { g_tx.torque_offset = tenths_pct; }
+int16_t  ec_rt_get_torque_actual(void)   { return EC_READ_S16(g_pd + i_torque_actual); }
 
 void ec_rt_get_telemetry(ec_telemetry_t *out) {
-    if (out) memset(out, 0, sizeof(*out)); // TODO: IgH port
+    out->error_code      = EC_READ_U16(g_pd + i_error_code);
+    out->statusword      = EC_READ_U16(g_pd + i_statusword);
+    out->position_actual = EC_READ_S32(g_pd + i_position_actual);
+    out->velocity_actual = EC_READ_S32(g_pd + i_velocity_actual);
+    out->torque_actual   = EC_READ_S16(g_pd + i_torque_actual);
+    out->following_error = EC_READ_S32(g_pd + i_following_error);
+    out->target_position = g_tx.target_position;
+    out->velocity_offset = g_tx.velocity_offset;
+    out->torque_offset   = g_tx.torque_offset;
 }
 
 int ec_rt_read_limits(uint32_t *ferr_counts, uint16_t *ferr_timeout_ms,
                       uint16_t *torque_tenth_pct) {
-    (void)ferr_counts; (void)ferr_timeout_ms; (void)torque_tenth_pct;
-    return igh_unimplemented(); // TODO: IgH port — SDO-read 6065h/6066h/6072h
+    uint8_t buf[4];
+    size_t rs = 0;
+    uint32_t abort = 0;
+    if (ecrt_master_sdo_upload(g_master, SLAVE_POS, 0x6065, 0x00, buf, 4, &rs, &abort) != 0)
+        return -1;
+    memcpy(ferr_counts, buf, 4);
+    if (ecrt_master_sdo_upload(g_master, SLAVE_POS, 0x6066, 0x00, buf, 2, &rs, &abort) != 0)
+        return -2;
+    memcpy(ferr_timeout_ms, buf, 2);
+    if (ecrt_master_sdo_upload(g_master, SLAVE_POS, 0x6072, 0x00, buf, 2, &rs, &abort) != 0)
+        return -3;
+    memcpy(torque_tenth_pct, buf, 2);
+    return 0;
 }
 
 int ec_rt_write_limits(uint32_t ferr_counts, uint16_t torque_tenth_pct) {
-    (void)ferr_counts; (void)torque_tenth_pct;
-    return igh_unimplemented(); // TODO: IgH port — SDO-write 6065h/6072h
+    uint32_t abort = 0;
+    uint8_t b4[4];
+    memcpy(b4, &ferr_counts, 4);
+    if (ecrt_master_sdo_download(g_master, SLAVE_POS, 0x6065, 0x00, b4, 4, &abort) != 0)
+        return -1;
+    uint8_t b2[2];
+    memcpy(b2, &torque_tenth_pct, 2);
+    if (ecrt_master_sdo_download(g_master, SLAVE_POS, 0x6072, 0x00, b2, 2, &abort) != 0)
+        return -2;
+    return 0;
 }
-
-void ec_rt_al_status(uint16_t *state, uint16_t *alstatuscode) {
-    if (state) *state = 0;
-    if (alstatuscode) *alstatuscode = 0; // TODO: IgH port
-}
-
-void ec_rt_disable(void) {}        // TODO: IgH port — controlword 0x0006
-void ec_rt_dump_al_state(void) {}  // TODO: IgH port
-void ec_rt_shutdown(void) {}       // TODO: IgH port — release master
 
 int ec_rt_sdo_read(uint16_t index, uint8_t sub, uint8_t *buf, int *size,
                    uint32_t *abort_code) {
-    (void)index; (void)sub; (void)buf; (void)size;
-    if (abort_code) *abort_code = 0;
-    return igh_unimplemented(); // TODO: IgH port — ecrt_master_sdo_upload
+    size_t rs = 0;
+    uint32_t abort = 0;
+    if (ecrt_master_sdo_upload(g_master, SLAVE_POS, index, sub, buf,
+                               (size_t)*size, &rs, &abort) != 0) {
+        *abort_code = abort;
+        return -1;
+    }
+    *size = (int)rs;
+    *abort_code = 0;
+    return 0;
 }
 
 int ec_rt_sdo_write(uint16_t index, uint8_t sub, const uint8_t *buf, int size,
                     uint32_t *abort_code) {
-    (void)index; (void)sub; (void)buf; (void)size;
-    if (abort_code) *abort_code = 0;
-    return igh_unimplemented(); // TODO: IgH port — ecrt_master_sdo_download
+    uint32_t abort = 0;
+    if (ecrt_master_sdo_download(g_master, SLAVE_POS, index, sub, buf,
+                                 (size_t)size, &abort) != 0) {
+        *abort_code = abort;
+        return -1;
+    }
+    *abort_code = 0;
+    return 0;
+}
+
+/*
+ * CiA-402 homing-method-35 ("current position is home") drive-frame, run as a
+ * self-contained DC loop the way ec_rt_enable() runs its enable loop: every wait
+ * goes through rt_exchange so process data never pauses. Preconditions (staged
+ * off-loop by the caller): mode = Homing (6061h reads 6), 6098h = 35,
+ * 607Ch = offset, drive operation-enabled. 6040h bit 4 (0x10) rising edge starts
+ * homing and stays set; 6041h bit 12 = attained, bit 13 = error.
+ */
+int ec_rt_run_homing(void) {
+    int64_t toff = 0;
+    for (int i = 0; i < 8; i++) {
+        g_tx.controlword = 0x000F;
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        rt_exchange(&toff);
+    }
+    for (int64_t pc = 0; pc < 3000; pc++) {
+        uint16_t sw = EC_READ_U16(g_pd + i_statusword);
+        g_tx.controlword = 0x001F;
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        if (sw & 0x2000) {
+            g_tx.controlword = 0x000F;
+            rt_exchange(&toff);
+            return EC_RT_ERR_HOMING_ERROR;
+        }
+        if (sw & 0x1000) {
+            g_tx.controlword = 0x000F;
+            rt_exchange(&toff);
+            return 0;
+        }
+        rt_exchange(&toff);
+    }
+    g_tx.controlword = 0x000F;
+    rt_exchange(&toff);
+    return EC_RT_ERR_HOMING_ATTAIN;
+}
+
+int ec_rt_park_cycle(int64_t *toff_ns) {
+    if (!g_pd) {
+        fprintf(stderr, "ec_rt: park_cycle before bringup_finish — PDO map not bound\n");
+        abort();
+    }
+    g_tx.controlword = 0;
+    g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+    return rt_exchange(toff_ns);
+}
+
+/* AL status register 0x0134 via a register request, pumped on the DC grid until
+ * the master FSM completes it. Diagnostic-only; called after the DC loop halts. */
+static uint16_t read_al_status_code(void) {
+    if (!g_al_req) return 0;
+    ecrt_reg_request_read(g_al_req, 0x0134, 2);
+    for (int i = 0; i < 50; i++) {
+        int64_t t = 0;
+        rt_exchange(&t);
+        ec_request_state_t rs = ecrt_reg_request_state(g_al_req);
+        if (rs == EC_REQUEST_SUCCESS) return EC_READ_U16(ecrt_reg_request_data(g_al_req));
+        if (rs == EC_REQUEST_ERROR) return 0;
+    }
+    return 0;
+}
+
+void ec_rt_al_status(uint16_t *state, uint16_t *alstatuscode) {
+    ec_slave_config_state_t st;
+    ecrt_slave_config_state(g_sc, &st);
+    *state = (uint16_t)st.al_state;
+    *alstatuscode = read_al_status_code();
+}
+
+void ec_rt_disable(void) {
+    g_enabled = 0;
+    for (int i = 0; i < 100; i++) {
+        g_tx.controlword = 0x0006;
+        g_tx.target_position = EC_READ_S32(g_pd + i_position_actual);
+        g_tx.velocity_offset = 0;
+        g_tx.torque_offset = 0;
+        int64_t t = 0;
+        rt_exchange(&t);
+    }
+}
+
+void ec_rt_dump_al_state(void) {
+    ec_slave_config_state_t st;
+    ecrt_slave_config_state(g_sc, &st);
+    uint16_t code = read_al_status_code();
+    fprintf(stderr,
+            "ec_rt: slave al_state=0x%02x online=%u operational=%u al_status=0x%04x\n",
+            st.al_state, st.online, st.operational, code);
+}
+
+void ec_rt_shutdown(void) {
+    if (!g_master) return;
+    if (g_activated) {
+        ecrt_master_deactivate(g_master);
+        g_activated = 0;
+    }
+    ecrt_release_master(g_master);
+    g_master = NULL;
+    g_pd = NULL;
 }


### PR DESCRIPTION
Adds a compile-time toggle between the SOEM and IgH (EtherLab) EtherCAT master
backends behind the shared `ec_rt_*` FFI surface, and ports the IgH backend from
a loud-unimplemented skeleton to **full feature parity with SOEM**.

## Toggle
- `--features hw` → SOEM (`csrc/libecrt.c`, `-lsoem`), unchanged default.
- `--features igh` (implies `hw`) → IgH (`csrc/libecrt_igh.c`, `-lethercat`).
- `src/ffi.rs` and the 24-symbol `ec_rt_*` contract are untouched; only the C
  backend and link differ. CI still builds the no-feature stub (no master lib).
- `Makefile.rust` gains `ethercat-endpoint-igh`; `build.rs` branches on
  `CARGO_FEATURE_IGH` with `IGH_DIR`/`IGH_LIB_DIR` (default `/opt/etherlab`).

## IgH port
- Declarative PDO map (`ecrt_slave_config_pdos`) reproduces SOEM's runtime
  1C12h/1C13h/1600h/1A00h remap byte-for-byte (out_t 18B / in_t 32B).
- Two-phase bring-up preserved: `preop` configures + stages CSP/FF-routing as
  config SDOs, arms DC, and clears a latched sync alarm in PRE-OP without
  activating; `finish` activates, walks to OP, parks at Ready-to-Switch-On.
- DC is distributed by the kernel master (`application_time` +
  `sync_reference_clock`/`sync_slave_clocks` slave the drive clock to the
  CLOCK_MONOTONIC wake grid); the cycle is fixed-rate, no userspace phase loop.
- Outputs are staged in a shadow struct and flushed into the domain image
  **after** receive — `ecrt_master_receive` overwrites the image's output region
  with the previous frame's echo, so a pre-receive write would be clobbered.
- Runtime SDO (`ecrt_master_sdo_upload/download`) backs read/write limits and
  arbitrary SdoRead/SdoWrite from the mailbox companion thread.
- CiA-402 enable / homing-method-35 / disable / park / AL-status ported from the
  SOEM state machines.

## Validation (Neptune EtherCAT bench, AS715N A6-EC drive)
Built the IgH kernel master (ec_master + ec_generic) against kernel 6.18-rt.
The IgH endpoint brings the drive to OP, parks at CiA-402 Ready-to-Switch-On,
and sustains the DC loop at **wkc 3/3, err 0x0000, following-error 0, toff 0**;
klippy reaches `ready`. The SOEM path is byte-for-byte behaviour-unchanged.

IgH/SOEM are never built in CI (no master lib); the toggle is verified on-bench.