### PR TITLE
motion: reject discontinuous moves at stream ingress

### DIFF
--- a/rust/motion-engine/examples/dump_stream_trajectory.rs
+++ b/rust/motion-engine/examples/dump_stream_trajectory.rs
@@ -164,7 +164,10 @@ fn main() {
                             continue;
                         }
                     };
-                state.push(m);
+                if let Err(e) = state.push(m) {
+                    eprintln!("push line {submitted}: {e}");
+                    continue;
+                }
                 submitted += 1;
                 if state.buffered() >= cap {
                     commit_into(&mut state, &mut all, false);

--- a/rust/motion-engine/src/bridge/tests.rs
+++ b/rust/motion-engine/src/bridge/tests.rs
@@ -380,6 +380,7 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
     let submitter = std::thread::Builder::new()
         .name("test-submitter".into())
         .spawn(move || {
+            let mut start = [50.0, 0.0, 0.0];
             while !stop_sub.load(Ordering::SeqCst) {
                 {
                     let guard = engine_sub.planner.lock().unwrap_or_else(|p| p.into_inner());
@@ -387,7 +388,7 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
                         break; // shutdown() took the planner; stop submitting.
                     };
                     let m = crate::classify::build_move(
-                        [0.0; 3],
+                        start,
                         50.0,
                         0.0,
                         0.0,
@@ -401,6 +402,7 @@ fn shutdown_joins_planner_before_dropping_pump_receiver() {
                     if p.submit_move(m).is_err() {
                         break;
                     }
+                    start[0] += 50.0;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(3));
             }

--- a/rust/motion-engine/src/seam_test_harness.rs
+++ b/rust/motion-engine/src/seam_test_harness.rs
@@ -359,7 +359,7 @@ pub fn run_moves(
     let mut cadence_step = 0usize;
 
     for (i, m) in moves.iter().cloned().enumerate() {
-        state.push(m);
+        state.push(m)?;
         if state.buffered() >= schedule.cadence.cap_for(cadence_step) {
             let segs = state.commit(false)?;
             if !segs.is_empty() {

--- a/rust/motion-engine/src/stream.rs
+++ b/rust/motion-engine/src/stream.rs
@@ -13,6 +13,7 @@ use trajectory::{AxisChainSet, ChainStage, CompiledChain, ShapedSegment, ShapedS
 use crate::lowering::{LoweringError, lower_move};
 
 const SEGMENT_TIME_EPS_S: f64 = 1e-9;
+const CONTIGUITY_EPS_MM: f64 = 1e-6;
 
 #[derive(Debug, Clone, Copy)]
 pub struct StreamConfig {
@@ -49,6 +50,17 @@ pub enum StreamError {
         lead_remaining: f64,
         solve_const: f64,
     },
+    /// A move entered the buffer whose spatial start does not meet the toolhead
+    /// where the previous move (or the committed odometer) left it. Real slicer
+    /// output is always position-contiguous; a gap means the move stream was
+    /// stitched wrong upstream. Caught here so the offending move is named at
+    /// ingress, not as a downstream `ZeroMotion` deep in the fitter.
+    Discontinuity {
+        line_no: u32,
+        expected: [f64; 3],
+        got: [f64; 3],
+        gap_mm: f64,
+    },
     PostProcess(PostProcessError),
 }
 
@@ -66,6 +78,17 @@ impl std::fmt::Display for StreamError {
                 f,
                 "brake-to-rest shortfall: locked lead {lead_remaining:.6}s below \
                  solve-time budget {solve_const:.6}s — solve-time constant too short"
+            ),
+            Self::Discontinuity {
+                line_no,
+                expected,
+                got,
+                gap_mm,
+            } => write!(
+                f,
+                "discontinuous move at line {line_no}: starts at {got:?} but the \
+                 toolhead is at {expected:?} ({gap_mm:.6}mm gap) — move stream is \
+                 not position-contiguous"
             ),
             Self::PostProcess(e) => write!(f, "post-processing: {e}"),
         }
@@ -182,8 +205,31 @@ impl StreamState {
         self.post_history.clear();
     }
 
-    pub fn push(&mut self, m: Move) {
+    pub fn push(&mut self, m: Move) -> Result<(), StreamError> {
+        if let Some(seg) = &m.segment.spatial {
+            let got = seg.point_at(0.0);
+            let expected = self.expected_spatial_end();
+            let gap_mm = dist3(expected, got);
+            if gap_mm > CONTIGUITY_EPS_MM {
+                return Err(StreamError::Discontinuity {
+                    line_no: m.source.start_line,
+                    expected,
+                    got,
+                    gap_mm,
+                });
+            }
+        }
         self.buffer.push_back(m);
+        Ok(())
+    }
+
+    fn expected_spatial_end(&self) -> [f64; 3] {
+        for m in self.buffer.iter().rev() {
+            if let Some(seg) = &m.segment.spatial {
+                return seg.point_at(m.segment.s_len());
+            }
+        }
+        [self.odometer[0], self.odometer[1], self.odometer[2]]
     }
 
     pub fn advance_time(&mut self, dt: f64) {

--- a/rust/motion-engine/src/stream/tests.rs
+++ b/rust/motion-engine/src/stream/tests.rs
@@ -97,7 +97,7 @@ fn voron_cube_perimeter_streams_without_degenerate_trim() {
     let mut prev = start;
     for (i, (x, y, e)) in VORON_PERIMETER.into_iter().enumerate() {
         let end = [x, y, 0.2];
-        s.push(line(i as u32 + 1, prev, end, e));
+        s.push(line(i as u32 + 1, prev, end, e)).unwrap();
         prev = end;
         s.commit(false)
             .unwrap_or_else(|err| panic!("commit at move {i} errored: {err}"));
@@ -219,7 +219,7 @@ fn cold_run_infill_streams_without_overcommit() {
     let mut prev = start;
     for (i, (x, y)) in pts.into_iter().enumerate() {
         let end = [x, y, 0.2];
-        s.push(line_bench(i as u32 + 1, prev, end));
+        s.push(line_bench(i as u32 + 1, prev, end)).unwrap();
         prev = end;
         s.commit(false)
             .unwrap_or_else(|err| panic!("commit at move {i} errored: {err}"));
@@ -231,8 +231,10 @@ fn cold_run_infill_streams_without_overcommit() {
 #[test]
 fn collinear_jogs_commit_at_the_seam_without_stopping() {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0));
-    s.push(line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0))
+        .unwrap();
 
     let committed = s.commit(false).unwrap();
     assert!(!committed.is_empty());
@@ -249,8 +251,10 @@ fn collinear_jogs_commit_at_the_seam_without_stopping() {
 #[test]
 fn flush_commits_everything_to_rest() {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0));
-    s.push(line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(2, [50.0, 0.0, 0.0], [100.0, 0.0, 0.0], 0.0))
+        .unwrap();
 
     // A forced flush drains the whole buffer to rest regardless of where the
     // finality barrier sits — it materializes the brake-to-rest tail.
@@ -269,8 +273,10 @@ fn blended_corner_commits_through_the_blend_without_stopping() {
     // blend and keeps the outgoing move as a head-trimmed remainder — never
     // splitting the blend itself, and never stopping at the corner.
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0));
-    s.push(line(2, [50.0, 0.0, 0.0], [50.0, 50.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(2, [50.0, 0.0, 0.0], [50.0, 50.0, 0.0], 0.0))
+        .unwrap();
 
     let committed = s.commit(false).unwrap();
     assert!(!committed.is_empty(), "the blend must commit");
@@ -310,7 +316,7 @@ fn continuous_blended_chain_drains_without_a_single_stop() {
         [120.0, 3.0, 0.0],
     ];
     for (i, w) in pts.windows(2).enumerate() {
-        s.push(line(i as u32 + 1, w[0], w[1], 0.0));
+        s.push(line(i as u32 + 1, w[0], w[1], 0.0)).unwrap();
     }
     let pushed = pts.len() - 1;
 
@@ -362,9 +368,12 @@ fn head_trim_preserves_position_and_extrusion_continuity() {
     // resumes exactly where the committed trajectory ended (no gap, no overlap)
     // in both the spatial axes and the extruder.
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 5.0));
-    s.push(line(2, [50.0, 0.0, 0.0], [50.0, 50.0, 0.0], 5.0));
-    s.push(line(3, [50.0, 50.0, 0.0], [100.0, 50.0, 0.0], 5.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 5.0))
+        .unwrap();
+    s.push(line(2, [50.0, 0.0, 0.0], [50.0, 50.0, 0.0], 5.0))
+        .unwrap();
+    s.push(line(3, [50.0, 50.0, 0.0], [100.0, 50.0, 0.0], 5.0))
+        .unwrap();
 
     let first = s.commit(false).unwrap();
     assert!(!first.is_empty());
@@ -387,8 +396,10 @@ fn head_trim_preserves_position_and_extrusion_continuity() {
 #[test]
 fn odometer_accumulates_extrusion_across_commits() {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [40.0, 0.0, 0.0], 4.0));
-    s.push(line(2, [40.0, 0.0, 0.0], [80.0, 0.0, 0.0], 4.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [40.0, 0.0, 0.0], 4.0))
+        .unwrap();
+    s.push(line(2, [40.0, 0.0, 0.0], [80.0, 0.0, 0.0], 4.0))
+        .unwrap();
 
     let committed = s.commit(true).unwrap();
     assert!(s.is_empty());
@@ -399,9 +410,12 @@ fn odometer_accumulates_extrusion_across_commits() {
 #[test]
 fn committed_trajectory_is_time_contiguous() {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 2.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [30.0, 0.0, 0.0], 0.0));
-    s.push(line(2, [30.0, 0.0, 0.0], [60.0, 0.0, 0.0], 0.0));
-    s.push(line(3, [60.0, 0.0, 0.0], [90.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [30.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(2, [30.0, 0.0, 0.0], [60.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(3, [60.0, 0.0, 0.0], [90.0, 0.0, 0.0], 0.0))
+        .unwrap();
 
     let committed = s.commit(true).unwrap();
     assert_eq!(committed[0].t_start, 2.0);
@@ -416,13 +430,15 @@ fn committed_trajectory_is_time_contiguous() {
 #[test]
 fn advance_idle_reanchors_committed_time_after_a_gap() {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [30.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [30.0, 0.0, 0.0], 0.0))
+        .unwrap();
     let first = s.commit(true).unwrap();
     let after_first = first.last().unwrap().t_end;
 
     let idle_gap_past_horizon_secs = 50.0;
     s.advance_idle(after_first + idle_gap_past_horizon_secs);
-    s.push(line(2, [30.0, 0.0, 0.0], [60.0, 0.0, 0.0], 0.0));
+    s.push(line(2, [30.0, 0.0, 0.0], [60.0, 0.0, 0.0], 0.0))
+        .unwrap();
     let second = s.commit(true).unwrap();
     assert!(
         second[0].t_start >= after_first + idle_gap_past_horizon_secs - 1e-9,
@@ -436,7 +452,7 @@ fn advance_idle_reanchors_committed_time_after_a_gap() {
 fn full_replan(moves: &[geometry::Move], home: &[f64]) -> Vec<ShapedSegment> {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), home, 0.0);
     for m in moves {
-        s.push(m.clone());
+        s.push(m.clone()).unwrap();
     }
     s.commit(true).expect("full re-plan flush")
 }
@@ -447,7 +463,7 @@ fn committed_prefix(moves: &[geometry::Move], home: &[f64]) -> Vec<ShapedSegment
     // barrier in one shot. Those are the segments actually dispatched mid-print.
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), home, 0.0);
     for m in moves {
-        s.push(m.clone());
+        s.push(m.clone()).unwrap();
     }
     s.commit(false).expect("incremental commit")
 }
@@ -539,7 +555,7 @@ fn open_tail_stays_bounded_as_buffer_depth_grows() {
         let mut max_tail = 0usize;
         for i in 0..depth {
             let end = [(i as f64 + 1.0) * 20.0, 0.0, 0.0];
-            s.push(line(i as u32 + 1, prev, end, 0.0));
+            s.push(line(i as u32 + 1, prev, end, 0.0)).unwrap();
             prev = end;
             s.commit(false).expect("commit");
             max_tail = max_tail.max(s.buffered());
@@ -559,7 +575,8 @@ fn open_tail_stays_bounded_as_buffer_depth_grows() {
 #[test]
 fn stall_brake_shortfall_is_attributable_and_fails_loud() {
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap();
     let solve_const = 0.05;
     match s.commit_stall_brake(0.01, solve_const) {
         Err(StreamError::BrakeToRestShortfall {
@@ -585,7 +602,7 @@ fn commit_prefix_signature(ys: &[f64], n: usize) -> Option<Vec<(f64, f64, f64, f
     let mut prev = [0.0, 0.0, 0.0];
     for i in 0..n {
         let end = [(i as f64 + 1.0) * 20.0, ys[i], 0.0];
-        s.push(line(i as u32 + 1, prev, end, 0.0));
+        s.push(line(i as u32 + 1, prev, end, 0.0)).unwrap();
         prev = end;
     }
     // Some random shapes lower to a degenerate phase; those inputs are out of
@@ -659,8 +676,8 @@ fn smooth_shaper_live_path_matches_shaped_signal_oracle() {
     let mut base = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
     let mut shaped = StreamState::new(cfg(), smooth_x_chains(18.0), &[0.0, 0.0, 0.0], 0.0);
     for m in moves {
-        base.push(m.clone());
-        shaped.push(m);
+        base.push(m.clone()).unwrap();
+        shaped.push(m).unwrap();
     }
 
     let base_out = base.commit(true).unwrap();
@@ -719,7 +736,7 @@ fn small_buffer_within_setback_yields_empty_commit() {
     // dispatched frontier would freeze (investigation batch 33: n=4 commit_count=0).
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.2, 0.0], 0.0);
     for m in short_collinear(4, 0.3) {
-        s.push(m);
+        s.push(m).unwrap();
     }
     let segs = s.commit(false).expect("commit must not error");
     assert!(
@@ -736,8 +753,10 @@ fn small_buffer_within_setback_yields_empty_commit() {
 #[test]
 fn smooth_shaper_holds_back_live_edge_inside_future_support() {
     let mut s = StreamState::new(cfg(), smooth_x_chains(0.5), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0));
-    s.push(line(2, [20.0, 0.0, 0.0], [40.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(2, [20.0, 0.0, 0.0], [40.0, 0.0, 0.0], 0.0))
+        .unwrap();
 
     assert!(
         s.commit(false).unwrap().is_empty(),
@@ -756,7 +775,7 @@ fn stall_brake_advances_a_frozen_frontier() {
     // of freezing it.
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.2, 0.0], 0.0);
     for m in short_collinear(4, 0.3) {
-        s.push(m);
+        s.push(m).unwrap();
     }
     assert!(s.commit(false).expect("commit must not error").is_empty());
     let segs = s
@@ -774,16 +793,48 @@ fn stall_brake_fails_loud_when_lead_already_collapsed() {
     // raises rather than scheduling a piece into the MCU's past.
     let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.2, 0.0], 0.0);
     for m in short_collinear(4, 0.3) {
-        s.push(m);
+        s.push(m).unwrap();
     }
     let err = s.commit_stall_brake(0.01, 0.05).unwrap_err();
     assert!(matches!(err, StreamError::BrakeToRestShortfall { .. }));
 }
 
 #[test]
+fn push_rejects_a_discontinuous_move() {
+    // Fail-loud (CLAUDE.md): real slicer output is position-contiguous. A move
+    // that does not start where the toolhead was left is a stitching bug
+    // upstream; reject it at ingress with the offending line named, instead of
+    // letting it surface as a `ZeroMotion` deep in the fitter.
+    let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    let err = s
+        .push(line(2, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap_err();
+    let StreamError::Discontinuity {
+        line_no, gap_mm, ..
+    } = err
+    else {
+        panic!("expected Discontinuity, got {err:?}");
+    };
+    assert_eq!(line_no, 2);
+    assert!((gap_mm - 50.0).abs() < 1e-9, "gap was {gap_mm}");
+}
+
+#[test]
+fn push_accepts_a_contiguous_chain() {
+    let mut s = StreamState::new(cfg(), AxisChainSet::default(), &[0.0, 0.0, 0.0], 0.0);
+    s.push(line(1, [0.0, 0.0, 0.0], [50.0, 0.0, 0.0], 0.0))
+        .unwrap();
+    s.push(line(2, [50.0, 0.0, 0.0], [50.0, 50.0, 0.0], 0.0))
+        .expect("a move starting where the last ended must be accepted");
+}
+
+#[test]
 fn smooth_shaper_first_commit_after_nonzero_start_time_is_valid() {
     let mut s = StreamState::new(cfg(), smooth_x_chains(18.0), &[0.0, 0.0, 0.0], 5.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0))
+        .unwrap();
 
     let committed = s.commit(true).unwrap();
     assert_eq!(committed[0].t_start, 5.0);
@@ -792,12 +843,14 @@ fn smooth_shaper_first_commit_after_nonzero_start_time_is_valid() {
 #[test]
 fn smooth_shaper_after_idle_gap_resumes_from_rest_edge() {
     let mut s = StreamState::new(cfg(), smooth_x_chains(18.0), &[0.0, 0.0, 0.0], 0.0);
-    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0));
+    s.push(line(1, [0.0, 0.0, 0.0], [20.0, 0.0, 0.0], 0.0))
+        .unwrap();
     let first = s.commit(true).unwrap();
     let idle_end = first.last().unwrap().t_end + 5.0;
 
     s.advance_idle(idle_end);
-    s.push(line(2, [20.0, 0.0, 0.0], [40.0, 0.0, 0.0], 0.0));
+    s.push(line(2, [20.0, 0.0, 0.0], [40.0, 0.0, 0.0], 0.0))
+        .unwrap();
     let second = s.commit(true).unwrap();
 
     assert!(second[0].t_start >= idle_end - 1e-9);
@@ -813,8 +866,8 @@ fn smooth_shaper_two_batch_output_matches_one_batch() {
     let mut one = StreamState::new(cfg(), chains.clone(), &[0.0, 0.0, 0.0], 0.0);
     let mut two = StreamState::new(cfg(), chains, &[0.0, 0.0, 0.0], 0.0);
     for m in moves {
-        one.push(m.clone());
-        two.push(m);
+        one.push(m.clone()).unwrap();
+        two.push(m).unwrap();
     }
 
     let one_batch = one.commit(true).unwrap();

--- a/rust/motion-engine/src/stream_planner.rs
+++ b/rust/motion-engine/src/stream_planner.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TrySendError, bounde
 use trajectory::{AxisChainSet, ShapedSegment};
 
 use crate::pump::AxisKey;
-use crate::stream::{StreamConfig, StreamState};
+use crate::stream::{StreamConfig, StreamError, StreamState};
 
 const LEAD: f64 = crate::anchor::DEFAULT_LEAD_SECS;
 
@@ -498,7 +498,7 @@ fn run_home_drip(
     let m =
         crate::classify::build_move(p.start, dx, dy, dz, 0, 0.0, state.limits(), p.speed_mm_s, 0)
             .map_err(|e| format!("HomeDrip build_move: {e:?}"))?;
-    state.push(m);
+    state.push(m).map_err(|e| format!("HomeDrip push: {e}"))?;
     let segs = state
         .commit(true)
         .map_err(|e| format!("HomeDrip commit: {e}"))?;
@@ -562,7 +562,7 @@ fn handle_move_arrival(
     m: geometry::Move,
     sync_instant: &mut Option<Instant>,
     tally: &mut IntakeTally,
-) {
+) -> Result<(), StreamError> {
     tracing::info!(
         subsystem = "motion",
         event = "pipe_ingress",
@@ -585,7 +585,7 @@ fn handle_move_arrival(
         state.restart_idle_timeline();
     }
     tally.record_intake(&m);
-    state.push(m);
+    state.push(m)
 }
 
 /// Handle one non-move control message. Returns `true` when the loop should
@@ -748,7 +748,8 @@ fn run_loop(
 
         match msg {
             StreamMsg::Move(m) => {
-                handle_move_arrival(&mut state, m, &mut sync_instant, &mut tally);
+                handle_move_arrival(&mut state, m, &mut sync_instant, &mut tally)
+                    .unwrap_or_else(|e| fatal(&format!("ingress: {e}")));
                 // Coalesce the burst up to COALESCE_BATCH_MOVES, then fit that
                 // batch ONCE. Committing per move re-fits the growing buffer each
                 // time (O(n²)); one fit per bounded batch is O(n) and keeps each
@@ -759,7 +760,8 @@ fn run_loop(
                 while state.buffered() < coalesce_cap {
                     match rx.try_recv() {
                         Ok(StreamMsg::Move(m2)) => {
-                            handle_move_arrival(&mut state, m2, &mut sync_instant, &mut tally);
+                            handle_move_arrival(&mut state, m2, &mut sync_instant, &mut tally)
+                                .unwrap_or_else(|e| fatal(&format!("ingress: {e}")));
                         }
                         Ok(other) => {
                             deferred = Some(other);


### PR DESCRIPTION
## What

Fixes the SIGABRT in `bridge::tests::shutdown_joins_planner_before_dropping_pump_receiver` and hardens the stream planner against non-contiguous move chains.

## Root cause

Bisected to merge #126 (the causal-fitter rewrite). It added `align_travels`, which snaps each travel move's endpoints onto its neighbours' endpoints — correctly assuming the move chain is **position-contiguous** (move N+1 starts where move N ended), as real slicer output always is.

The failing test submits identical `[0,0,0]→[50,0,0]` moves — every move teleports back to the origin. For move 0, `align_travels` overwrites its true endpoint `[50,0,0]` with the *next* move's start `[0,0,0]`, collapsing it to a zero-length line → `GeometryError::ZeroMotion` → `FitError::Internal` → the planner's fail-loud path `abort()`s the process. The pre-#126 fitter had no such pass, so it tolerated the synthetic input.

Verified in isolation: 2+ non-contiguous moves fail; the same count of contiguous collinear moves fit cleanly. The production fitter is sound on real geometry.

## Changes

- **Test fix:** the shutdown-ordering test now threads a running start position so submitted moves are contiguous, matching what the planner sees in practice. (Its actual job — exercising shutdown ordering under a move flood — is unchanged.)
- **Fail-loud guard:** `StreamState::push` now rejects a move whose spatial start does not meet the expected toolhead position (previous buffered move's end, or the committed odometer) as `StreamError::Discontinuity`, naming the offending line and the gap — caught at ingress instead of surfacing as a confusing `ZeroMotion` deep in the fitter. `push` now returns `Result`; callers route the error through the planner's existing `fatal()` path. Added unit tests for both the reject and accept paths.

## Testing

- `cargo nextest run -p motion-engine` — 349 passed
- Full workspace suite green (one unrelated `ethercat-rt` socket-streaming test is flaky under parallel load; passes 3/3 in isolation)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean