### PR TITLE
fix(motion): flush commits without blocking the reactor on play-out

### DIFF
--- a/rust/motion-engine/src/stream_planner.rs
+++ b/rust/motion-engine/src/stream_planner.rs
@@ -223,18 +223,9 @@ impl StreamPlannerHandle {
         self.sender
             .send(StreamMsg::Flush { notify: tx })
             .map_err(|_| StreamPlannerError::ChannelClosed)?;
-        match rx.recv() {
-            Ok(finish) => {
-                if let Some(deadline) = finish {
-                    let now = Instant::now();
-                    if deadline > now {
-                        std::thread::sleep(deadline - now);
-                    }
-                }
-                Ok(())
-            }
-            Err(_) => Err(StreamPlannerError::ChannelClosed),
-        }
+        rx.recv()
+            .map(|_committed_through| ())
+            .map_err(|_| StreamPlannerError::ChannelClosed)
     }
 
     pub fn flush_start(

--- a/rust/motion-engine/src/stream_planner/tests.rs
+++ b/rust/motion-engine/src/stream_planner/tests.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use super::*;
 use crate::stream::StreamConfig;
@@ -555,6 +556,36 @@ fn live_retune_pressure_advance_applies_to_plans_after_the_swap() {
     assert!(
         post_swap > pre_swap + 1e-2,
         "post-swap PA should push the extruder ahead at mid-move: {post_swap} vs {pre_swap}"
+    );
+    h.shutdown();
+}
+
+#[test]
+fn flush_returns_after_commit_without_sleeping_until_playout() {
+    let cap = Capture::default();
+    let mut h = StreamPlannerHandle::spawn(
+        cfg(),
+        AxisChainSet::default(),
+        vec![0.0, 0.0, 0.0, 0.0],
+        cap.dispatch(),
+        cap.nudge_dispatch(),
+    );
+    h.submit_move(line_e(1, 5.0, [0.0, 0.0, 0.0], [10.0, 0.0, 0.0], 0.0))
+        .unwrap();
+
+    let started = Instant::now();
+    h.flush().unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        !cap.snapshot().is_empty(),
+        "flush committed nothing to dispatch"
+    );
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "flush blocked {elapsed:?} on a ~2s move: it slept until the play-out \
+         deadline instead of returning after commit and letting the caller poll \
+         the drain counter"
     );
     h.shutdown();
 }


### PR DESCRIPTION
## Problem

`StreamPlanner::flush()` does `rx.recv()` (commit) and then `std::thread::sleep(deadline - now)` to wait until the committed move physically plays out. It is called from Python via `py.detach`, which releases the GIL but **blocks the host reactor thread** — no other reactor timers run while the call is parked in the sleep.

On a slow homing drip the sleep stalls the reactor for the whole move (~2s measured on the Neptune bench). During that stall the heater's ADC callback can't fire; the heater then schedules a PWM at a `print_time` ~524ms in the MCU's past, and the MCU shuts down with **`Timer too close`**. Symptom: deterministic crash when a print runs `G28` while a heater is set (heater-gated, G28-gated).

Bisected to `f132b29dc`, which routed the common `wait_moves()` — and thus every homing `trip_move` — onto this blocking path. The blocking sleep itself predates it (it was already on `wait_moves_and_mcu`/`set_position`); f132b29dc just made it hit the common homing path.

## Fix

The play-out wait was a redundant host-side estimate. The authoritative completion signal is the **heartbeat-fed drain counter** (`retired == sent`, fed from `attach_heartbeat_callback` = MCU-acknowledged retirement). Every live caller already waits on it *after* `flush()`:

- `motion_drain_poll` → `is_drained_now` + the reactor-yielding `_wait_mcu_drained` loop
- `set_position` → `wait_drained`

So `flush()` now only commits and returns. The retained `rx.recv()` still guarantees the worker has dispatched (the `sent` counter is bumped) before the counter is trusted — no early-return race.

## Verification

- New regression test `flush_returns_after_commit_without_sleeping_until_playout`: submits a ~2s move and asserts `flush()` returns in <500ms (it slept ~2s before).
- `cargo nextest run -p motion-engine`: 330 pass.
- `./scripts/ci.sh quick`: green (ruff, rust-test, rust-clippy, rust-fmt, watchdog-canary).
- Bench (Neptune): the deterministic G28 + heater repro no longer crashes.