### PR TITLE
Reclaim F401 MCU memory: dynmem measurement + max_path_deviation knob

### DIFF
--- a/_bmad-output/implementation-artifacts/investigations/mcu-telemetry-memory-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/mcu-telemetry-memory-investigation.md
@@ -1,0 +1,136 @@
+# Investigation: MCU telemetry memory reclamation (F401 ring growth)
+
+## Hand-off Brief
+
+1. **What happened.** The premise — "a chunk of MCU memory was dedicated to telemetry that was never built" — is only *partially* confirmed: exactly **40 bytes** of genuinely-dead telemetry counters exist in `SharedState`, and the *entire* telemetry/diagnostic surface on the MCU totals well under 1 KB.
+2. **Where the case stands.** Confirmed: 4 unwired counters (40 B) are reclaimable with zero functional impact. Deduced: reclaiming telemetry memory cannot meaningfully grow the F401 piece ring — the ring is 32 KB and the entire diagnostic surface is <1 KB. The real lever for ring growth is the `rt_storage` ceiling vs. the C-side dynamic pool split.
+3. **What's needed next.** Decide the actual goal: (a) tidy the 40 B of dead counters (cheap, correct, but immaterial to ring size), or (b) pursue ring growth via the `RUNTIME_STORAGE_SIZE_SMALL` ceiling and SRAM budget — a different change with no telemetry connection.
+
+## Case Info
+
+| Field            | Value                                                                      |
+| ---------------- | -------------------------------------------------------------------------- |
+| Ticket           | N/A                                                                        |
+| Date opened      | 2026-06-24                                                                  |
+| Status           | Active                                                                      |
+| System           | Kalico fork, MCU firmware; targets STM32H7 / STM32F4(F401) / STM32G0       |
+| Evidence sources | Source code (rust/runtime, src/), Kconfig, linker script, git log          |
+
+## Problem Statement
+
+User recollection: "we dedicated a chunk of MCU memory to telemetry, and we never actually built this telemetry." Goal: free that memory — **especially on F401** (Neptune3 Pro, 64 KB SRAM) — so the piece ring (`CONFIG_RUNTIME_PIECE_RING_SIZE`) can be increased. The recollection is treated as a hypothesis to verify, not a fact.
+
+## Evidence Inventory
+
+| Source                                   | Status    | Notes                                                                 |
+| ---------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `rust/runtime/src/state.rs` SharedState  | Available | The MCU's telemetry/diagnostic counter surface lives here             |
+| `src/Kconfig`                            | Available | Per-target ring + rt_storage byte budgets                             |
+| `src/generic/armcm_link.lds.S`           | Available | Linker sections; no telemetry-named region exists                     |
+| `src/runtime_storage.c`                  | Available | `rt_storage[]` backing buffer + static-assert headroom guard          |
+| `docs/rewrite/mcu-c-rust-boundary.md`    | Available | B2 names "future telemetry rings" — aspirational, not allocated       |
+| git history (`-i --grep=telemetr`)       | Available | All telemetry commits are EtherCAT/servo host-side, not MCU SRAM      |
+
+## Confirmed Findings
+
+### Finding 1: Exactly 40 bytes of dead telemetry counters in SharedState
+
+**Evidence:** `rust/runtime/src/state.rs:227-231`
+
+```
+pub queue_high_water: [AtomicU32; 4],            // 16 B
+pub queue_overflow_count: [AtomicU32; 4],        // LIVE — 2 write/read sites
+pub spi_saturated_samples: AtomicU32,            //  4 B
+pub sample_isr_peak_cycles: AtomicU32,           //  4 B
+pub per_axis_consumer_peak_cycles: [AtomicU32; 4], // 16 B
+```
+
+**Detail:** A grep for non-declaration, non-test uses returns **0 sites** for `queue_high_water`, `spi_saturated_samples`, `sample_isr_peak_cycles`, and `per_axis_consumer_peak_cycles` — they are only declared (lines 227, 229-231) and zero-initialized (`new()`), never written or read by live code. `queue_overflow_count` is live (2 sites). Total dead = 16 + 4 + 4 + 16 = **40 bytes**. These were added alongside `queue_overflow_count` as a batch of "five new telemetry counters" during the stepping-redesign bring-up; only `queue_overflow_count` was ever wired.
+
+### Finding 2: No telemetry-named linker section or buffer exists
+
+**Evidence:** `src/generic/armcm_link.lds.S:101-135`; `docs/rewrite/mcu-c-rust-boundary.md` (B2)
+
+**Detail:** The MCU linker sections are `.sched_protected`, `.persistent_diag`, `.axi_bss` (H7-only), `.bkp_bss` (H7-only) — all live. There is **no** telemetry/trace/capture section. The boundary doc lists "future telemetry rings" only as an *example* of state that *would* live C-side if it were ever built — it was never allocated. No large telemetry/trace/scope buffer exists in `src/*.c` either.
+
+### Finding 3: The entire MCU telemetry/diagnostic surface is < 1 KB
+
+**Evidence:** `rust/runtime/src/state.rs:85-258` field-type tally — 69×`AtomicU32`, 13×`AtomicU64`, 6×`AtomicU8`, 10×`AtomicBool`, 4×`AtomicI32`, 1×`AtomicU16`, plus a handful of `[_;4]` arrays.
+
+**Detail:** Scalar counters ≈ 414 B; the per-axis arrays add ~112 B; stepper-OID arrays are functional, not telemetry. The whole forensic/diagnostic block is on the order of **0.5–0.7 KB**. Most of it (the `isr_last_*`, `producer_*_total`, `last_push_*`, `last_resolved_*`, `tick_blocker_*` fields) is stepping-redesign bring-up forensics that *is* written by live code — so it is "diagnostic cruft that could be retired," not "telemetry that was never built." Retiring it requires also removing its write sites and any `DIAG_DUMP`/`status_drain` readers.
+
+## Deduced Conclusions
+
+### Deduction 1: Reclaiming telemetry memory cannot meaningfully grow the F401 ring
+
+**Based on:** Findings 1 & 3, plus the F401 budget below.
+
+**Reasoning:** F401 `CONFIG_RUNTIME_PIECE_RING_SIZE = 32768` (32 KB) — `Kconfig:389`. The total telemetry/diagnostic surface is <1 KB, of which only 40 B is genuinely dead. Even retiring the *entire* diagnostic block frees <1 KB — ~3% of the existing ring, ~1.5% of the 64 KB SRAM. It does not change the ring-growth math.
+
+**Conclusion:** Telemetry reclamation is the wrong lever for ring growth. It is a worthwhile *tidy* (the 40 B, and optionally the bring-up forensics), but it is not what unlocks a bigger ring.
+
+### Deduction 2: The real F401 ring-growth lever is the rt_storage ceiling / SRAM split
+
+**Based on:** `src/Kconfig:386-401, 476-480`; `src/runtime_storage.c:15-32`
+
+**Reasoning:** On F401 the ring lives inside `rt_storage[RT_STORAGE_SIZE]`, ceiling `RUNTIME_STORAGE_SIZE_SMALL = 36864` (36 KB). Fixed (non-ring) RuntimeContext ≈ 2520 B, so current occupancy ≈ 2520 + 32768 = 35288 B → **~1.5 KB of slack already exists under the ceiling** (the ring could grow ~1.5 KB today with no other change). Beyond that, the ceiling itself must rise, which eats into the leftover C-side dynamic pool and stack on the 64 KB part. That budget split — not telemetry — is the constraint.
+
+### Deduction 3: The "C-side dynamic pool" is leftover RAM, not a fixed reservation — the Kconfig "~17 KB" note is doubly misleading
+
+**Based on:** `src/generic/armcm_boot.c:182-192`; `src/stm32/Makefile:59`; `src/linux/Makefile:8`, `src/simulator/Makefile:6`; `src/generic/alloc.c:9`; `src/stm32/Kconfig:275` (STACK_SIZE=4096)
+
+**Reasoning:** On STM32/ARM, `dynmem_start() = &_persistent_diag_end` and `dynmem_end() = &_stack_start` (`armcm_boot.c:182-192`) — the dynamic pool is **all RAM between the end of the .bss/.persistent_diag region and the top-of-RAM stack**, i.e. a *computed leftover*, not an allocation. The fixed `static char dynmem_pool[20 * 1024]` in `generic/alloc.c:9` is compiled **only for `linux` and `simulator`** (`src/*/Makefile`), never for F401 — it is a red herring. Therefore: (1) the Kconfig "~17 KB" figure is not a budget line item, it is whatever happens to be left over; (2) **raising `RUNTIME_STORAGE_SIZE_SMALL` shrinks the dynamic pool 1:1** — there is no separate pool to "free", only a gap to re-divide. The hard floor is whatever the printer's config-time allocations (oid tables + `alloc_chunk` command objects, `src/basecmd.c:31-51`) actually consume at runtime; everything above that high-water is ring headroom.
+
+**Conclusion:** F401 ring growth is bounded by the runtime **dynmem high-water**, not by any reservation. The number cannot be read off the source — it needs a live measurement (or a conservative static bound from a build `.map`).
+
+## Hypothesized Paths
+
+### Hypothesis 1: User's "chunk dedicated to telemetry" referred to a larger reservation
+
+**Status:** Refuted
+
+**Theory:** A multi-KB telemetry ring/buffer was reserved in SRAM or the linker map.
+
+**Would refute:** No telemetry-named section, Kconfig budget, or large static buffer anywhere; the only telemetry-tagged memory is the <1 KB SharedState counter block, 40 B of it dead.
+
+**Resolution:** Refuted by Findings 1–3. The recollection most likely conflates (a) the 40 B of unwired counters with (b) the broader bring-up forensic block, neither of which is a reclaimable "chunk" at ring scale.
+
+## Missing Evidence
+
+| Gap                                          | Impact                                              | How to Obtain                                              |
+| -------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------- |
+| Live F401 SRAM map (.map file / size output) | Confirms exact dynamic-pool + stack headroom        | Build F401 image, inspect `.map` / `arm-none-eabi-size`   |
+| C-side dynamic pool actual high-water        | How much of the ~17 KB pool is really used on F401  | Runtime `dynmem` stats / DIAG dump on the bench           |
+
+## Source Code Trace
+
+| Element       | Detail                                                                    |
+| ------------- | ------------------------------------------------------------------------- |
+| Dead counters | `rust/runtime/src/state.rs:227,229-231` (decl) + `new()` init (~line 387) |
+| Ring budget   | `src/Kconfig:386-401` (`RUNTIME_PIECE_RING_SIZE`, F401=32768)             |
+| Storage ceiling | `src/Kconfig:471-480` (`RUNTIME_STORAGE_SIZE_SMALL`, F401=36864)         |
+| Backing buffer | `src/runtime_storage.c:15` (`rt_storage[]`) + static-asserts             |
+| Caps report   | `src/mcu_transport_dispatch.c:212` (ring size surfaced to host)           |
+
+## Conclusion
+
+**Confidence:** High (for the telemetry accounting); Medium (for ring-growth headroom, pending a live `.map`).
+
+Confirmed: only **40 bytes** of MCU memory is telemetry-that-was-never-built (4 unwired `SharedState` counters); they are safe to delete. The broader diagnostic surface is still <1 KB and mostly live-written bring-up forensics. **The premise that reclaiming telemetry frees a meaningful chunk for ring growth is not supported.** The actual F401 ring lever is the `rt_storage` ceiling (36864) and the SRAM split with the C-side dynamic pool — ~1.5 KB of ring growth is already available under today's ceiling without touching telemetry at all.
+
+## Recommended Next Steps
+
+### Fix direction
+
+- **Tidy (cheap, immaterial to ring):** delete the 4 dead counters at `state.rs:227,229-231` and their `new()` initializers. ~40 B, zero behavior change. Candidate for `bmad-quick-dev`.
+- **Ring growth (the actual goal):** treat as a separate change — raise F401 `RUNTIME_STORAGE_SIZE_SMALL` (and/or `RUNTIME_PIECE_RING_SIZE`) after measuring real C-side dynamic-pool + stack headroom from a live `.map`. Not a telemetry change.
+
+### Diagnostic
+
+Build the F401 image and capture `arm-none-eabi-size` + `.map` to confirm how much of the 64 KB is actually free; pull `dynmem` high-water from the bench to size the safe ceiling increase.
+
+## Side Findings
+
+- Host-side telemetry (EtherCAT `EcTelemetry`, servo `SERVO_CAPTURE`, geometry `TelemetryEvent`) is fully built and live — unrelated to MCU SRAM. (`rust/ethercat-rt/src/ffi.rs:10`, `rust/geometry/src/telemetry.rs`)
+- `event_log` ring (`src/event_log.c:26`, 64 entries) is the live structured-log ring — built and in use, not reclaimable.
+- The large `isr_last_*` / `producer_*` forensic counter block is a legitimate future cleanup target if bring-up is considered closed, but it is live-written and tied to `DIAG_DUMP` readers — removal is a deliberate de-instrumentation, not free memory.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -241,6 +241,16 @@ max_accel:
 #   decelerate to zero at each corner. The value specified here may be
 #   changed at runtime using the SET_VELOCITY_LIMIT command. The
 #   default is 5mm/s.
+#max_path_deviation: 0.005
+#   Maximum distance (in mm) the executed motion may deviate from the
+#   commanded path. The planner represents each move as a series of cubic
+#   pieces and subdivides a move until every piece tracks the path to
+#   within this value, so a smaller value yields more pieces (tighter path
+#   following) and a larger value yields fewer pieces. Loosening it reduces
+#   the per-move piece count, which lowers MCU piece-ring pressure on
+#   memory-constrained boards at the cost of slightly coarser path
+#   following. This is unrelated to [arc_fit], which reconstructs arcs from
+#   faceted segments. The default is 0.005 (5 microns).
 #max_accel_to_decel:
 #   This parameter is deprecated and should no longer be used.
 ```

--- a/klippy/motion.py
+++ b/klippy/motion.py
@@ -800,6 +800,9 @@ class Motion:
         self.max_z_accel = config.getfloat(
             "max_z_accel", self._max_accel, above=0.0, maxval=self._max_accel
         )
+        self.max_path_deviation = config.getfloat(
+            "max_path_deviation", 0.005, above=0.0, maxval=1.0
+        )
         self.limit_sections = []
         for sc in config.get_prefix_sections("limit "):
             name = sc.get_name().split(None, 1)[1]
@@ -1004,6 +1007,7 @@ class Motion:
                 arc_fit=self.arc_fit,
                 max_extrude_only_velocity=max_extrude_only_velocity,
                 max_extrude_only_accel=max_extrude_only_accel,
+                fit_tolerance_mm=self.max_path_deviation,
             )
             self._configure_axes_per_mcu(engine_mcus)
             self._planner_ready = True

--- a/klippy/motion_engine.py
+++ b/klippy/motion_engine.py
@@ -386,6 +386,7 @@ class MotionEngineWrapper:
         arc_fit=None,
         max_extrude_only_velocity=None,
         max_extrude_only_accel=None,
+        fit_tolerance_mm=None,
     ):
         return self._engine.init_planner(
             axes,
@@ -397,6 +398,7 @@ class MotionEngineWrapper:
             arc_fit,
             max_extrude_only_velocity,
             max_extrude_only_accel,
+            fit_tolerance_mm,
         )
 
     def submit_move(self, dx, dy, dz, de, feedrate):

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -2510,6 +2510,7 @@ impl PyMotionEngine {
         arc_fit = None,
         max_extrude_only_velocity = None,
         max_extrude_only_accel = None,
+        fit_tolerance_mm = None,
     ))]
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     fn init_planner(
@@ -2523,6 +2524,7 @@ impl PyMotionEngine {
         arc_fit: Option<u32>,
         max_extrude_only_velocity: Option<f64>,
         max_extrude_only_accel: Option<f64>,
+        fit_tolerance_mm: Option<f64>,
     ) -> PyResult<()> {
         if self
             .planner
@@ -2607,6 +2609,14 @@ impl PyMotionEngine {
             }
         }
 
+        if let Some(v) = fit_tolerance_mm {
+            if !(v.is_finite() && v > 0.0) {
+                return Err(PyValueError::new_err(format!(
+                    "[printer] fit_tolerance must be finite and positive, got {v}"
+                )));
+            }
+        }
+
         let mut cfg = config::PlannerConfig::default();
         cfg.axis_registry = axis_registry;
         cfg.limit_sections = limit_sections;
@@ -2614,6 +2624,9 @@ impl PyMotionEngine {
         cfg.post_processors = post_processor_set;
         cfg.max_extrude_only_velocity = max_extrude_only_velocity;
         cfg.max_extrude_only_accel = max_extrude_only_accel;
+        if let Some(v) = fit_tolerance_mm {
+            cfg.fit_tolerance_mm = v;
+        }
         cfg.chain = match arc_fit {
             Some(min_run_facets) => {
                 if min_run_facets < 3 {

--- a/rust/runtime/src/log_codes.rs
+++ b/rust/runtime/src/log_codes.rs
@@ -78,6 +78,7 @@ pub const EVENT_DIAG_TX_DROP_KAL: u16 = 5;
 pub const EVENT_DIAG_TX_DROP_KLP: u16 = 6;
 pub const EVENT_DIAG_ENGINE_XITION: u16 = 7;
 pub const EVENT_DIAG_RUST_FAULT: u16 = 8;
+pub const EVENT_DIAG_DYNMEM_FREE: u16 = 9;
 
 /// Resolve a `(subsystem, event)` pair to a `(name, template)` tuple.
 ///
@@ -185,6 +186,10 @@ pub fn event_info(subsystem: u8, event: u16) -> (&'static str, &'static str) {
         (SUBSYSTEM_DIAG, EVENT_DIAG_RUST_FAULT) => {
             ("diag.rust_fault", "rust fault err={arg0} detail={arg1}")
         }
+        (SUBSYSTEM_DIAG, EVENT_DIAG_DYNMEM_FREE) => (
+            "diag.dynmem_free",
+            "dynmem free={arg0} B of total={arg1} B at finalize_config",
+        ),
         (SUBSYSTEM_MOTION, EVENT_MOTION_PIECE_START_PAST) => (
             "motion.piece_start_past",
             "piece start in past start_time={arg0} now={arg1}",

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -456,15 +456,11 @@ config RUNTIME_STORAGE_SIZE_LARGE
     default 122880
     range 65536 524288
     help
-      Byte ceiling for rt_storage (the C-declared backing buffer that
-      replaces RT_CELL's Rust-side #[link_section] placement). The fixed
-      (non-ring) part of RuntimeContext measures 2520 bytes on the MCU
-      build (2026-06-07); total is that plus PIECE_RING_SIZE. Default is
-      122880 bytes (120 KB), providing ample headroom for piece-ring
-      growth. The AXI SRAM ceiling on H7 is 320 KB; the C-side
-      _Static_assert in src/runtime_storage.c enforces 2 KB headroom.
-      The Rust-side const_assert fires if RuntimeContext exceeds this
-      value at compile time.
+      Byte ceiling for rt_storage, the C-declared buffer backing the
+      runtime engine (fixed RuntimeContext + PIECE_RING_SIZE), placed in
+      H7 AXI SRAM. The _Static_assert in src/runtime_storage.c enforces
+      2 KB headroom under the 320 KB AXI region; the Rust-side
+      const_assert fires if RuntimeContext exceeds this at compile time.
 
 config RUNTIME_STORAGE_SIZE_SMALL
     int "rt_storage byte ceiling (small profile, F4/G0)"
@@ -473,14 +469,11 @@ config RUNTIME_STORAGE_SIZE_SMALL
     default 73728
     range 32768 131072
     help
-      Byte ceiling for rt_storage (the C-declared backing buffer that
-      replaces RT_CELL's Rust-side #[link_section] placement). The fixed
-      (non-ring) part of RuntimeContext measures 2520 bytes on the F4
-      MCU build (2026-06-07), so the floor is PIECE_RING_SIZE + ~3 KB.
-      Default is 73728 bytes (72 KB), providing headroom for piece-ring
-      growth on F4's 128 KB SRAM. F401 (64 KB SRAM total) defaults to
-      36864 to leave the C-side dynamic pool ~17 KB. Const_assert on
-      Rust catches RuntimeContext growth at compile time.
+      Byte ceiling for rt_storage, the C-declared buffer backing the
+      runtime engine (fixed RuntimeContext + PIECE_RING_SIZE). The Rust
+      const_assert fires if RuntimeContext exceeds this at compile time.
+      Sized per target to fit SRAM alongside the stack and the dynamic
+      allocation pool (the leftover RAM between .bss and the stack).
 
 config MCU_SIM
     bool "Build for simulator (disables IWDG, enables Linux sim shims)"

--- a/src/basecmd.c
+++ b/src/basecmd.c
@@ -10,6 +10,8 @@
 #include "board/misc.h" // alloc_maxsize
 #include "board/pgm.h" // READP
 #include "command.h" // DECL_COMMAND
+#include "event_log.h" // event_log_emit
+#include "generic/fault_handler.h" // DIAG_EV_DYNMEM_FREE
 #include "sched.h" // sched_clear_shutdown
 
 
@@ -171,6 +173,10 @@ move_finalize(void)
 {
     if (is_finalized())
         shutdown("Already finalized");
+    event_log_emit(EVENT_LOG_LEVEL_WARN, EVENT_LOG_SUBSYS_DIAG,
+                   DIAG_EV_DYNMEM_FREE, 0,
+                   (uint32_t)((char *)dynmem_end() - (char *)alloc_end),
+                   (uint32_t)((char *)dynmem_end() - (char *)dynmem_start()));
     struct move_queue_head dummy;
     move_queue_setup(&dummy, sizeof(*move_free_list));
     move_list = alloc_chunks(move_item_size, 1024, &move_count);

--- a/src/generic/fault_handler.c
+++ b/src/generic/fault_handler.c
@@ -101,6 +101,7 @@ enum {
     DIAG_EV_TX_DROP_KLP   = 6,
     DIAG_EV_ENGINE_XITION = 7,
     DIAG_EV_RUST_FAULT    = 8,
+    DIAG_EV_DYNMEM_FREE   = 9,
 };
 
 struct diag_event {

--- a/src/generic/fault_handler.h
+++ b/src/generic/fault_handler.h
@@ -18,6 +18,9 @@ extern "C" {
 #define DIAG_EV_ENGINE_XITION 7
 // a = (uint32_t)last_error (i32 cast), b = fault_detail.
 #define DIAG_EV_RUST_FAULT    8
+// One-shot at finalize_config: a = free dynmem bytes (pool the move queue is
+// about to claim), b = total dynmem pool bytes.
+#define DIAG_EV_DYNMEM_FREE   9
 
 // ISR-phase breadcrumb; value at IWDG reset names the hung phase.
 // MUST match rust/runtime/src/isr_phase.rs.

--- a/test/test_motion_topology.py
+++ b/test/test_motion_topology.py
@@ -175,6 +175,7 @@ class CaptureEngine:
         arc_fit=None,
         max_extrude_only_velocity=None,
         max_extrude_only_accel=None,
+        fit_tolerance_mm=None,
     ):
         self.init_planner_args = {
             "topology": topology,
@@ -183,6 +184,7 @@ class CaptureEngine:
             "arc_fit": arc_fit,
             "max_extrude_only_velocity": max_extrude_only_velocity,
             "max_extrude_only_accel": max_extrude_only_accel,
+            "fit_tolerance_mm": fit_tolerance_mm,
         }
 
 
@@ -197,6 +199,7 @@ def test_init_planner_passes_claimed_axes():
     motion.max_z_accel = 100.0
     motion._square_corner_velocity = 8.0
     motion.arc_fit = None
+    motion.max_path_deviation = 0.02
     motion._planner_ready = False
     engine = CaptureEngine()
     motion.engine = engine
@@ -218,3 +221,4 @@ def test_init_planner_passes_claimed_axes():
     cartesian_limits = engine.init_planner_args["cartesian_limits"]
     assert cartesian_limits == (300.0, 3000.0, 6000.0, 15.0, 100.0, 8.0)
     assert engine.init_planner_args["arc_fit"] is None
+    assert engine.init_planner_args["fit_tolerance_mm"] == 0.02


### PR DESCRIPTION
Motivated by an investigation into MCU memory we could reclaim to grow the piece ring, especially on the F401 (Neptune3 Pro, 64 KB SRAM). The headline finding: there is no large "telemetry" reservation to free — the only genuinely-dead telemetry is ~40 bytes of unwired counters — and the real F401 ring lever is the `rt_storage` ceiling vs. the leftover C-side dynamic pool. This PR lands the tooling and the user-facing knob to act on that.

## Changes

**1. `docs(kconfig)`: drop stale rt_storage byte-budget prose**
The `RUNTIME_STORAGE_SIZE_*` help text carried hand-maintained byte counts and a misleading "~17 KB C-side dynamic pool" claim. On ARM the pool is leftover RAM between `.bss` and the stack, not a fixed reservation. Removed the unmaintainable figures; kept the durable function and the protecting asserts.

**2. `feat(diag)`: emit free dynmem pool size at finalize_config**
`move_finalize()` hands the entire leftover dynamic pool to the move queue, so post-config free is ~0 by design. A one-shot `diag.dynmem_free` event just before the grab reports `(free, total)` pool bytes — the free figure is exactly the reclaimable headroom available to grow the MCU piece ring. Adds `DIAG_EV_DYNMEM_FREE` (tag 9) across the C/Rust log-code seam, plus the investigation case file that motivated it.

**3. `feat(motion)`: expose `max_path_deviation` `[printer]` knob**
New `[printer] max_path_deviation` option (default 0.005 mm) bounding how far the executed cubic-piece trajectory may deviate from the commanded path. Smaller → more pieces (tighter following); larger → fewer pieces, lowering MCU piece-ring pressure on memory-constrained boards like the F401. Plumbs `motion.py` → `init_planner` → `PlannerConfig.fit_tolerance_mm`; omitting it keeps the prior default. Distinct from `[arc_fit]`, which reconstructs arcs from facets.

## Verification
- `./scripts/ci.sh quick` — 5/5 pass (ruff, rust-test, rust-clippy, rust-fmt, watchdog-canary)
- `./scripts/ci.sh py` — 441 passed, 109 skipped, 2 xfailed
- C MCU side compiles on the bench toolchain (not built locally; no arm toolchain here)

## Follow-up (not in this PR)
Flash an F401 image and read `diag.dynmem_free` on the Neptune bench to get the actual reclaimable byte count, then size a concrete `RUNTIME_STORAGE_SIZE_SMALL` / ring increase.