### PR TITLE
fix(motion): key motion history by host schedule time (z_tilt beacon crash)

### DIFF
--- a/_bmad-output/brainstorming/brainstorming-session-2026-06-28-clock-monotonicity.md
+++ b/_bmad-output/brainstorming/brainstorming-session-2026-06-28-clock-monotonicity.md
@@ -1,0 +1,37 @@
+---
+stepsCompleted: [1]
+inputDocuments: ['_bmad-output/implementation-artifacts/investigations/trident-homing-ztilt-crash-investigation.md']
+session_topic: 'Fixing the motion-history monotonicity panic (host→MCU clock projection jitter) without losing trajectory optimality'
+session_goals: 'Enumerate candidate solutions AND the problems each one might cause; converge on the architecturally-correct direction'
+selected_approach: 'Progressive flow: diverge on solution candidates, then adversarial pre-mortem on each'
+techniques_used: []
+ideas_generated: []
+context_file: ''
+---
+
+# Brainstorming Session Results
+
+**Facilitator:** dderg
+**Date:** 2026-06-28
+
+## Session Overview
+
+**Topic:** Fixing the motion-history monotonicity panic (`HistoryStore::record` assert at
+`motion_history.rs:138`) — caused by re-projecting host time through a live, re-fit clock-sync model
+between dispatches, so host-monotonic piece order does not survive into MCU clocks.
+
+**Goals:** Generate the full space of candidate solutions, and for each, surface the problems /
+failure modes it might introduce. Converge on a direction that holds the non-negotiables: print
+throughput / trajectory optimality, fail-loud philosophy, and monotonic-by-construction scheduling.
+
+### Confirmed root-cause facts (from investigation case file)
+- Panic: `out-of-order piece for AxisKey { mcu_id: 1, axis: 2 }: 447537601286 < 447537603339` (Z, 2053-tick regression).
+- `start_clock = PieceEntry.start_time = project(mcu_id, host_secs)`, `host_secs = t0 + curve_u_start + sub_offset` (monotonic in host time).
+- `project` = `router.host_time_to_mcu_clock` — live clock model re-fit between dispatches → backward µs-scale jitter.
+- Same drift surfaces as the soft homing warning `stale print_time … lead=21.4ms`.
+- `record()` runs before `pump_tx.send()`, so the host aborts before the overlapping piece hits the MCU.
+
+### Session Setup
+Progressive flow — first diverge widely on solution candidates (no filtering), then run an adversarial
+pre-mortem per candidate. Facilitated collaboratively; ideas count when developed in dialogue.
+

--- a/_bmad-output/implementation-artifacts/investigations/trident-homing-ztilt-crash-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/trident-homing-ztilt-crash-investigation.md
@@ -1,0 +1,376 @@
+# Investigation: Trident homing stale-schedule warning + z_tilt_adjust crash
+
+## Hand-off Brief
+
+1. **What happened.** On the Trident, `Z_TILT_ADJUST` randomly crashes with `KeyError: 'pos'`
+   (`beacon.py:544`): the beacon proximity probe is a Z-only move, and any dispatch **re-anchor**
+   during the slow descend runs the engine's **global `motion_history.clear()`**
+   (`rust/motion-engine/src/bridge.rs:3285`), which wipes stationary X/Y endpoints the Z-only
+   segment never re-records → `position_at_clock` can't return x/y → returns `None` → the sample
+   gets no `pos` → beacon's unguarded `samples[0]["pos"]` crashes the host. Confirmed end-to-end.
+2. **Where the case stands.** Root cause Confirmed, High confidence. The PG5 stale-print_time
+   warning, `seg0_deficit` (always +250 ms healthy lead), and the once-per-session window-miss
+   warning are all **noise/red herrings**, refuted as the cause. The older -308/-310 MCU faults are
+   a **separate** bug (Bug B).
+3. **What's needed next.** Fix the engine root: on re-anchor, **rebase per-axis to the held
+   endpoint** (`motion_history.rs:161` `rebase_axis`) instead of the global `clear()`, so stationary
+   axes still answer position queries; add a fail-loud guard in beacon's `_probe` for a missing
+   `pos`. Then verify on the bench with repeated `Z_TILT_ADJUST`.
+
+## Case Info
+
+| Field            | Value                                                                      |
+| ---------------- | -------------------------------------------------------------------------- |
+| Ticket           | N/A                                                                        |
+| Date opened      | 2026-06-28                                                                 |
+| Status           | Concluded — root cause Confirmed (High); fix direction open                |
+| System           | Trident bench (`dderg@trident.local`), H723 main 'main' + F446 bottom 'bottom'; branch `trident-crash` |
+| Evidence sources | `klippy/mcu.py`, z_tilt_ng/probe code, VictoriaLogs (Trident), prior case files |
+
+## Problem Statement
+
+User report: "sometimes when I start homing I get `digital_out PG5 on mcu 'bottom' scheduled with
+stale print_time: print_time=302.508044 estimated_now=302.486613 lead=21.4ms (< 50ms)` in console.
+It doesn't crash; I retry homing and it works. Then during z_tilt_adjust it randomly crashes —
+sometimes right away, sometimes after a few probing cycles, sometimes it finishes the cycle
+correctly, but more often than not it crashes."
+
+Premise check (pending): the two symptoms are treated as one disease (insufficient scheduling lead
+after queue drain). To be confirmed/refuted by the crash fault evidence.
+
+## Evidence Inventory
+
+| Source   | Status    | Notes     |
+| -------- | --------- | --------- |
+| `klippy/mcu.py:482-509` `MCU_digital_out.set_digital` | Available | Stronghold — emits Symptom A's exact warning when `print_time < est + MIN_SCHEDULE_LEAD` |
+| `MIN_SCHEDULE_LEAD = 0.050` (`klippy/mcu.py:25`) | Available | 50 ms host guard; lead observed 21.4 ms |
+| Guard origin commit `0a90fb4ad` (2026-06-10, dderg) | Available | "mcu: reject stale-print_time digital_out schedules on the host" — guard is the user's own fail-loud check |
+| Trident VictoriaLogs (z_tilt crash session) | **Missing** | Decisive: actual MCU fault code + event chain during a crash |
+| Prior case `piece-start-in-past-clock-rebase-investigation.md` | Available | Same family (clock projection → -308) on Neptune under print load |
+| Trident `printer.cfg` (what PG5 is) | Partial | Need to confirm PG5 = motor-enable / probe / output pin on 'bottom' |
+
+## Investigation Backlog
+
+| # | Path to Explore | Priority | Status | Notes |
+| - | --------------- | -------- | ------ | ----- |
+| 1 | Query Trident VL for the z_tilt_adjust crash fault code + chain | High | Open | Decisive; user can reproduce |
+| 2 | Identify what PG5 on 'bottom' is and what schedules its digital_out at homing start | High | Open | Pins whether it's motor-enable, probe, or output_pin |
+| 3 | Trace how the rewritten pipeline seeds/advances print_time after the move queue drains (homing/dwell) | High | Open | Suspected disease — analog of Klipper BUFFER_TIME_START / min_restart_time |
+| 4 | Compare host `estimated_print_time` vs scheduled print_time during sparse ops | Medium | Open | Distinguishes lead-collapse from clock-projection skew |
+
+## Confirmed Findings
+
+### Finding 1: `seg0_deficit ≈ +250 ms` is healthy designed lead, not "in the past"
+
+**Evidence:** `rust/motion-engine/src/anchor.rs:62` sets `t0 = host_now + lead_secs − seg_t_start`
+with `DEFAULT_LEAD_SECS = 0.25` (anchor.rs:2); `seg0_deficit` (`router.rs:532`) =
+`start_time − ack_now` = `host_now + 0.25 − now` ≈ +250 ms. It is logged on every `fresh` anchor
+(bridge.rs:3237-3242). The log string itself reads "negative deficit_us => in past".
+
+**Detail:** The ~250 ms `seg0_deficit` the first log pass flagged as "250 ms behind" is a POSITIVE
+lead — the intended 0.25 s cushion. It is always-on noise on every re-anchor, NOT the anomaly.
+(User flagged this; Confirmed.)
+
+### Finding 2: Every re-anchor unconditionally wipes motion history
+
+**Evidence:** `rust/motion-engine/src/bridge.rs:3285-3290` — `if fresh { motion_history…clear() }`.
+`clear()` (motion_history.rs:156-159) drops all per-axis rings + endpoints.
+
+**Detail:** `anchor_segment` (anchor.rs:36-66) returns `fresh = true` on first segment,
+`timeline_reset` (`seg_t_start < last_t_end`, i.e. idle/stream restart), or `underrun`
+(`t0 + seg_t_start < host_now`, the playhead overran a thinly-committed slow segment). Slow homing
+and beacon-probe moves live in exactly this regime, so re-anchors — and history wipes — are frequent
+there, and rare during a continuous buffered print.
+
+### Finding 3: The crash is a silent missing-axis `None` from `position_at_clock`, not the warned window-miss
+
+**Evidence:** Log facts (re-query): `seg0_deficit` is always **+250 ms, never negative** (7d negative
+count = 0) — pure noise. The `beacon: dropping stream sample … precedes retained motion history`
+warning fires **once per session in ~50 sessions, crash and healthy alike** (a startup artifact); in
+the crash session it fired **18 s before** the KeyError. The crash discriminator is **`KeyError:
+'pos'`** (`exception` field, `beacon.py:544 samples[0]["pos"]`), present in exactly 4 sessions, all
+Z_TILT/probe. **No warning precedes the KeyError** → the `None` came from a silent path, not the
+warned `BeforeRetainedWindow` (which warns on first occurrence, `beacon_motion_engine.py:227-237`).
+
+**Detail:** The silent path is the missing-axis one: `motion_state_at_clock` (`bridge.rs:4496-4499`)
+**skips `NoHistoryForAxis` axes with `continue`**, returning a dict missing those axes; the seam
+`position_at_clock` (`beacon_motion_engine.py:212-219`) does `state["x"][0], state["y"][0],
+state["z"][0]` and on `KeyError` returns `None` — no log. `beacon.py:952-953` only sets
+`sample["pos"]` when `pos is not None`, so the sample has no `'pos'`; `_probe` (`beacon.py:544`)
+reads `samples[0]["pos"]` unconditionally → `KeyError: 'pos'` → `Internal error on command
+"Z_TILT_ADJUST"` → host commands shutdown (mcu/bottom reason "Command request").
+
+### Finding 4: Re-anchor `clear()` wipes stationary X/Y, which a Z-only probe never re-records — the root
+
+**Evidence:** `clear()` wipes **both** `rings` and `endpoints` for **all** axes
+(`motion_history.rs:156-159`). `state_at_clock` returns `NoHistoryForAxis` when an axis has neither
+ring nor endpoint (`motion_history.rs:198-201`). A beacon proximity descend is a **Z-only** move; the
+re-anchored segment re-records only Z (`bridge.rs:3291-3301`), so X/Y stay empty after the wipe.
+
+**Detail:** The probe descend is slow and thinly-committed → underrun-prone → `fresh` re-anchor
+during the descend → global `clear()` → X/Y lose ring + endpoint → `position_at_clock` returns
+`None` (Finding 3) → crash. Because a stationary axis had a valid held position that `clear()`
+needlessly discarded (vs `rebase_axis`, which preserves an endpoint), the engine throws away
+answerable state. This is the proximate root: the global wipe is too aggressive.
+
+### Finding 5: -308/-310 (06-23…06-27) is a SEPARATE bug, not this crash
+
+**Evidence:** Those sessions show MCU shutdown reason **"kalico runtime fault"** with a real fault
+code and **no `KeyError`**; several began "automated MCU restart … was in shutdown state at config
+time". The Z_TILT crash sessions show host reason **"Command request"**, `KeyError 'pos'`, **no fault
+code**. (Log re-query.)
+
+**Detail:** Premise correction: the user's reproducible Z_TILT crash is Bug A (host beacon
+`KeyError`). The older MCU `PieceStartInPast`/`StepsPerSampleExceeded` faults are Bug B, a distinct
+issue (likely during actual motion / restart recovery). They share only the background noise
+(`seg0_deficit`, once-per-session beacon-drop).
+
+### Finding 6: A continuous print avoids the bug (explains the one successful print)
+
+**Evidence:** Deduced from Findings 2-3. A buffered print keeps the committed frontier
+`buffer_time` ahead of the playhead (anchor.rs:24-26 doc), so no underrun, no `timeline_reset`, no
+`fresh` → motion history accumulates uninterrupted → beacon queries always land inside the window.
+
+## Hypothesized Paths
+
+### Hypothesis 1: Print_time lead collapses below the MCU safety margin after the queue drains
+
+**Status:** Refuted (as the crash cause) — Partially confirmed for Symptom A only
+
+**Resolution:** The z_tilt crash is NOT a lead-collapse / scheduling-in-past event. `seg0_deficit`
+never goes negative (+250 ms designed lead). The crash is the beacon `KeyError 'pos'` from a
+re-anchor history wipe (Findings 3-4). The "lead collapse" idea survives only for **Symptom A** (the
+PG5 21 ms warning), which is a genuine but separate, non-fatal host-guard event — see Side Findings.
+
+**Theory:** During homing and between z_tilt probe points the move queue drains; the rewritten
+pipeline fails to re-seed the toolhead print_time far enough ahead of `estimated_print_time`, so
+the next scheduled command lands with tiny lead. The host guard catches the digital_out case
+(Symptom A, non-fatal); a stepper/piece schedule with no equivalent host guard slips into the
+MCU's past → hard fault → crash (Symptom B).
+
+**Supporting indicators:** Both symptoms occur in sparse, probe-heavy, low-velocity contexts (not
+under print throughput load); lead observed at 21.4 ms (positive but small); the guard is brand new
+so previously these slipped through to the MCU silently.
+
+**Would confirm:** Crash fault is a "start in past" / "timer too close" class fault on 'bottom'
+during a probe move, correlated with a collapsed host lead just before it.
+
+**Would refute:** Crash fault is unrelated (e.g. comms/USB, watchdog, an assert in z_tilt math), or
+the lead is healthy at crash time.
+
+### Hypothesis 2: Same clock-projection divergence as the prior case (two writers feed the anchor)
+
+**Status:** Refuted
+
+**Theory:** The host→MCU clock anchor is biased by a competing writer (per
+`piece-start-in-past-clock-rebase`), making projected start_times early relative to the MCU.
+
+**Supporting indicators:** Prior case Confirmed this mechanism on Neptune; lead=21.4 ms is within
+the scale of projection excursions.
+
+**Would confirm:** VL shows `set_clock_est_rebased` / projection-divergence events on Trident around
+the crash, matching the prior signature.
+
+**Would refute:** Crash correlates with queue-drain lead collapse, not with a clock rebase event.
+
+**Resolution:** No `set_clock_est_rebased` / `junction_jump_anomalous` / `projection_divergence`
+events occur in any of the 4 crash sessions. Refuted.
+
+## Conclusion
+
+**Confidence:** High — root cause Confirmed end-to-end in code and corroborated by the log crash
+signature; only the exact `None` sub-path (silent missing-axis vs repeat silent window-miss) carries
+minor uncertainty, and both reduce to the same root.
+
+**Root cause (z_tilt crash, "Bug A"):** A beacon proximity probe is a Z-only move. The dispatch
+anchor re-anchors (`fresh`) on the slow, thinly-committed descend (underrun) or on idle restart, and
+**every re-anchor calls the global `motion_history.clear()`** (`bridge.rs:3285`), wiping the rings
+**and endpoints** of *all* axes — including stationary X/Y, which the Z-only segment never
+re-records. `position_at_clock` then needs x, y, z but X/Y are `NoHistoryForAxis`
+(silently skipped by `motion_state_at_clock`, `bridge.rs:4498`) → the seam returns `None`
+(`beacon_motion_engine.py:217-219`) → beacon never sets `sample["pos"]` → `_probe`'s unconditional
+`samples[0]["pos"]` (`beacon.py:544`) raises `KeyError: 'pos'` → host shutdown. The race (a re-anchor
+landing during the probe) explains the intermittency; a continuous print keeps all axes populated,
+explaining the single successful print.
+
+Two cooperating defects: the engine's **over-broad history wipe** (root) and beacon's **unguarded
+`samples[0]["pos"]`** (proximate amplifier that turns a transient `None` into a fatal `KeyError`).
+
+## Recommended Next Steps
+
+### Fix direction
+
+- **Engine (root, preferred): stop the global wipe from destroying answerable state for axes not in
+  the re-anchored segment.** On `fresh`, instead of `motion_history.clear()` (which drops endpoints
+  for every axis), **rebase each axis to its current held endpoint at the new baseline** (the
+  `rebase_axis` path already exists, `motion_history.rs:161-164`) — or clear only the axes the new
+  segment will re-record. A stationary axis then still answers `state_at_clock` with its hold
+  position, so `position_at_clock` returns a full x/y/z and the beacon sample keeps its `pos`. This
+  removes the crash *and* preserves correctness. (`rust/motion-engine/src/bridge.rs:3281-3301`,
+  `rust/motion-engine/src/motion_history.rs`.)
+- **Beacon (defense in depth / fail-loud):** `_probe` should not assume `samples[0]["pos"]` exists.
+  Either retry/skip samples lacking `pos`, or raise a clear `command_error` ("beacon sample lacked a
+  resolvable toolhead position") instead of a bare `KeyError`. This is the external beacon fork
+  (`~/klipper/klippy/extras/beacon.py:544,567`); a host KeyError that aborts a probe is exactly the
+  "fail loudly with a clear error" the project mandates — make the failure legible, but fix the
+  engine so it does not occur.
+- Do **not** widen `MIN_SCHEDULE_LEAD` or touch `seg0_deficit` — both are red herrings here.
+
+### Diagnostic (to confirm before/after a fix)
+
+- Add (temporarily) a one-line warn in `motion_state_at_clock` when it `continue`s on
+  `NoHistoryForAxis` (currently silent) — it would have named the missing axis at crash time.
+- Reproduce with `Z_TILT_ADJUST` and watch for `[anchor-decision] condition=reanchor` /
+  `anchor_underrun` events interleaved with the probe; correlate a re-anchor immediately preceding a
+  `position_at_clock` → `None`. LogsQL: `event:anchor_underrun OR _msg:"anchor-decision"` within the
+  probe window.
+
+## Reproduction Plan
+
+1. Home, then run `Z_TILT_ADJUST` repeatedly on the Trident with the beacon probe.
+2. Expected (pre-fix): intermittent `KeyError: 'pos'` (`beacon.py:544`) → `Internal error on command
+   "Z_TILT_ADJUST"` → host shutdown, more often than not, correlated with an `anchor_underrun` /
+   `reanchor` during the slow descend.
+3. Post-fix (engine rebase): no `KeyError`; `position_at_clock` returns full x/y/z across re-anchors.
+
+## Side Findings
+
+- **Symptom A (the PG5 stale-print_time warning) is a separate, non-fatal issue.** `digital_out PG5
+  on mcu 'bottom'` is scheduled at homing start with ~21 ms lead, below the 50 ms `MIN_SCHEDULE_LEAD`
+  host guard (`mcu.py:25,490`), 5 occurrences in 7d, all ~21-22 ms. The guard (commit `0a90fb4ad`)
+  catches it and the retry succeeds. It co-locates with the crash sessions only because both arise
+  from the same sparse homing/probe regime, not because one causes the other. Worth a follow-up:
+  why a homing-start digital_out lands with only ~21 ms lead (idle-restart print_time seeding).
+- **`seg0_deficit` and the once-per-session beacon window-miss warning are background noise** — neither
+  is diagnostic of the crash. Consider down-ranking `seg0_deficit` from `warn` to `debug` to reduce
+  noise (it logs on every re-anchor with the healthy +250 ms lead).
+- **Bug B (older -308/-310 MCU faults)** remains unaddressed and distinct — track separately if it
+  still reproduces.
+
+## Source Code Trace
+
+| Element       | Detail                                      |
+| ------------- | ------------------------------------------- |
+| Error origin (crash) | `beacon.py:544` `samples[0]["pos"]` → `KeyError: 'pos'` |
+| Proximate cause | `position_at_clock` returns `None` (`beacon_motion_engine.py:212-219`) because the engine dict lacks x/y |
+| Root cause | global `motion_history.clear()` on re-anchor (`rust/motion-engine/src/bridge.rs:3285`) wipes stationary X/Y endpoints; Z-only probe never re-records them → `NoHistoryForAxis` skipped at `bridge.rs:4498` |
+| Trigger       | `fresh` re-anchor (`anchor.rs:36-66`: underrun on slow Z descend, or idle restart) during a beacon probe |
+| Related files | `rust/motion-engine/src/{bridge.rs,anchor.rs,motion_history.rs}`; `klippy/extras/beacon.py`, `klippy/extras/beacon_motion_engine.py` (external fork) |
+| Symptom A origin (separate) | `klippy/mcu.py:490-502` `MCU_digital_out.set_digital` — non-fatal host guard, ~21 ms lead on PG5 at homing start |
+
+## Follow-up: 2026-06-28 — fix applied
+
+### Engine (root)
+`rust/motion-engine/src/motion_history.rs`: replaced `HistoryStore::clear()` (which dropped rings
+**and** endpoints for all axes) with `drop_pieces_on_reanchor()` — clears only the ring pieces and
+**keeps each axis's endpoint**. The re-anchor call site (`bridge.rs:3285`) now calls it. A stationary
+axis the re-anchored Z-only probe segment never re-records now answers `state_at_clock` with its held
+position instead of `NoHistoryForAxis`, so `position_at_clock` returns a full x/y/z and the beacon
+sample keeps its `pos`. Strictly improves `final_position` consumers (bridge.rs:3845, homing.rs:85),
+which previously defaulted/errored on the wiped endpoints. New unit test
+`drop_pieces_on_reanchor_keeps_unrecorded_axis_answerable`; full motion-engine + host-rt suites green
+(641 passed).
+
+### Beacon (fail-loud defense in depth)
+`~/Developer/beacon_klipper/beacon.py`: added `_require_sample_pos(samples)` — returns the first
+sample with a resolvable `pos`, else raises a clear `command_error` instead of a bare `KeyError:
+'pos'`. `_probe` now routes both `samples[0]["pos"]` accesses (lines 544, 567) through it.
+
+### Log clarity (prior turn)
+`seg0_deficit` → `seg0_lead` (`lead_us`/`lead_ticks`, positive = healthy lead); now `debug` when
+healthy and a distinct `seg0_start_in_past` **warn** only when genuinely negative.
+
+### Status: Concluded — fixes applied, pending bench verification (rebuild host `.so` + redeploy beacon, repeat `Z_TILT_ADJUST`).
+
+## Follow-up: 2026-06-28 #2 — "crashed just like before" — premise does not match evidence
+
+User reports the crash recurred after deploy. Evidence on the bench contradicts a recurrence of the
+original z_tilt `KeyError: 'pos'`:
+
+### Confirmed — both fixes ARE deployed and active
+- Engine: `~/klipper/klippy/_motion_engine.so` rebuilt 2026-06-28 12:28:42 (+0200), AFTER fix commit
+  `0ffad2f89` (12:13). `strings` shows `seg0_lead`, `seg0_start_in_past`, and `drop_pieces_on_reanchor`
+  (×2). The old `seg0_deficit` log is gone from the new binary.
+- Beacon: `beacon.py` symlinks to `~/beacon_klipper` on `fix/probe-resolve-toolhead-pos` (`d5237e6`,
+  has `_require_sample_pos`); `.pyc` rebuilt 12:29.
+- Note: healthy `seg0_lead` is now `debug`-level → filtered from VictoriaLogs. Its absence in VL does
+  NOT mean the old `.so` — corrected an earlier mis-read.
+
+### Confirmed — the original crash has NOT recurred since deploy
+- Last `KeyError: 'pos'` / `Internal error on command "Z_TILT_ADJUST"`: 09:23–09:24 UTC, sessions
+  k-1782638256-4226 / k-1782638626-4437 — both BEFORE the ~10:28 UTC deploy.
+- Post-deploy sessions k-1782642561-7265 (10:29) and k-1782643050-7469 (10:37, current) show only
+  startup (Args, Config file); **no G28 / Z_TILT / probe / "ready" / trigger events** — the printer
+  was not driven to z_tilt. The new beacon fail-loud message never fired either.
+
+### New issue A (non-fatal): `Failed to load module 'beacon_kalico'` every boot
+- `printer.py:135 import_module('klippy.extras.beacon_kalico')` → `ModuleNotFoundError`. Active config
+  has `[beacon]`, NOT `[beacon_kalico]`; no active `.py`/`.cfg` references `beacon_kalico` (only `.bak`
+  configs + log files). A stale **dangling symlink** `extras/beacon_kalico.py → ~/beacon_klipper/beacon_kalico.py`
+  (renamed away) remains. klippy continues past it (MCUs come up), so non-fatal — but it should be
+  cleaned and the source of the optional load request identified.
+
+### New issue B (one-time): MCU-reset / USB-burst storm in session 7265
+- 10:29:42 UTC: `runtime.mcu_reset` (×2), `runtime.isr_phase ring_overflow=82000`,
+  `runtime.block_source usb_burst=138295 cyc`, `diag.tx_drop_kalico/klipper`, `attach_open_retry`,
+  then `pump send_mcu_frames failed` (×2) at 10:36:58. Did NOT recur in session 7469. This is an
+  MCU-comms/firmware-class event, orthogonal to the motion_history bug — needs the `mcu-diagnostics`
+  skill if it is what the user actually hit.
+
+### Open question (blocking): which crash did the user see, and when?
+The evidence shows the original bug fixed-and-not-recurring, plus two unrelated new signals. Need the
+user to (a) state the exact console text + approximate time, or (b) re-run `G28` + `Z_TILT_ADJUST`
+now so a live post-deploy session can be captured.
+
+### Status: Active — awaiting user repro/clarification; original root cause remains fixed per binary + log evidence.
+
+## Follow-up: 2026-06-28 #3 — CONFIRMED root cause of the live crash: motion-history monotonicity panic
+
+The user re-ran the flow ("crashed, just says moonraker can't connect to klipper"). This is a **different**
+root cause than the original Python `KeyError: 'pos'` (which remains fixed) — a hard **Rust panic** that
+aborts the planner thread.
+
+### Confirmed (journald, session PID 8062, crash at 13:10:47 local)
+- `systemd: klipper.service: Main process exited, code=killed, status=6/ABRT` → klippy dies → moonraker
+  cannot connect. Auto-restarted 13:10:57.
+- Panic: `thread 'kalico-stream-planner' panicked at motion-engine/src/motion_history.rs:138:13`
+  - `out-of-order piece for AxisKey { mcu_id: 1, axis: 2 }: 447537601286 < 447537603339`
+  - axis 2 = **Z**; regression = **2053 ticks** (~µs-scale, NOT a re-anchor baseline jump).
+- Backtrace: `HistoryStore::record` (motion_history.rs:138) ← `init_planner::{{closure}}` (bridge.rs:3296)
+  ← `dispatch_committed` (stream_planner.rs:447) ← `run_loop` (stream_planner.rs:736), spawned thread.
+- Bench HEAD == worktree HEAD == `0ffad2f89` (line numbers authoritative).
+- Pre-restart klippy.log ends abruptly mid-probe (Z lift to 8, then fast XY travel to 270,5) with no
+  Python traceback — consistent with the native abort.
+
+### Deduced (High confidence) — mechanism
+- `HistoryStore::record` (motion_history.rs:138) asserts `piece.start_clock >= last.start_clock` per
+  (mcu,axis) ring — the fail-loud monotonicity guard. It fired with a `last` present, so the crashing
+  dispatch recorded against an existing baseline (non-`fresh`, or the segment right after a `fresh` one).
+- `start_clock = PieceEntry.start_time` (motion_history.rs:50), set in enqueue.rs:210-211:
+  `host_secs = t0 + curve_u_start + sub_offset` (monotonic in HOST time) → `start_time =
+  project(mcu_id, host_secs)` where `project` = `router.host_time_to_mcu_clock` (bridge.rs:3245-3248).
+- `host_time_to_mcu_clock` uses the **live clock-sync model, re-fit between dispatches**. A
+  later-in-host-time piece in the next segment can project to a slightly EARLIER MCU clock than the
+  prior dispatch's last piece (here 2053 ticks). Host-monotonic ordering does not survive projection
+  through a mutating clock model → the assert trips → panic → SIGABRT.
+- Same projection drift produces the soft homing warning the user reports
+  (`stale print_time … lead=21.4ms (< 50ms)`). One root cause, two surfaces (soft at homing, hard in
+  history record). Z-during-probing is most exposed: many tiny, closely-spaced moves → inter-piece
+  clock gaps small enough for projection jitter to flip their order. Explains "sometimes right away,
+  sometimes after a few cycles, sometimes finishes."
+- record() runs BEFORE pump_tx.send (bridge.rs:3296 then 3300), so the host aborts before the
+  overlapping piece reaches the MCU — hence no MCU-side complaint at the crash.
+
+### Fix direction (needs user decision — architectural)
+- **(B, recommended) Make the per-stream host→MCU projection monotonic by construction.** Anchor the
+  MCU-clock origin once per stream/re-anchor and derive each piece's start_time from accumulated
+  durations off that anchor (or carry the last dispatched MCU clock forward so each segment starts
+  exactly where the previous ended), instead of re-projecting each dispatch through the live model.
+  Removes the jitter at the source, also fixes the soft homing "stale print_time" warning, and matches
+  the project's "fail loudly / monotonic-by-construction" philosophy. The wire schedule shares
+  `start_time`, so this is a motion-correctness fix, not just an observability one.
+- **(A, not recommended) Relax/clamp the history assert** (e.g. `start_clock = max(start_clock, last)`).
+  Papers over the symptom in the derived lookup structure, diverges history from the wire, and violates
+  CLAUDE.md "do not advance/pad times — raise an error."
+
+### Status: Active — root cause CONFIRMED (High). Awaiting user decision on fix direction (B recommended).

--- a/_bmad-output/planning-artifacts/plan-history-host-time-keying.md
+++ b/_bmad-output/planning-artifacts/plan-history-host-time-keying.md
@@ -1,0 +1,96 @@
+# Implementation Plan — Key motion history in host (schedule) time
+
+**Date:** 2026-06-28
+**Branch:** trident-crash
+**Driving defect:** `HistoryStore::record` panic at `motion_history.rs:138` → `SIGABRT` → klippy dies → "moonraker can't connect." See investigation case file and the brainstorm/research/party-mode artifacts.
+
+## One-line
+Re-key the motion-history ring on the planner's **host schedule time** (`t0 + u`, monotone by construction) instead of the projected per-axis **MCU clock tick** (non-monotone across dispatches because the host→MCU projection is re-fit between them). The wire schedule is unchanged. The crashing assert becomes monotone-by-construction; the panic demotes to a clean fail-loud fault.
+
+## Why this is the right key (settled by code + adversarial review)
+- `start_clock = PieceEntry.start_time` (`motion_history.rs:50`) is the **raw transmitted MCU tick**, computed once in `enqueue_segment` (`enqueue.rs:211` `project(mcu_id, host_secs)`) and used for BOTH the history ring (`bridge.rs:3296`) and the wire (`bridge.rs:3300`).
+- The tick is **not** monotone by construction: it is `host_secs` projected through the live clock-sync regression, which is re-fit between dispatches, so consecutive segments can produce a backward tick (the crash: `447537601286 < 447537603339`, Z, 2053 ticks).
+- `host_secs = t0 + curve_u_start + sub_offset` (`enqueue.rs:210`), `t0 = host_now + lead_secs − seg_t_start` (`anchor.rs:61`), `host_now` = MCU `est_print_time` projected into host-seconds (`anchor.rs:20`). This is **pure planner arithmetic**: monotone within a segment, `t0` advances across segments, immutable once recorded (`drop_pieces_on_reanchor` *clears*, never *revises*).
+- **`_host_t` is already computed and discarded** at the record site (`bridge.rs:3296` `for (piece, _host_t) in &m.pieces`). The fix keeps it.
+- All 10 history readers are host-time-natural or position-only; the two cross-MCU readers (`motion_state_at_clock` beacon-Z, `homing.rs:75` trip reconstruction) **already pivot through host-seconds** via `clock_between_mcus` (`motion_history.rs:228-233`). Host-time keying *removes* the second projection hop (host→target-MCU) rather than adding one — strictly fewer clock models in the metrology path.
+- The wire keeps its two authoritative past-time guards, independent of the history: host-side `motion_core.rs:114-128` `FaultCode::PieceStartInPast (-308, 200µs)` and MCU-side `sched.c:182-183` `try_shutdown("Timer too close")`. The history monotonicity check was a redundant *third*, process-fatal authority on a derived structure.
+
+## Acceptance gates (from the party-mode panel — all four are blocking)
+1. **Shadow residual (Murat).** Keep a parallel stepper-clock lookup and, on every probe/homing query, compare host-keyed vs stepper-clock-keyed position; divergence beyond tolerance → loud structured fault. Restores the canary the demotion removes; aimed at frame-drift. **No shadow residual, no merge.**
+2. **Eval-in-`u` + finiteness (Amelia).** Within-piece eval uses normalized `u = ((host_t − start_host) / duration_secs).clamp(0,1)` — never a clock projection. `is_finite` asserts on every record key and every query, *before* `partition_point` (a NaN silently corrupts the partition). Keep hard aborts for non-finite and for post-selection `u ∉ [0,1]`.
+3. **Typed single transition map + epoch identity (Winston/Amelia).** One clock-domain transition function used everywhere; `HostSecs`/`McuClock` newtypes so the compiler refuses an unconverted cross-domain lookup. Assert the history `t0` clock epoch ≡ the clocksync host epoch (today both are the router host-seconds domain — make it explicit).
+4. **Reanchor drop scope (Amelia).** Confirm `drop_pieces_on_reanchor` only discards the re-anchored future tail, never the executed prefix; with host-time keying it likely needs to drop **only on a genuine timeline reset** (`seg_t_start + EPS < last_t_end`, `anchor.rs:40`), and can *retain* history across an underrun re-anchor (t0 jumps forward → keys stay monotone) — which is strictly better for probe coverage.
+
+## Design — data and APIs (`rust/motion-engine/src/motion_history.rs`)
+`HistoryPiece` gains the host key and retains the clock fields for the shadow:
+```
+struct HistoryPiece {
+    start_host: f64,      // NEW primary key (schedule time)
+    start_clock: u64,     // retained for shadow-residual lookup
+    end_clock: u64,       // retained for shadow eval
+    duration_secs: f32,
+    coeffs: [f32; 4],
+}
+// end_host is derived: start_host + f64::from(duration_secs)
+```
+- `record(key, host_secs: f64, entry: &PieceEntry, nominal_freq_hz) -> Result<(), HistoryError>`
+  - `assert!(host_secs.is_finite())`.
+  - monotone check vs `ring.back()`: `host_secs >= last.start_host` (non-strict — equal allowed for zero-length pieces; lookup take-last resolves it). On violation return `Err(HistoryError::OutOfOrderPiece{..})` — **no panic**.
+- `state_at_host(key, host_t: f64, now_host: Option<f64>) -> Result<AxisState, HistoryError>`
+  - `assert!(host_t.is_finite())`, `partition_point(|p| p.start_host <= host_t)`, eval normalized `u`, future-guard `host_t > now_host`.
+- `eval_state(piece, host_t)`: `u = ((host_t − start_host) / duration_secs).clamp(0,1)`; `assert!((0.0..=1.0).contains(&u_unclamped) within slop)`; position/velocity/accel as today (velocity/accel already use `duration_secs`, unchanged).
+- New free fn `clock_to_host(router, source, clock) -> Result<f64,_>` = the first hop of today's `clock_between_mcus`; the second hop is deleted from the query path.
+- `HistoryError::OutOfOrderPiece { key, host_secs, last_host }` (clean-fault variant).
+
+## Design — shadow residual (gate 1)
+On the low-frequency query paths only (beacon `motion_state_at_clock`, homing `reconstruct_axis_position`):
+- Primary: `pos_host = state_at_host(key, host_t, ..)`.
+- Shadow: project `host_t → tick = host_time_to_mcu_clock(target, host_t)` (the hop removed from the primary), select by `start_clock`, eval → `pos_clock`.
+- If `|pos_host − pos_clock| > RESIDUAL_TOL` → `fault`/structured warn via the event pipeline (`event_log_emit`), carrying both positions and the offending key/clock. Always on; cost is per-sample, not per-tick.
+
+## File-by-file change list
+- `motion_history.rs` — struct fields, `record` (Result + asserts), `state_at_host`, `eval_state` in `u`, `clock_to_host`, `OutOfOrderPiece`, `HISTORY_CAPACITY` unchanged. (`rebase_axis`, `final_position`, `last_endpoint_clock` re-expressed in host time; `final_position` is position-only, untouched.)
+- `bridge.rs:3287-3302` — record `host_t` (stop discarding); map `Err(OutOfOrderPiece)` to a clean shutdown fault; line 3300 wire send unchanged.
+- `bridge.rs:3355-3394` (nudge dispatch) — same record change.
+- `bridge.rs:4438-4506` (`motion_state_at_clock`) — `clock_to_host(source, clock)` → `state_at_host`; drop the per-target `host_time_to_mcu_clock`; add shadow residual; `now_host` from the existing host-seconds `host_now`.
+- `bridge.rs:3709-3842` (`set_position`) — `rebase_axis(key, now_host, pos)` with `now_host` in host-seconds; remove the `host_time_to_mcu_clock` at 3792.
+- `homing.rs:20-85` — `reconstruct_axis_position`: `clock_to_host(endstop_mcu, trip_clock)` → `state_at_host`; drop the `host_time_to_mcu_clock(axis_mcu)` hop; add shadow residual; `trajectory_final_position` unchanged.
+- New newtypes `HostSecs`/`McuClock` + single transition map (gate 3) — can land as its own phase.
+- Tests in a separate file per CLAUDE.md (`motion_history` tests live beside as `#[cfg(test)] mod tests;` → its own file).
+
+## Test matrix (acceptance)
+- **Crash replay (headline):** feed the captured z_tilt dispatch sequence that `SIGABRT`s today → no panic, clean.
+- **Late arrival:** force `t0` regression → backward `host_secs` → `OutOfOrderPiece` clean shutdown, asserted NOT a panic.
+- **Property:** monotone `host_secs` in → monotone selection; zero-length piece (equal keys) → last-writer parity with today.
+- **NaN/inf:** record and query with non-finite → finite-assert fires before `partition_point`.
+- **Eval-in-`u`:** golden positions vs today’s clock eval, within slop; `u∉[0,1]` aborts.
+- **Golden homing-trip reconstruction:** P (single projection) vs legacy (double) within clocksync residual — equal-or-better.
+- **Chaos — frame skew:** re-anchor/slew between record and query of one piece → shadow residual within tol or faults.
+- **Chaos — beacon-sync drift:** jitter beacon→host conversion → residual bounded/detected.
+- **Chaos — reorder/dup:** non-monotonic stepper ticks (old trigger) → host keying does not collapse two instants into one bucket.
+- **Differential:** same G-code, old MCU-keyed vs new host-keyed, clean run → beacon Z mesh matches within tol (proves we moved crash handling, not metrology).
+- Run via `cargo nextest run -p motion-engine`; offline repro through klipper-sim where useful.
+
+## Phasing (each phase independently green via `./scripts/ci.sh quick` + `cargo fmt --all --check`)
+- **P0** — Add `start_host` to `HistoryPiece`, record it (dual-keyed), still assert/lookup on `start_clock`. No behavior change; de-risks plumbing.
+- **P1** — Flip assert + lookups to host time; demote panic → clean fault; delete the second projection hop in the two readers. *Fixes the crash.*
+- **P2** — Shadow residual (gate 1) + chaos tests.
+- **P3** — `HostSecs`/`McuClock` newtypes + single transition map + epoch-identity assert (gate 3).
+- **P4** — Reanchor drop-scope refinement (gate 4): drop only on timeline reset, retain across underrun re-anchor.
+
+## Open questions / risks
+- **Residual tolerance values** (gate 1) and the slow-probe Z budget — set from an instrumented histogram of real backward-jitter and lead-interval drift on the bench before fixing constants (no guessed thresholds).
+- **`rebase_axis` / `set_position` (G92) host-domain `now`** — confirm the host-seconds `now` used for the rebase endpoint matches the query domain.
+- **Epoch identity** — verify `host_now_secs()` (record) and `clock_to_host_secs()` (query) are the same router host-seconds epoch (expected yes; assert it).
+- **Reanchor retention** — confirm executed-prefix pieces are never re-timed once recorded (expected yes; pieces enter history at dispatch = already committed to the wire).
+
+## Non-goals
+- No change to the wire schedule, the clock-sync regression, or the A/D slew/anchor machinery (those now serve only wire-lead health, decoupled from probe correctness).
+- No silent clamp/pad of any timestamp (CLAUDE.md fail-loud).
+
+## Status — 2026-06-28
+- **P0+P1 (host-time keying) — DONE & bench-validated.** `57a6aaa5e`. Z_TILT_ADJUST ran repeatedly on Trident, 0 retries, converged, no crash, moonraker stayed up. Workspace green.
+- **P2 (shadow residual) — DONE & bench-validated.** `f729d31bb`. `history_shadow_divergence` = 0 across every probe sample → host-keyed lookup matches the legacy stepper-clock lookup; canary live and quiet.
+- **P3 (epoch identity) — DONE (`28f29f2bc`).** T-then-T⁻¹ round-trip test pins the shared-host-epoch invariant. **Newtypes deferred** — disproportionate `host-rt` churn for marginal safety over the existing f64-host/u64-clock split.
+- **P4 (reanchor) — DONE as self-healing ring (`28f29f2bc`).** Backward host_secs pops the superseded tail, keeping the ring sorted independent of the reanchor drop. **"Retain across underrun" optimization deferred** — the conservative drop is safe; the marginal probe-coverage gain didn't justify the ordering-correctness risk, and self-healing removes the latent unsorted-ring failure mode anyway.
+- **Open:** the backward-tick race stayed dormant on the fresh-flashed bench (no `history_order_jitter` captured yet); instrumentation + canary remain deployed as a standing trap to size the gate-1 tolerance empirically if it recurs.

--- a/_bmad-output/planning-artifacts/research/domain-host-mcu-clock-monotonic-scheduling-research-2026-06-28.md
+++ b/_bmad-output/planning-artifacts/research/domain-host-mcu-clock-monotonic-scheduling-research-2026-06-28.md
@@ -1,0 +1,113 @@
+# Domain Research — How industry keeps a streaming motion schedule monotonic under live host→device clock sync
+
+**Date:** 2026-06-28
+**Author:** dderg (facilitated)
+**Driving problem:** `HistoryStore::record` panic (`motion_history.rs:138`) — host-monotonic piece order does
+not survive projection into MCU clocks because `host_time_to_mcu_clock` is a live model re-fit between
+dispatches (µs-scale backward jitter → fail-loud assert → SIGABRT). See investigation case file.
+
+---
+
+## The question
+
+When a host streams a motion schedule to a device whose clock is being continuously re-synchronized,
+how do real systems guarantee the dispatched/recorded times stay monotonic — without freezing the clock
+estimate (which would drift) and without silently shoving motion later (which hides faults)?
+
+## Prior art surveyed
+
+### 1. Klipper upstream — the most direct analogue (it has our exact hazard)
+`clocksync.py` converts host/print time ↔ MCU clock through a **moving linear regression** updated on every
+`get_clock` response. Confirmed properties:
+- `print_time_to_clock(pt) = int(pt * mcu_freq)`; system-time path `get_clock(t) = clock + (t - sample_time)*freq`.
+- Regression updated by exponential decay `DECAY = 1/30`; `new_freq = clock_covariance / time_variance`.
+- **The mapping is NOT mathematically monotonic** — "it can step backward slightly if frequency estimates
+  drop." Same hazard we hit. (WebFetch of clocksync.py.)
+- Mitigations Klipper actually relies on:
+  1. **Heavy smoothing / slew** — decayed regression + outlier rejection (`25 * prediction_variance`) +
+     `Resetting prediction variance` guard, so `freq` moves slowly and continuously.
+  2. **Forward-anchored recalibration** — `SecondarySync.calibrate_clock()` solves `adjusted_freq`/
+     `adjusted_offset` to align at a sync point **~4+ seconds in the future**, so corrections take effect
+     *beyond the dispatch horizon*, never retroactively near the frontier.
+  3. **Single authoritative invariant, enforced at the boundary, not mid-pipeline** — Klipper does NOT put
+     a process-fatal host-side per-piece monotonicity assert. "Scheduled in the past" is checked **on the
+     MCU** → `Timer too close` → clean MCU **shutdown** (printer fault state), not a host `SIGABRT`.
+- The proposed multi-MCU sync refinement PR #6753 was **rejected** by K. O'Connor (redundant timer update;
+  the query-decrement change "would introduce a regression"). So upstream's answer remains: smooth + forward
+  sync point + MCU-side boundary check — not a tighter host model.
+
+### 2. PTP / IEEE-1588 clock discipline — the controls-theory principle
+- Universal rule: **slew, don't step.** Small errors → ppb-level *frequency* correction (slewing) that keeps
+  time monotonic; large errors → atomic *step* that "can cause problems for applications that require a
+  smooth and monotonically increasing time base." Smoothness-critical paths avoid steps.
+- Servos are **PI controllers + low-pass filters** (PTPd; fuzzy-PI variants in the literature). Corrections
+  are continuous by construction.
+
+### 3. Linux kernel monotonic clock / adjtimex
+- `CLOCK_MONOTONIC`: NTP **stepping has no effect**; only **slewing** applies. "Slewing itself does not cause
+  time to go backward — a vital guarantee." The OS answer to "I need a never-backward timeline off a
+  disciplined clock" is to expose a view that *only ever slews*.
+
+### 4. EtherCAT Distributed Clocks (industrial multi-axis motion)
+- Different architecture: a **hardware DC in every node**, one 64-bit/1 ns **reference time** distributed and
+  disciplined to <100 ns. There is **one authoritative monotonic counter**; the host does not re-project a
+  per-cycle host→device map. Coordinated motion rides a single common time base.
+
+---
+
+## Synthesis — the three recurring patterns
+
+Robust systems combine these; none rely on a single one:
+
+- **P1 — Slew, never step.** Clock-model corrections are slow continuous *frequency* adjustments, never
+  discontinuous offset jumps. (PTP, NTP, CLOCK_MONOTONIC.) → validates "fix the model continuity" and
+  condemns abrupt per-dispatch re-fits.
+- **P2 — Apply corrections beyond the commit/lookahead horizon.** Klipper's "sync ~4 s ahead": the mapping is
+  only ever changed at a future point past everything already scheduled, so near-frontier ordering is
+  immutable. → the lookahead/commit-horizon discipline.
+- **P3 — One authority for the monotonicity invariant, checked at the boundary, failing loud-but-clean.**
+  Klipper checks "in the past?" once, on the MCU (`Timer too close` → clean shutdown). EtherCAT has one DC
+  reference. Nobody sprinkles *process-fatal* asserts on a *derived* structure that independently re-projects.
+
+## Mapping to our candidate solution families (from the brainstorm)
+
+| Family | Industry verdict |
+|---|---|
+| A. Single per-stream clock anchor (affine, project once) | Validated — EtherCAT single-time-base + Klipper forward sync. Monotonic by construction. |
+| D. Phase-continuous / slew-limited clock model | Validated as the *cause* fix (P1) — but biggest blast radius; Klipper keeps smoothing heavy AND adds P2 rather than trusting smoothing alone. |
+| B/C. Clamp forward (`max(projected, last)`) | **Anti-pattern.** Clamping forward = a silent "step"/pad — exactly what PTP avoids and CLAUDE.md forbids; masks real lateness faults. |
+| E. History in host-time domain, project at query | Partially aligns with "don't duplicate the invariant on a derived structure," but leaves the wire untouched; weaker than P3. |
+| F. Graceful shutdown instead of SIGABRT | **Strongly validated** — Klipper's analogous failure is a clean MCU shutdown, never a host process abort. Preserves fail-loud while keeping the process alive to report. |
+
+## Recommendation direction (evidence-based)
+
+The industry-standard combination, translated to our pipeline:
+1. **Make the schedule monotonic by construction** — adopt Family A (single per-stream anchor) or Family D
+   (slew-limited model), so `start_time` cannot invert near the frontier (P1).
+2. **Don't re-project inside the committed window** — apply any clock-model correction only beyond the
+   lookahead horizon, Klipper-style (P2).
+3. **Enforce "monotonic / not-in-the-past" at ONE authoritative boundary that fails loud-but-clean** — keep a
+   single check (pump/MCU egress), convert the history assert off `panic→SIGABRT` to a clean shutdown
+   (Family F), and let the derived history *trust* the authoritative schedule (P3) rather than re-asserting it.
+
+## Open questions for next pass
+- Does our MCU step queue already reject in-the-past absolute clocks (a `Timer too close` analogue)? If yes,
+  the host-side assert is a *redundant* second authority and P3 says remove/demote it.
+- What is the real magnitude/frequency distribution of the backward jitter on the bench? (Quantify before
+  picking any horizon/slew constant — instrument a histogram.)
+- Could pieces carry *relative* clocks and let the pump assign absolute clocks at a single monotone egress
+  point (a clean P3 implementation)?
+
+## Sources
+- [klipper/clocksync.py (master)](https://github.com/Klipper3d/klipper/blob/master/klippy/clocksync.py)
+- [Klipper PR #6753 — Improve multi-MCU clock sync (rejected)](https://github.com/Klipper3d/klipper/pull/6753)
+- [Klipper Code Overview — time](https://www.klipper3d.org/Code_Overview.html)
+- [Klipper "Timer too close" knowledge base](https://klipper.discourse.group/t/timer-too-close/6634)
+- [PTPd source documentation (clock servo, slew vs step)](https://ptpd.sourceforge.net/doc.html)
+- [Discrete model of IEEE 1588 PTP with PI clock servo (IEEE Xplore)](https://ieeexplore.ieee.org/document/8754102/)
+- [Adaptive Fuzzy-PI clock servo for IEEE 1588 (ResearchGate)](https://www.researchgate.net/publication/340214644)
+- [Baeldung — Timekeeping and Clocks in Linux (slew vs step, monotonic)](https://www.baeldung.com/linux/timekeeping-clocks)
+- [Clock Synchronization and Monotonic Clocks — I. Pandzic](https://inelpandzic.com/articles/clock-synchronization-and-monotonic-clocks/)
+- [EtherCAT Motion Control guide — Elmo](https://www.elmomc.com/elmo_academy/ethercat-motion-control/)
+- [acontis — Distributed Clocks (DC) synchronization](https://www.acontis.com/en/dcm.html)
+- [Synchronous multi-axis motion via modified EtherCAT DC (IEEE Xplore)](https://ieeexplore.ieee.org/document/9327605/)

--- a/rust/host-rt/src/passthrough_queue/router.rs
+++ b/rust/host-rt/src/passthrough_queue/router.rs
@@ -501,15 +501,15 @@ impl PassthroughRouter {
         Ok(projected)
     }
 
-    pub fn log_seg0_deficit(&self, mcu: McuHandle, seg0_host_secs: f64, t0: f64) {
+    pub fn log_seg0_lead(&self, mcu: McuHandle, seg0_host_secs: f64, t0: f64) {
         let rec = match self.mcus.get(&mcu) {
             Some(r) => r,
             None => {
                 tracing::warn!(
                     subsystem = "motion",
-                    event = "seg0_deficit_unknown_mcu",
+                    event = "seg0_lead_unknown_mcu",
                     mcu = ?mcu,
-                    "[seg0-deficit] UNKNOWN mcu"
+                    "[seg0-lead] UNKNOWN mcu"
                 );
                 return;
             }
@@ -517,11 +517,11 @@ impl PassthroughRouter {
         if rec.clock_freq == 0.0 {
             tracing::warn!(
                 subsystem = "motion",
-                event = "seg0_deficit_not_synced",
+                event = "seg0_lead_not_synced",
                 mcu = ?mcu,
                 t0,
                 seg0_host_secs,
-                "[seg0-deficit] clock_freq=0 (not yet synced)"
+                "[seg0-lead] clock_freq=0 (not yet synced)"
             );
             return;
         }
@@ -529,23 +529,41 @@ impl PassthroughRouter {
             .host_time_to_mcu_clock(mcu, seg0_host_secs)
             .unwrap_or(0);
         let ack_now = self.compute_ack_clock(mcu).unwrap_or(0);
-        let deficit_ticks = start_time as i64 - ack_now as i64;
-        let deficit_us = (deficit_ticks as f64 / rec.clock_freq) * 1e6;
-        tracing::warn!(
-            subsystem = "motion",
-            event = "seg0_deficit",
-            mcu = ?mcu,
-            freq = rec.clock_freq,
-            offset = rec.clock_offset,
-            last_clock = rec.last_clock,
-            t0,
-            seg0_host_secs,
-            start_time,
-            ack_now,
-            deficit_ticks,
-            deficit_us,
-            "[seg0-deficit] (negative deficit_us => in past)"
-        );
+        let lead_ticks = start_time as i64 - ack_now as i64;
+        let lead_us = (lead_ticks as f64 / rec.clock_freq) * 1e6;
+        if lead_ticks < 0 {
+            tracing::warn!(
+                subsystem = "motion",
+                event = "seg0_start_in_past",
+                mcu = ?mcu,
+                freq = rec.clock_freq,
+                offset = rec.clock_offset,
+                last_clock = rec.last_clock,
+                t0,
+                seg0_host_secs,
+                start_time,
+                ack_now,
+                lead_ticks,
+                lead_us,
+                "[seg0-lead] segment 0 starts behind the MCU ack clock (in the past)"
+            );
+        } else {
+            tracing::debug!(
+                subsystem = "motion",
+                event = "seg0_lead",
+                mcu = ?mcu,
+                freq = rec.clock_freq,
+                offset = rec.clock_offset,
+                last_clock = rec.last_clock,
+                t0,
+                seg0_host_secs,
+                start_time,
+                ack_now,
+                lead_ticks,
+                lead_us,
+                "[seg0-lead] segment 0 lead over the MCU ack clock"
+            );
+        }
     }
 
     pub fn get_stats(&self, mcu: McuHandle) -> Result<PassthroughStats, RouterError> {

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -31,7 +31,7 @@ struct HomingRun {
     axis: u8,
     axis_key: crate::pump::AxisKey,
     all_axis_keys: Vec<crate::pump::AxisKey>,
-    window_start_clock: u64,
+    window_start_host: f64,
     notify: crossbeam_channel::Sender<Result<([f64; 3], [f64; 3], u64), String>>,
 }
 
@@ -3292,8 +3292,8 @@ impl PyMotionEngine {
                         let mut store = motion_history_for_cb
                             .lock()
                             .unwrap_or_else(|p| p.into_inner());
-                        for (piece, _host_t) in &m.pieces {
-                            store.record(m.key, piece, nominal_freq);
+                        for (piece, host_t) in &m.pieces {
+                            store.record(m.key, piece, nominal_freq, *host_t);
                         }
                     }
                     drain_disp.add_sent(m.key.mcu_id, m.key.axis, m.pieces.len() as u32);
@@ -3390,8 +3390,8 @@ impl PyMotionEngine {
                         let mut store = nudge_motion_history
                             .lock()
                             .unwrap_or_else(|p| p.into_inner());
-                        for (piece, _host_t) in &pieces {
-                            store.record(key, piece, nominal_freq);
+                        for (piece, host_t) in &pieces {
+                            store.record(key, piece, nominal_freq, *host_t);
                         }
                     }
                     nudge_drain.add_sent(mcu_id, axis, pieces.len() as u32);
@@ -3783,63 +3783,48 @@ impl PyMotionEngine {
                 .unwrap_or_else(|p| p.into_inner())
                 .clone();
             let positions = [x, y, z];
-            let rebases: Vec<(crate::pump::AxisKey, u64, f64)> = {
-                let router = self.router.lock().unwrap_or_else(|p| p.into_inner());
-                configs
-                    .iter()
-                    .flat_map(|cfg| {
-                        let handle = crate::types::mcu_handle_from_raw(cfg.mcu_id);
-                        let now_clock =
-                            router.host_time_to_mcu_clock(handle, host_now).unwrap_or(0);
-                        cfg.axes
-                            .iter()
-                            .filter(|&&a| a < SPATIAL_AXES)
-                            .map(move |&axis| {
-                                let key = crate::pump::AxisKey {
+            let rebases: Vec<(crate::pump::AxisKey, f64)> = configs
+                .iter()
+                .flat_map(|cfg| {
+                    cfg.axes
+                        .iter()
+                        .filter(|&&a| a < SPATIAL_AXES)
+                        .map(move |&axis| {
+                            (
+                                crate::pump::AxisKey {
                                     mcu_id: cfg.mcu_id,
                                     axis: axis as u8,
-                                };
-                                (key, now_clock, positions[axis])
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .collect()
-            };
-            let follower_rebases: Vec<(crate::pump::AxisKey, u64)> = {
-                let router = self.router.lock().unwrap_or_else(|p| p.into_inner());
-                configs
-                    .iter()
-                    .flat_map(|cfg| {
-                        let handle = crate::types::mcu_handle_from_raw(cfg.mcu_id);
-                        let now_clock =
-                            router.host_time_to_mcu_clock(handle, host_now).unwrap_or(0);
-                        cfg.axes
-                            .iter()
-                            .filter(|&&a| a >= 3)
-                            .map(move |&axis| {
-                                (
-                                    crate::pump::AxisKey {
-                                        mcu_id: cfg.mcu_id,
-                                        axis: axis as u8,
-                                    },
-                                    now_clock,
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .collect()
-            };
+                                },
+                                positions[axis],
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            let follower_keys: Vec<crate::pump::AxisKey> = configs
+                .iter()
+                .flat_map(|cfg| {
+                    cfg.axes
+                        .iter()
+                        .filter(|&&a| a >= 3)
+                        .map(move |&axis| crate::pump::AxisKey {
+                            mcu_id: cfg.mcu_id,
+                            axis: axis as u8,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
             {
                 let mut store = self
                     .motion_history
                     .lock()
                     .unwrap_or_else(|p| p.into_inner());
-                for (key, now_clock, pos) in rebases {
-                    store.rebase_axis(key, now_clock, pos);
+                for (key, pos) in rebases {
+                    store.rebase_axis(key, host_now, pos);
                 }
-                for (key, now_clock) in follower_rebases {
+                for key in follower_keys {
                     let held_position = store.final_position(key).unwrap_or(0.0);
-                    store.rebase_axis(key, now_clock, held_position);
+                    store.rebase_axis(key, host_now, held_position);
                 }
             }
         }
@@ -4084,17 +4069,9 @@ impl PyMotionEngine {
                 .map_err(PyRuntimeError::new_err)?;
         }
 
-        let window_start_clock_in_drip_piece_era = {
+        let window_start_host = {
             let router = self.router.lock().unwrap_or_else(|p| p.into_inner());
-            let host_now = router.host_now_secs();
-            router
-                .host_time_to_mcu_clock(mcu_handle_from_raw(axis_key.mcu_id), host_now)
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!(
-                        "home_axis: cannot project arm-time clock for axis mcu {}: {e:?}",
-                        axis_key.mcu_id
-                    ))
-                })?
+            router.host_now_secs()
         };
 
         {
@@ -4132,7 +4109,7 @@ impl PyMotionEngine {
                 axis,
                 axis_key,
                 all_axis_keys: all_axis_keys.clone(),
-                window_start_clock: window_start_clock_in_drip_piece_era,
+                window_start_host,
                 notify: result_tx,
             });
         }
@@ -4452,44 +4429,31 @@ impl PyMotionEngine {
                 "motion_state_at: no axes configured on the engine",
             ));
         }
-        let resolved: Vec<(crate::pump::AxisKey, u64, u64)> = {
+        let query_host = {
             let router = self.router.lock().unwrap_or_else(|p| p.into_inner());
-            let source_handle = crate::types::mcu_handle_from_raw(source_mcu);
-            let mut acc = Vec::new();
-            for cfg in &configs {
-                let target_handle = crate::types::mcu_handle_from_raw(cfg.mcu_id);
-                let axis_clock = crate::motion_history::clock_between_mcus(
-                    &router,
-                    source_handle,
-                    target_handle,
-                    clock,
-                )
-                .map_err(PyRuntimeError::new_err)?;
-                let now_clock = router
-                    .host_time_to_mcu_clock(target_handle, host_now)
-                    .map_err(|e| {
-                        PyRuntimeError::new_err(format!(
-                            "motion_state_at: clock unsynced for mcu {}: {e:?}",
-                            cfg.mcu_id
-                        ))
-                    })?;
-                for &axis in &cfg.axes {
-                    let key = crate::pump::AxisKey {
-                        mcu_id: cfg.mcu_id,
-                        axis: axis as u8,
-                    };
-                    acc.push((key, axis_clock, now_clock));
-                }
-            }
-            acc
+            crate::motion_history::clock_to_host(
+                &router,
+                crate::types::mcu_handle_from_raw(source_mcu),
+                clock,
+            )
+            .map_err(PyRuntimeError::new_err)?
         };
+        let keys: Vec<crate::pump::AxisKey> = configs
+            .iter()
+            .flat_map(|cfg| {
+                cfg.axes.iter().map(move |&axis| crate::pump::AxisKey {
+                    mcu_id: cfg.mcu_id,
+                    axis: axis as u8,
+                })
+            })
+            .collect();
         let store = self
             .motion_history
             .lock()
             .unwrap_or_else(|p| p.into_inner());
         let mut out = std::collections::HashMap::new();
-        for (key, axis_clock, now_clock) in resolved {
-            let st = match store.state_at_clock(key, axis_clock, Some(now_clock)) {
+        for key in keys {
+            let st = match store.state_at_host(key, query_host, Some(host_now)) {
                 Ok(st) => st,
                 Err(crate::motion_history::HistoryError::NoHistoryForAxis(_)) => continue,
                 Err(e) => return Err(PyRuntimeError::new_err(e.to_string())),
@@ -4733,7 +4697,7 @@ pub(crate) fn dispatch_endstop_trip(
                     axis_key,
                     &router_arc,
                     &history_arc,
-                    run.window_start_clock,
+                    run.window_start_host,
                 )?;
                 let motor_frame =
                     trip_position_to_motor_frame(axis, motor_pos, &configs, axis_key.mcu_id);

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -4438,26 +4438,44 @@ impl PyMotionEngine {
             )
             .map_err(PyRuntimeError::new_err)?
         };
-        let keys: Vec<crate::pump::AxisKey> = configs
-            .iter()
-            .flat_map(|cfg| {
-                cfg.axes.iter().map(move |&axis| crate::pump::AxisKey {
-                    mcu_id: cfg.mcu_id,
-                    axis: axis as u8,
-                })
-            })
-            .collect();
+        let resolved: Vec<(crate::pump::AxisKey, u64, u64)> = {
+            let router = self.router.lock().unwrap_or_else(|p| p.into_inner());
+            let mut acc = Vec::new();
+            for cfg in &configs {
+                let target = crate::types::mcu_handle_from_raw(cfg.mcu_id);
+                let shadow_clock = router
+                    .host_time_to_mcu_clock(target, query_host)
+                    .unwrap_or(0);
+                let now_clock = router.host_time_to_mcu_clock(target, host_now).unwrap_or(0);
+                for &axis in &cfg.axes {
+                    acc.push((
+                        crate::pump::AxisKey {
+                            mcu_id: cfg.mcu_id,
+                            axis: axis as u8,
+                        },
+                        shadow_clock,
+                        now_clock,
+                    ));
+                }
+            }
+            acc
+        };
         let store = self
             .motion_history
             .lock()
             .unwrap_or_else(|p| p.into_inner());
         let mut out = std::collections::HashMap::new();
-        for key in keys {
+        for (key, shadow_clock, now_clock) in resolved {
             let st = match store.state_at_host(key, query_host, Some(host_now)) {
                 Ok(st) => st,
                 Err(crate::motion_history::HistoryError::NoHistoryForAxis(_)) => continue,
                 Err(e) => return Err(PyRuntimeError::new_err(e.to_string())),
             };
+            crate::motion_history::check_shadow_divergence(
+                key,
+                st.position,
+                store.state_at_clock_legacy(key, shadow_clock, now_clock),
+            );
             let name = AXIS_NAMES.get(key.axis as usize).ok_or_else(|| {
                 PyRuntimeError::new_err(format!("motion_state_at: unnamed axis {}", key.axis))
             })?;

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -3238,7 +3238,7 @@ impl PyMotionEngine {
                     let r = router_for_cb.lock().unwrap_or_else(|p| p.into_inner());
                     for cfg in mcu_configs_for_cb.iter() {
                         let h = crate::types::mcu_handle_from_raw(cfg.mcu_id);
-                        r.log_seg0_deficit(h, t0 + seg.t_start, t0);
+                        r.log_seg0_lead(h, t0 + seg.t_start, t0);
                     }
                 }
 
@@ -3278,15 +3278,11 @@ impl PyMotionEngine {
                     .lock()
                     .unwrap_or_else(|p| p.into_inner())
                     .clone();
-                // A re-anchor jumps the clock baseline; drop the now-stale history
-                // once, before recording this segment, so a resumed piece is not
-                // compared against pieces on the old timeline (which would read as
-                // out-of-order and abort the dispatch).
                 if fresh {
                     motion_history_for_cb
                         .lock()
                         .unwrap_or_else(|p| p.into_inner())
-                        .clear();
+                        .drop_pieces_on_reanchor();
                 }
                 for m in msgs {
                     let nominal_freq = *nominal_freqs
@@ -3351,7 +3347,7 @@ impl PyMotionEngine {
                 if fresh {
                     let r = nudge_router.lock().unwrap_or_else(|p| p.into_inner());
                     let h = crate::types::mcu_handle_from_raw(mcu_id);
-                    r.log_seg0_deficit(h, t0 + np.piece.u_start, t0);
+                    r.log_seg0_lead(h, t0 + np.piece.u_start, t0);
                 }
 
                 let project = |proj_mcu_id: u32, host_secs: f64| -> u64 {

--- a/rust/motion-engine/src/homing.rs
+++ b/rust/motion-engine/src/homing.rs
@@ -54,11 +54,24 @@ pub fn reconstruct_axis_position(
         ));
     }
 
+    let shadow_clock = {
+        let router_guard = router.lock().unwrap_or_else(|p| p.into_inner());
+        router_guard
+            .host_time_to_mcu_clock(crate::types::mcu_handle_from_raw(axis_mcu), trip_host)
+            .ok()
+    };
     let store = history.lock().unwrap_or_else(|p| p.into_inner());
-    store
+    let st = store
         .state_at_host(axis_key, trip_host, None)
-        .map(|st| st.position)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    if let Some(shadow_clock) = shadow_clock {
+        crate::motion_history::check_shadow_divergence(
+            axis_key,
+            st.position,
+            store.state_at_clock_legacy(axis_key, shadow_clock, u64::MAX),
+        );
+    }
+    Ok(st.position)
 }
 
 pub fn trajectory_final_position(

--- a/rust/motion-engine/src/homing.rs
+++ b/rust/motion-engine/src/homing.rs
@@ -23,56 +23,40 @@ pub fn reconstruct_axis_position(
     axis_key: AxisKey,
     router: &Arc<Mutex<PassthroughRouter>>,
     history: &Arc<Mutex<crate::motion_history::HistoryStore>>,
-    window_start_clock: u64,
+    window_start_host: f64,
 ) -> Result<f64, String> {
     let axis_mcu = axis_key.mcu_id;
 
-    let (axis_clock, trip_host_secs, host_now_secs) = if endstop_mcu == axis_mcu {
-        (trip_clock, 0.0, 0.0)
-    } else {
+    let trip_host = {
         let router_guard = router.lock().unwrap_or_else(|p| p.into_inner());
-        let host_secs = router_guard
-            .clock_to_host_secs(crate::types::mcu_handle_from_raw(endstop_mcu), trip_clock)
-            .ok_or_else(|| {
-                ReconstructError::ClockUnsynced {
-                    description: format!(
-                        "clock_to_host_secs returned None for endstop mcu {endstop_mcu}"
-                    ),
-                    endstop_mcu,
-                    axis_mcu,
-                    trip_clock,
-                }
-                .to_string()
-            })?;
-        let axis_clock = router_guard
-            .host_time_to_mcu_clock(crate::types::mcu_handle_from_raw(axis_mcu), host_secs)
-            .map_err(|e| {
-                ReconstructError::ClockUnsynced {
-                    description: format!(
-                        "host_time_to_mcu_clock failed for axis mcu {axis_mcu}: {e:?}"
-                    ),
-                    endstop_mcu,
-                    axis_mcu,
-                    trip_clock,
-                }
-                .to_string()
-            })?;
-        (axis_clock, host_secs, router_guard.host_now_secs())
+        crate::motion_history::clock_to_host(
+            &router_guard,
+            crate::types::mcu_handle_from_raw(endstop_mcu),
+            trip_clock,
+        )
+        .map_err(|description| {
+            ReconstructError::ClockUnsynced {
+                description,
+                endstop_mcu,
+                axis_mcu,
+                trip_clock,
+            }
+            .to_string()
+        })?
     };
 
-    if axis_clock <= window_start_clock {
+    if trip_host <= window_start_host {
         return Err(format!(
-            "endstop trip clock {axis_clock} predates this homing move \
-             (window starts at {window_start_clock}) — stale trip or \
+            "endstop trip host time {trip_host:.6}s predates this homing move \
+             (window starts at {window_start_host:.6}s) — stale trip or \
              mis-synced clock (endstop_mcu={endstop_mcu} trip_clock={trip_clock} \
-             trip_host_secs={trip_host_secs:.6} host_now={host_now_secs:.6} \
              axis_mcu={axis_mcu})"
         ));
     }
 
     let store = history.lock().unwrap_or_else(|p| p.into_inner());
     store
-        .state_at_clock(axis_key, axis_clock, None)
+        .state_at_host(axis_key, trip_host, None)
         .map(|st| st.position)
         .map_err(|e| e.to_string())
 }

--- a/rust/motion-engine/src/homing/tests.rs
+++ b/rust/motion-engine/src/homing/tests.rs
@@ -47,6 +47,25 @@ fn shared(store: HistoryStore) -> Arc<Mutex<HistoryStore>> {
     Arc::new(Mutex::new(store))
 }
 
+fn host_of(router: &Arc<Mutex<PassthroughRouter>>, mcu_id: u32, clock: u64) -> f64 {
+    router
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clock_to_host_secs(crate::types::mcu_handle_from_raw(mcu_id), clock)
+        .expect("test router must resolve clock_to_host_secs")
+}
+
+fn record_synced(
+    store: &mut HistoryStore,
+    router: &Arc<Mutex<PassthroughRouter>>,
+    key: AxisKey,
+    e: &PieceEntry,
+    freq: u32,
+) {
+    let host = host_of(router, key.mcu_id, e.start_time);
+    store.record(key, e, freq, host);
+}
+
 #[test]
 fn eval_bernstein_cubic_linear_piece_endpoints() {
     let coeffs = [0.0f32, 0.0, 1.0, 1.0];
@@ -103,11 +122,18 @@ fn same_mcu_trip_clock_exact_reconstruction() {
         axis: AXIS_X as u8,
     };
     let mut store = HistoryStore::default();
-    store.record(key, &piece, FREQ);
+    record_synced(&mut store, &router, key, &piece, FREQ);
 
     let trip_clock = piece_start + duration_ticks / 2;
 
-    let result = reconstruct_axis_position(MCU_ID, trip_clock, key, &router, &shared(store), 0);
+    let result = reconstruct_axis_position(
+        MCU_ID,
+        trip_clock,
+        key,
+        &router,
+        &shared(store),
+        f64::NEG_INFINITY,
+    );
     let pos = result.expect("same-MCU reconstruction must succeed");
 
     assert!(
@@ -131,9 +157,16 @@ fn trip_at_piece_start_returns_start_position() {
         axis: AXIS_Z as u8,
     };
     let mut store = HistoryStore::default();
-    store.record(key, &piece, 520_000_000_u32);
+    record_synced(&mut store, &router, key, &piece, 520_000_000_u32);
 
-    let result = reconstruct_axis_position(MCU_ID, piece_start, key, &router, &shared(store), 0);
+    let result = reconstruct_axis_position(
+        MCU_ID,
+        piece_start,
+        key,
+        &router,
+        &shared(store),
+        f64::NEG_INFINITY,
+    );
     let pos = result.expect("trip at piece start must succeed");
     assert!(
         (pos - 10.0).abs() < 0.5,
@@ -157,11 +190,18 @@ fn trip_outside_trajectory_window_holds_last_position() {
         axis: AXIS_X as u8,
     };
     let mut store = HistoryStore::default();
-    store.record(key, &piece, FREQ);
+    record_synced(&mut store, &router, key, &piece, FREQ);
 
     #[allow(clippy::cast_possible_truncation)]
     let way_after = piece_start + (duration_secs as f64 * FREQ_F64) as u64 + 9_999_999;
-    let result = reconstruct_axis_position(MCU_ID, way_after, key, &router, &shared(store), 0);
+    let result = reconstruct_axis_position(
+        MCU_ID,
+        way_after,
+        key,
+        &router,
+        &shared(store),
+        f64::NEG_INFINITY,
+    );
     let pos = result.expect("trip after last piece holds endpoint position");
     assert!(
         (pos - 10.0).abs() < 0.5,
@@ -184,11 +224,18 @@ fn trip_before_trajectory_window_errors() {
         axis: AXIS_X as u8,
     };
     let mut store = HistoryStore::default();
-    store.record(key, &piece, FREQ);
+    record_synced(&mut store, &router, key, &piece, FREQ);
 
     let before = piece_start - 1;
-    let err =
-        reconstruct_axis_position(MCU_ID, before, key, &router, &shared(store), 0).unwrap_err();
+    let err = reconstruct_axis_position(
+        MCU_ID,
+        before,
+        key,
+        &router,
+        &shared(store),
+        f64::NEG_INFINITY,
+    )
+    .unwrap_err();
     assert!(
         err.contains("precedes retained"),
         "expected 'precedes retained' in error, got: {err}"
@@ -208,8 +255,15 @@ fn no_history_for_axis_errors() {
     };
     let store = HistoryStore::default();
 
-    let err =
-        reconstruct_axis_position(MCU_ID, 12_345_678, key, &router, &shared(store), 0).unwrap_err();
+    let err = reconstruct_axis_position(
+        MCU_ID,
+        12_345_678,
+        key,
+        &router,
+        &shared(store),
+        f64::NEG_INFINITY,
+    )
+    .unwrap_err();
     assert!(
         err.contains("no motion history"),
         "expected 'no motion history' in error, got: {err}"
@@ -238,11 +292,18 @@ fn multiple_pieces_trip_in_second_piece() {
         axis: AXIS_X as u8,
     };
     let mut store = HistoryStore::default();
-    store.record(key, &piece1, FREQ);
-    store.record(key, &piece2, FREQ);
+    record_synced(&mut store, &router, key, &piece1, FREQ);
+    record_synced(&mut store, &router, key, &piece2, FREQ);
 
     let trip_clock = piece2_start + duration_ticks / 2;
-    let result = reconstruct_axis_position(MCU_ID, trip_clock, key, &router, &shared(store), 0);
+    let result = reconstruct_axis_position(
+        MCU_ID,
+        trip_clock,
+        key,
+        &router,
+        &shared(store),
+        f64::NEG_INFINITY,
+    );
     let pos = result.expect("trip in second piece must succeed");
     assert!(
         (pos - 75.0).abs() < 1.0,
@@ -262,16 +323,22 @@ fn trip_before_homing_window_is_rejected() {
         axis: AXIS_X as u8,
     };
     let mut store = HistoryStore::default();
-    store.record(key, &make_linear_piece(1_000_000, 0.01, 0.0, 5.0), FREQ);
+    record_synced(
+        &mut store,
+        &router,
+        key,
+        &make_linear_piece(1_000_000, 0.01, 0.0, 5.0),
+        FREQ,
+    );
 
-    let window_start = 2_000_000_u64;
+    let window_start_host = host_of(&router, MCU_ID, 2_000_000);
     let err = reconstruct_axis_position(
         MCU_ID,
         1_500_000,
         key,
         &router,
         &shared(store),
-        window_start,
+        window_start_host,
     )
     .unwrap_err();
     assert!(
@@ -288,7 +355,7 @@ fn trajectory_final_position_single_piece() {
     };
     let piece = make_linear_piece(1_000_000, 0.025, 5.0, 45.0);
     let mut store = HistoryStore::default();
-    store.record(key, &piece, FREQ);
+    store.record(key, &piece, FREQ, 0.0);
 
     let pos =
         trajectory_final_position(key, &shared(store)).expect("single-piece store must succeed");
@@ -307,8 +374,8 @@ fn trajectory_final_position_multi_piece_takes_last() {
     let piece1 = make_linear_piece(1_000_000, 0.025, 0.0, 50.0);
     let piece2 = make_linear_piece(5_500_000, 0.025, 50.0, 82.5);
     let mut store = HistoryStore::default();
-    store.record(key, &piece1, FREQ);
-    store.record(key, &piece2, FREQ);
+    store.record(key, &piece1, FREQ, 0.0);
+    store.record(key, &piece2, FREQ, 1.0);
 
     let pos =
         trajectory_final_position(key, &shared(store)).expect("multi-piece store must succeed");
@@ -352,7 +419,7 @@ fn trajectory_final_position_constant_piece() {
         _reserved: [0; 3],
     };
     let mut store = HistoryStore::default();
-    store.record(key, &piece, FREQ);
+    store.record(key, &piece, FREQ, 0.0);
 
     let pos =
         trajectory_final_position(key, &shared(store)).expect("constant-piece store must succeed");

--- a/rust/motion-engine/src/motion_history.rs
+++ b/rust/motion-engine/src/motion_history.rs
@@ -7,6 +7,11 @@ use crate::pump::AxisKey;
 
 pub const HISTORY_CAPACITY: usize = 4096;
 
+/// Provisional alarm threshold for the host-keyed vs legacy MCU-clock-keyed
+/// position cross-check. Refine from the bench `history_shadow_divergence`
+/// distribution once real probe runs land.
+pub const SHADOW_DIVERGENCE_TOL_MM: f64 = 0.01;
+
 #[derive(Debug, thiserror::Error)]
 pub enum HistoryError {
     #[error(
@@ -103,19 +108,13 @@ pub fn eval_bernstein_cubic(coeffs: [f32; 4], u: f64) -> f64 {
     v * v * v * b0 + 3.0 * v * v * u * b1 + 3.0 * v * u * u * b2 + u * u * u * b3
 }
 
-fn eval_state(piece: &HistoryPiece, host_t: f64) -> AxisState {
-    let span = f64::from(piece.duration_secs);
-    let u = if span > 0.0 {
-        ((host_t - piece.start_host) / span).clamp(0.0, 1.0)
-    } else {
-        0.0
-    };
+fn eval_at_u(piece: &HistoryPiece, u: f64) -> AxisState {
     let v = 1.0 - u;
     let b0 = f64::from(piece.coeffs[0]);
     let b1 = f64::from(piece.coeffs[1]);
     let b2 = f64::from(piece.coeffs[2]);
     let b3 = f64::from(piece.coeffs[3]);
-    let t = span;
+    let t = f64::from(piece.duration_secs);
     let (velocity, acceleration) = if t > 0.0 {
         let db = 3.0 * ((b1 - b0) * v * v + 2.0 * (b2 - b1) * v * u + (b3 - b2) * u * u);
         let d2b = 6.0 * ((b2 - 2.0 * b1 + b0) * v + (b3 - 2.0 * b2 + b1) * u);
@@ -128,6 +127,26 @@ fn eval_state(piece: &HistoryPiece, host_t: f64) -> AxisState {
         velocity,
         acceleration,
     }
+}
+
+fn eval_state(piece: &HistoryPiece, host_t: f64) -> AxisState {
+    let span = f64::from(piece.duration_secs);
+    let u = if span > 0.0 {
+        ((host_t - piece.start_host) / span).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    eval_at_u(piece, u)
+}
+
+fn eval_state_by_clock(piece: &HistoryPiece, clock: u64) -> AxisState {
+    let dur_ticks = piece.end_clock.saturating_sub(piece.start_clock) as f64;
+    let u = if dur_ticks > 0.0 {
+        (clock.saturating_sub(piece.start_clock) as f64 / dur_ticks).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    eval_at_u(piece, u)
 }
 
 #[derive(Debug, Default)]
@@ -215,6 +234,35 @@ impl HistoryStore {
         self.endpoints.get(&key).map(|e| e.position)
     }
 
+    /// Shadow lookup in the legacy per-axis MCU-clock domain, used only to
+    /// cross-check the host-keyed result. Returns `None` when the ring cannot
+    /// resolve the clock (no pieces, before window, or future) — those cases
+    /// carry no divergence signal and are skipped by the caller.
+    pub fn state_at_clock_legacy(
+        &self,
+        key: AxisKey,
+        clock: u64,
+        now_clock: u64,
+    ) -> Option<AxisState> {
+        let ring = self.rings.get(&key).filter(|r| !r.is_empty())?;
+        let idx = ring.partition_point(|p| p.start_clock <= clock);
+        if idx == 0 {
+            return None;
+        }
+        let piece = &ring[idx - 1];
+        if clock < piece.end_clock {
+            return Some(eval_state_by_clock(piece, clock));
+        }
+        if clock > now_clock {
+            return None;
+        }
+        Some(AxisState {
+            position: f64::from(piece.coeffs[3]),
+            velocity: 0.0,
+            acceleration: 0.0,
+        })
+    }
+
     pub fn state_at_host(
         &self,
         key: AxisKey,
@@ -260,6 +308,25 @@ impl HistoryStore {
             }
         }
         Ok(hold.hold_state())
+    }
+}
+
+pub fn check_shadow_divergence(key: AxisKey, host_pos: f64, shadow: Option<AxisState>) {
+    let Some(shadow) = shadow else {
+        return;
+    };
+    let delta_mm = (host_pos - shadow.position).abs();
+    if delta_mm > SHADOW_DIVERGENCE_TOL_MM {
+        tracing::warn!(
+            subsystem = "motion",
+            event = "history_shadow_divergence",
+            mcu = key.mcu_id,
+            axis = key.axis,
+            host_pos,
+            shadow_pos = shadow.position,
+            delta_mm,
+            "[history-shadow] host-keyed vs stepper-clock-keyed position diverged"
+        );
     }
 }
 

--- a/rust/motion-engine/src/motion_history.rs
+++ b/rust/motion-engine/src/motion_history.rs
@@ -176,11 +176,12 @@ impl HistoryStore {
         }
         let piece = HistoryPiece::from_entry(entry, nominal_freq_hz, host_secs);
         let ring = self.rings.entry(key).or_default();
-        if let Some(last) = ring.back() {
-            if piece.start_clock < last.start_clock {
-                let regress_ticks = last.start_clock - piece.start_clock;
+        let prev = ring.back().map(|p| (p.start_clock, p.start_host));
+        if let Some((last_clock, last_host)) = prev {
+            if piece.start_clock < last_clock {
+                let regress_ticks = last_clock - piece.start_clock;
                 let regress_us = regress_ticks as f64 * 1.0e6 / f64::from(nominal_freq_hz);
-                let host_delta_us = (piece.start_host - last.start_host) * 1.0e6;
+                let host_delta_us = (piece.start_host - last_host) * 1.0e6;
                 tracing::warn!(
                     subsystem = "motion",
                     event = "history_order_jitter",
@@ -192,16 +193,19 @@ impl HistoryStore {
                     "[history-jitter] projected MCU tick regressed; host schedule time delta"
                 );
             }
-            if piece.start_host < last.start_host {
+            if piece.start_host < last_host {
                 tracing::warn!(
                     subsystem = "motion",
                     event = "history_host_out_of_order",
                     mcu = key.mcu_id,
                     axis = key.axis,
                     start_host = piece.start_host,
-                    last_start_host = last.start_host,
-                    "[history] host schedule time regressed vs previous piece — late segment / ordering bug"
+                    last_start_host = last_host,
+                    "[history] host schedule time regressed vs previous piece — superseding stale tail"
                 );
+                while ring.back().is_some_and(|p| p.start_host > piece.start_host) {
+                    ring.pop_back();
+                }
             }
         }
         if ring.len() == HISTORY_CAPACITY {

--- a/rust/motion-engine/src/motion_history.rs
+++ b/rust/motion-engine/src/motion_history.rs
@@ -135,12 +135,22 @@ impl HistoryStore {
         let piece = HistoryPiece::from_entry(entry, nominal_freq_hz);
         let ring = self.rings.entry(key).or_default();
         if let Some(last) = ring.back() {
-            assert!(
-                piece.start_clock >= last.start_clock,
-                "out-of-order piece for {key:?}: {} < {}",
-                piece.start_clock,
-                last.start_clock
-            );
+            if piece.start_clock < last.start_clock {
+                let regress_ticks = last.start_clock - piece.start_clock;
+                let regress_us = regress_ticks as f64 * 1.0e6 / f64::from(nominal_freq_hz);
+                tracing::warn!(
+                    subsystem = "motion",
+                    event = "history_order_jitter",
+                    mcu = key.mcu_id,
+                    axis = key.axis,
+                    start_clock = piece.start_clock,
+                    last_start_clock = last.start_clock,
+                    regress_ticks,
+                    regress_us,
+                    nominal_freq_hz,
+                    "[history-jitter] projected MCU tick regressed vs previous piece"
+                );
+            }
         }
         if ring.len() == HISTORY_CAPACITY {
             ring.pop_front();

--- a/rust/motion-engine/src/motion_history.rs
+++ b/rust/motion-engine/src/motion_history.rs
@@ -149,13 +149,16 @@ impl HistoryStore {
         ring.push_back(piece);
     }
 
-    /// Drop all recorded history. Called when the dispatch anchor re-anchors
-    /// (`fresh`): the clock baseline jumps, so prior pieces sit on a stale timeline
-    /// and a freshly-recorded piece would otherwise read as out-of-order against
-    /// them. The next pieces re-seed the rings from the new baseline.
-    pub fn clear(&mut self) {
-        self.rings.clear();
-        self.endpoints.clear();
+    /// Drop the stale ring pieces on a dispatch re-anchor (`fresh`): the clock
+    /// baseline jumps, so a freshly-recorded piece would otherwise read as
+    /// out-of-order against pieces on the old timeline. Endpoints are kept, so an
+    /// axis the re-anchored segment does not re-record (e.g. X/Y during a Z-only
+    /// probe move) still answers `state_at_clock` with its held position instead
+    /// of `NoHistoryForAxis` — which the beacon probe `pos` lookup depends on.
+    pub fn drop_pieces_on_reanchor(&mut self) {
+        for ring in self.rings.values_mut() {
+            ring.clear();
+        }
     }
 
     pub fn rebase_axis(&mut self, key: AxisKey, clock: u64, position: f64) {

--- a/rust/motion-engine/src/motion_history.rs
+++ b/rust/motion-engine/src/motion_history.rs
@@ -10,25 +10,28 @@ pub const HISTORY_CAPACITY: usize = 4096;
 #[derive(Debug, thiserror::Error)]
 pub enum HistoryError {
     #[error(
-        "query clock {queried} precedes retained motion history for axis \
-         {key:?} (window {window_start}..{window_end})"
+        "query host time {queried:.6}s precedes retained motion history for axis \
+         {key:?} (window {window_start:.6}..{window_end:.6}s)"
     )]
     BeforeRetainedWindow {
         key: AxisKey,
-        queried: u64,
-        window_start: u64,
-        window_end: u64,
+        queried: f64,
+        window_start: f64,
+        window_end: f64,
     },
 
     #[error(
-        "query clock {queried} is in the future for axis {key:?} \
-         (now≈{now_clock}) — motion history answers the past only"
+        "query host time {queried:.6}s is in the future for axis {key:?} \
+         (now≈{now_host:.6}s) — motion history answers the past only"
     )]
     QueryInFuture {
         key: AxisKey,
-        queried: u64,
-        now_clock: u64,
+        queried: f64,
+        now_host: f64,
     },
+
+    #[error("non-finite query host time for axis {key:?}: {queried}")]
+    NonFiniteQuery { key: AxisKey, queried: f64 },
 
     #[error("no motion history recorded for axis {0:?}")]
     NoHistoryForAxis(AxisKey),
@@ -36,6 +39,7 @@ pub enum HistoryError {
 
 #[derive(Debug, Clone, Copy)]
 pub struct HistoryPiece {
+    pub start_host: f64,
     pub start_clock: u64,
     pub end_clock: u64,
     pub duration_secs: f32,
@@ -43,10 +47,10 @@ pub struct HistoryPiece {
 }
 
 impl HistoryPiece {
-    pub fn from_entry(entry: &PieceEntry, nominal_freq_hz: u32) -> Self {
-        #[allow(clippy::cast_precision_loss)]
+    pub fn from_entry(entry: &PieceEntry, nominal_freq_hz: u32, host_secs: f64) -> Self {
         let end_clock = entry.end_time(nominal_freq_hz as f32);
         Self {
+            start_host: host_secs,
             start_clock: entry.start_time,
             end_clock,
             duration_secs: entry.duration,
@@ -54,9 +58,13 @@ impl HistoryPiece {
         }
     }
 
+    fn end_host(&self) -> f64 {
+        self.start_host + f64::from(self.duration_secs)
+    }
+
     fn endpoint(&self) -> AxisEndpoint {
         AxisEndpoint {
-            clock: self.end_clock,
+            host: self.end_host(),
             position: f64::from(self.coeffs[3]),
         }
     }
@@ -71,7 +79,7 @@ pub struct AxisState {
 
 #[derive(Debug, Clone, Copy)]
 struct AxisEndpoint {
-    clock: u64,
+    host: f64,
     position: f64,
 }
 
@@ -95,12 +103,10 @@ pub fn eval_bernstein_cubic(coeffs: [f32; 4], u: f64) -> f64 {
     v * v * v * b0 + 3.0 * v * v * u * b1 + 3.0 * v * u * u * b2 + u * u * u * b3
 }
 
-fn eval_state(piece: &HistoryPiece, clock: u64) -> AxisState {
-    #[allow(clippy::cast_precision_loss)]
-    let dur_ticks = piece.end_clock.saturating_sub(piece.start_clock) as f64;
-    #[allow(clippy::cast_precision_loss)]
-    let u = if dur_ticks > 0.0 {
-        ((clock - piece.start_clock) as f64 / dur_ticks).clamp(0.0, 1.0)
+fn eval_state(piece: &HistoryPiece, host_t: f64) -> AxisState {
+    let span = f64::from(piece.duration_secs);
+    let u = if span > 0.0 {
+        ((host_t - piece.start_host) / span).clamp(0.0, 1.0)
     } else {
         0.0
     };
@@ -109,7 +115,7 @@ fn eval_state(piece: &HistoryPiece, clock: u64) -> AxisState {
     let b1 = f64::from(piece.coeffs[1]);
     let b2 = f64::from(piece.coeffs[2]);
     let b3 = f64::from(piece.coeffs[3]);
-    let t = f64::from(piece.duration_secs);
+    let t = span;
     let (velocity, acceleration) = if t > 0.0 {
         let db = 3.0 * ((b1 - b0) * v * v + 2.0 * (b2 - b1) * v * u + (b3 - b2) * u * u);
         let d2b = 6.0 * ((b2 - 2.0 * b1 + b0) * v + (b3 - 2.0 * b2 + b1) * u);
@@ -131,24 +137,51 @@ pub struct HistoryStore {
 }
 
 impl HistoryStore {
-    pub fn record(&mut self, key: AxisKey, entry: &PieceEntry, nominal_freq_hz: u32) {
-        let piece = HistoryPiece::from_entry(entry, nominal_freq_hz);
+    pub fn record(
+        &mut self,
+        key: AxisKey,
+        entry: &PieceEntry,
+        nominal_freq_hz: u32,
+        host_secs: f64,
+    ) {
+        if !host_secs.is_finite() {
+            tracing::error!(
+                subsystem = "motion",
+                event = "history_non_finite_host",
+                mcu = key.mcu_id,
+                axis = key.axis,
+                start_clock = entry.start_time,
+                "[history] non-finite host time for piece — skipping record"
+            );
+            return;
+        }
+        let piece = HistoryPiece::from_entry(entry, nominal_freq_hz, host_secs);
         let ring = self.rings.entry(key).or_default();
         if let Some(last) = ring.back() {
             if piece.start_clock < last.start_clock {
                 let regress_ticks = last.start_clock - piece.start_clock;
                 let regress_us = regress_ticks as f64 * 1.0e6 / f64::from(nominal_freq_hz);
+                let host_delta_us = (piece.start_host - last.start_host) * 1.0e6;
                 tracing::warn!(
                     subsystem = "motion",
                     event = "history_order_jitter",
                     mcu = key.mcu_id,
                     axis = key.axis,
-                    start_clock = piece.start_clock,
-                    last_start_clock = last.start_clock,
                     regress_ticks,
                     regress_us,
-                    nominal_freq_hz,
-                    "[history-jitter] projected MCU tick regressed vs previous piece"
+                    host_delta_us,
+                    "[history-jitter] projected MCU tick regressed; host schedule time delta"
+                );
+            }
+            if piece.start_host < last.start_host {
+                tracing::warn!(
+                    subsystem = "motion",
+                    event = "history_host_out_of_order",
+                    mcu = key.mcu_id,
+                    axis = key.axis,
+                    start_host = piece.start_host,
+                    last_start_host = last.start_host,
+                    "[history] host schedule time regressed vs previous piece — late segment / ordering bug"
                 );
             }
         }
@@ -159,52 +192,56 @@ impl HistoryStore {
         ring.push_back(piece);
     }
 
-    /// Drop the stale ring pieces on a dispatch re-anchor (`fresh`): the clock
-    /// baseline jumps, so a freshly-recorded piece would otherwise read as
-    /// out-of-order against pieces on the old timeline. Endpoints are kept, so an
-    /// axis the re-anchored segment does not re-record (e.g. X/Y during a Z-only
-    /// probe move) still answers `state_at_clock` with its held position instead
-    /// of `NoHistoryForAxis` — which the beacon probe `pos` lookup depends on.
+    /// Endpoints are kept, so an axis the re-anchored segment does not re-record
+    /// (e.g. X/Y during a Z-only probe move) still answers `state_at_host` with
+    /// its held position instead of `NoHistoryForAxis` — which the beacon probe
+    /// position lookup depends on.
     pub fn drop_pieces_on_reanchor(&mut self) {
         for ring in self.rings.values_mut() {
             ring.clear();
         }
     }
 
-    pub fn rebase_axis(&mut self, key: AxisKey, clock: u64, position: f64) {
+    pub fn rebase_axis(&mut self, key: AxisKey, host: f64, position: f64) {
         self.rings.entry(key).or_default().clear();
-        self.endpoints.insert(key, AxisEndpoint { clock, position });
+        self.endpoints.insert(key, AxisEndpoint { host, position });
     }
 
-    pub fn last_endpoint_clock(&self, key: AxisKey) -> u64 {
-        self.endpoints.get(&key).map_or(0, |e| e.clock)
+    pub fn last_endpoint_host(&self, key: AxisKey) -> f64 {
+        self.endpoints.get(&key).map_or(0.0, |e| e.host)
     }
 
     pub fn final_position(&self, key: AxisKey) -> Option<f64> {
         self.endpoints.get(&key).map(|e| e.position)
     }
 
-    pub fn state_at_clock(
+    pub fn state_at_host(
         &self,
         key: AxisKey,
-        clock: u64,
-        now_clock: Option<u64>,
+        host_t: f64,
+        now_host: Option<f64>,
     ) -> Result<AxisState, HistoryError> {
+        if !host_t.is_finite() {
+            return Err(HistoryError::NonFiniteQuery {
+                key,
+                queried: host_t,
+            });
+        }
         let ring = self.rings.get(&key).filter(|r| !r.is_empty());
         let hold = match ring {
             Some(ring) => {
-                let idx = ring.partition_point(|p| p.start_clock <= clock);
+                let idx = ring.partition_point(|p| p.start_host <= host_t);
                 if idx == 0 {
                     return Err(HistoryError::BeforeRetainedWindow {
                         key,
-                        queried: clock,
-                        window_start: ring.front().map_or(0, |p| p.start_clock),
-                        window_end: ring.back().map_or(0, |p| p.end_clock),
+                        queried: host_t,
+                        window_start: ring.front().map_or(0.0, |p| p.start_host),
+                        window_end: ring.back().map_or(0.0, |p| p.end_host()),
                     });
                 }
                 let piece = &ring[idx - 1];
-                if clock < piece.end_clock {
-                    return Ok(eval_state(piece, clock));
+                if host_t < piece.end_host() {
+                    return Ok(eval_state(piece, host_t));
                 }
                 piece.endpoint()
             }
@@ -213,17 +250,27 @@ impl HistoryStore {
                 .get(&key)
                 .ok_or(HistoryError::NoHistoryForAxis(key))?,
         };
-        if let Some(now_clock) = now_clock {
-            if clock > now_clock {
+        if let Some(now_host) = now_host {
+            if host_t > now_host {
                 return Err(HistoryError::QueryInFuture {
                     key,
-                    queried: clock,
-                    now_clock,
+                    queried: host_t,
+                    now_host,
                 });
             }
         }
         Ok(hold.hold_state())
     }
+}
+
+pub fn clock_to_host(
+    router: &PassthroughRouter,
+    source: McuHandle,
+    clock: u64,
+) -> Result<f64, String> {
+    router
+        .clock_to_host_secs(source, clock)
+        .ok_or_else(|| format!("clock_to_host_secs returned None for source mcu {source:?}"))
 }
 
 pub fn clock_between_mcus(
@@ -235,9 +282,7 @@ pub fn clock_between_mcus(
     if source == target {
         return Ok(clock);
     }
-    let host_secs = router
-        .clock_to_host_secs(source, clock)
-        .ok_or_else(|| format!("clock_to_host_secs returned None for source mcu {source:?}"))?;
+    let host_secs = clock_to_host(router, source, clock)?;
     router
         .host_time_to_mcu_clock(target, host_secs)
         .map_err(|e| format!("host_time_to_mcu_clock failed for target mcu {target:?}: {e:?}"))

--- a/rust/motion-engine/src/motion_history/tests.rs
+++ b/rust/motion-engine/src/motion_history/tests.rs
@@ -188,6 +188,25 @@ fn eviction_keeps_capacity_and_reports_true_window() {
 }
 
 #[test]
+fn drop_pieces_on_reanchor_keeps_unrecorded_axis_answerable() {
+    let mut store = HistoryStore::default();
+    let moving = AxisKey { mcu_id: 7, axis: 2 };
+    let stationary = AxisKey { mcu_id: 7, axis: 0 };
+    store.record(moving, &linear(0, 1.0, 0.0, 10.0), FREQ);
+    store.record(stationary, &linear(0, 1.0, 3.0, 3.0), FREQ);
+
+    store.drop_pieces_on_reanchor();
+
+    let held = store
+        .state_at_clock(stationary, 5_000_000, Some(10_000_000))
+        .unwrap();
+    assert!((held.position - 3.0).abs() < 1e-6);
+
+    store.record(moving, &linear(2_000_000_000, 1.0, 10.0, 20.0), FREQ);
+    assert_eq!(store.final_position(moving), Some(20.0));
+}
+
+#[test]
 fn rebase_to_earlier_clock_accepts_post_rewind_pieces() {
     let mut store = HistoryStore::default();
     store.record(key(), &linear(3_000_000, 1.0, 0.0, 5.0), FREQ);

--- a/rust/motion-engine/src/motion_history/tests.rs
+++ b/rust/motion-engine/src/motion_history/tests.rs
@@ -58,20 +58,31 @@ fn linear(start_time: u64, duration: f32, p0: f32, p1: f32) -> PieceEntry {
     entry(start_time, duration, [p0, p0 + third, p0 + 2.0 * third, p1])
 }
 
+fn h(clock: u64) -> f64 {
+    clock as f64 / f64::from(FREQ)
+}
+
+fn rec(store: &mut HistoryStore, key: AxisKey, e: PieceEntry) {
+    let host = h(e.start_time);
+    store.record(key, &e, FREQ, host);
+}
+
 #[test]
 fn end_clock_matches_isr_formula() {
     let e = entry(1_000, 0.0123, [0.0; 4]);
-    let h = HistoryPiece::from_entry(&e, FREQ);
-    assert_eq!(h.end_clock, e.end_time(FREQ as f32));
-    assert_eq!(h.start_clock, 1_000);
+    let hp = HistoryPiece::from_entry(&e, FREQ, h(1_000));
+    assert_eq!(hp.end_clock, e.end_time(FREQ as f32));
+    assert_eq!(hp.start_clock, 1_000);
 }
 
 #[test]
 fn linear_piece_position_velocity_acceleration() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(0, 1.0, 0.0, 10.0), FREQ);
-    let mid = FREQ as u64 / 2;
-    let st = store.state_at_clock(key(), mid, Some(u64::MAX)).unwrap();
+    rec(&mut store, key(), linear(0, 1.0, 0.0, 10.0));
+    let mid = h(FREQ as u64 / 2);
+    let st = store
+        .state_at_host(key(), mid, Some(f64::INFINITY))
+        .unwrap();
     assert!((st.position - 5.0).abs() < 1e-6);
     assert!((st.velocity - 10.0).abs() < 1e-6);
     assert!(st.acceleration.abs() < 1e-6);
@@ -80,9 +91,11 @@ fn linear_piece_position_velocity_acceleration() {
 #[test]
 fn quadratic_piece_derivatives() {
     let mut store = HistoryStore::default();
-    store.record(key(), &entry(0, 1.0, [0.0, 0.0, 5.0, 15.0]), FREQ);
-    let mid = FREQ as u64 / 2;
-    let st = store.state_at_clock(key(), mid, Some(u64::MAX)).unwrap();
+    rec(&mut store, key(), entry(0, 1.0, [0.0, 0.0, 5.0, 15.0]));
+    let mid = h(FREQ as u64 / 2);
+    let st = store
+        .state_at_host(key(), mid, Some(f64::INFINITY))
+        .unwrap();
     assert!((st.position - 3.75).abs() < 1e-5);
     assert!((st.velocity - 15.0).abs() < 1e-5);
     assert!((st.acceleration - 30.0).abs() < 1e-4);
@@ -91,15 +104,15 @@ fn quadratic_piece_derivatives() {
 #[test]
 fn gap_between_pieces_holds_previous_endpoint() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(0, 0.001, 0.0, 10.0), FREQ);
-    let gap_start = HistoryPiece::from_entry(&linear(0, 0.001, 0.0, 10.0), FREQ).end_clock;
-    store.record(
+    rec(&mut store, key(), linear(0, 0.001, 0.0, 10.0));
+    let gap_start = HistoryPiece::from_entry(&linear(0, 0.001, 0.0, 10.0), FREQ, 0.0).end_clock;
+    rec(
+        &mut store,
         key(),
-        &linear(gap_start + 1_000_000, 0.001, 10.0, 20.0),
-        FREQ,
+        linear(gap_start + 1_000_000, 0.001, 10.0, 20.0),
     );
     let st = store
-        .state_at_clock(key(), gap_start + 500_000, Some(u64::MAX))
+        .state_at_host(key(), h(gap_start + 500_000), Some(f64::INFINITY))
         .unwrap();
     assert!((st.position - 10.0).abs() < 1e-6);
     assert_eq!(st.velocity, 0.0);
@@ -109,13 +122,13 @@ fn gap_between_pieces_holds_previous_endpoint() {
 #[test]
 fn after_last_piece_holds_when_not_future() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(0, 0.001, 0.0, 10.0), FREQ);
+    rec(&mut store, key(), linear(0, 0.001, 0.0, 10.0));
     let end = store
-        .state_at_clock(key(), 519_999, Some(u64::MAX))
+        .state_at_host(key(), h(519_999), Some(f64::INFINITY))
         .unwrap();
     assert!((end.position - 10.0).abs() < 1e-4);
     let held = store
-        .state_at_clock(key(), 5_000_000, Some(10_000_000))
+        .state_at_host(key(), h(5_000_000), Some(h(10_000_000)))
         .unwrap();
     assert!((held.position - 10.0).abs() < 1e-6);
 }
@@ -123,9 +136,9 @@ fn after_last_piece_holds_when_not_future() {
 #[test]
 fn hold_in_the_future_is_an_error() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(0, 0.001, 0.0, 10.0), FREQ);
+    rec(&mut store, key(), linear(0, 0.001, 0.0, 10.0));
     let err = store
-        .state_at_clock(key(), 5_000_000, Some(1_000_000))
+        .state_at_host(key(), h(5_000_000), Some(h(1_000_000)))
         .unwrap_err();
     assert!(matches!(err, HistoryError::QueryInFuture { .. }));
 }
@@ -133,9 +146,9 @@ fn hold_in_the_future_is_an_error() {
 #[test]
 fn inside_committed_future_piece_evaluates() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(0, 1.0, 0.0, 10.0), FREQ);
+    rec(&mut store, key(), linear(0, 1.0, 0.0, 10.0));
     let st = store
-        .state_at_clock(key(), FREQ as u64 / 2, Some(1_000))
+        .state_at_host(key(), h(FREQ as u64 / 2), Some(h(1_000)))
         .unwrap();
     assert!((st.position - 5.0).abs() < 1e-6);
 }
@@ -143,9 +156,9 @@ fn inside_committed_future_piece_evaluates() {
 #[test]
 fn before_window_is_an_error() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(1_000_000, 0.001, 0.0, 10.0), FREQ);
+    rec(&mut store, key(), linear(1_000_000, 0.001, 0.0, 10.0));
     let err = store
-        .state_at_clock(key(), 500, Some(u64::MAX))
+        .state_at_host(key(), h(500), Some(f64::INFINITY))
         .unwrap_err();
     assert!(matches!(err, HistoryError::BeforeRetainedWindow { .. }));
 }
@@ -153,20 +166,34 @@ fn before_window_is_an_error() {
 #[test]
 fn unknown_axis_is_an_error() {
     let store = HistoryStore::default();
-    let err = store.state_at_clock(key(), 0, Some(u64::MAX)).unwrap_err();
+    let err = store
+        .state_at_host(key(), 0.0, Some(f64::INFINITY))
+        .unwrap_err();
     assert!(matches!(err, HistoryError::NoHistoryForAxis(_)));
+}
+
+#[test]
+fn non_finite_query_is_an_error() {
+    let mut store = HistoryStore::default();
+    rec(&mut store, key(), linear(0, 1.0, 0.0, 10.0));
+    let err = store
+        .state_at_host(key(), f64::NAN, Some(f64::INFINITY))
+        .unwrap_err();
+    assert!(matches!(err, HistoryError::NonFiniteQuery { .. }));
 }
 
 #[test]
 fn rebase_clears_ring_and_answers_from_register() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(0, 1.0, 0.0, 10.0), FREQ);
-    store.rebase_axis(key(), 2_000_000_000, 42.0);
+    rec(&mut store, key(), linear(0, 1.0, 0.0, 10.0));
+    store.rebase_axis(key(), h(2_000_000_000), 42.0);
     let held = store
-        .state_at_clock(key(), 2_000_000_500, Some(3_000_000_000))
+        .state_at_host(key(), h(2_000_000_500), Some(h(3_000_000_000)))
         .unwrap();
     assert!((held.position - 42.0).abs() < 1e-9);
-    let held_before = store.state_at_clock(key(), 1_000, Some(u64::MAX)).unwrap();
+    let held_before = store
+        .state_at_host(key(), h(1_000), Some(f64::INFINITY))
+        .unwrap();
     assert!((held_before.position - 42.0).abs() < 1e-9);
 }
 
@@ -176,12 +203,14 @@ fn eviction_keeps_capacity_and_reports_true_window() {
     let dur = 0.001_f32;
     let dur_ticks = (dur * FREQ as f32) as u64;
     for i in 0..(HISTORY_CAPACITY as u64 + 10) {
-        store.record(key(), &linear(i * dur_ticks, dur, 0.0, 1.0), FREQ);
+        rec(&mut store, key(), linear(i * dur_ticks, dur, 0.0, 1.0));
     }
-    let err = store.state_at_clock(key(), 0, Some(u64::MAX)).unwrap_err();
+    let err = store
+        .state_at_host(key(), 0.0, Some(f64::INFINITY))
+        .unwrap_err();
     match err {
         HistoryError::BeforeRetainedWindow { window_start, .. } => {
-            assert_eq!(window_start, 10 * dur_ticks);
+            assert!((window_start - h(10 * dur_ticks)).abs() < 1e-12);
         }
         other => panic!("expected BeforeRetainedWindow, got {other:?}"),
     }
@@ -192,26 +221,26 @@ fn drop_pieces_on_reanchor_keeps_unrecorded_axis_answerable() {
     let mut store = HistoryStore::default();
     let moving = AxisKey { mcu_id: 7, axis: 2 };
     let stationary = AxisKey { mcu_id: 7, axis: 0 };
-    store.record(moving, &linear(0, 1.0, 0.0, 10.0), FREQ);
-    store.record(stationary, &linear(0, 1.0, 3.0, 3.0), FREQ);
+    rec(&mut store, moving, linear(0, 1.0, 0.0, 10.0));
+    rec(&mut store, stationary, linear(0, 1.0, 3.0, 3.0));
 
     store.drop_pieces_on_reanchor();
 
     let held = store
-        .state_at_clock(stationary, 5_000_000, Some(10_000_000))
+        .state_at_host(stationary, h(5_000_000), Some(h(10_000_000)))
         .unwrap();
     assert!((held.position - 3.0).abs() < 1e-6);
 
-    store.record(moving, &linear(2_000_000_000, 1.0, 10.0, 20.0), FREQ);
+    rec(&mut store, moving, linear(2_000_000_000, 1.0, 10.0, 20.0));
     assert_eq!(store.final_position(moving), Some(20.0));
 }
 
 #[test]
 fn rebase_to_earlier_clock_accepts_post_rewind_pieces() {
     let mut store = HistoryStore::default();
-    store.record(key(), &linear(3_000_000, 1.0, 0.0, 5.0), FREQ);
+    rec(&mut store, key(), linear(3_000_000, 1.0, 0.0, 5.0));
     let held = store.final_position(key()).unwrap();
-    store.rebase_axis(key(), 2_000_000, held);
-    store.record(key(), &linear(2_500_000, 1.0, 5.0, 6.0), FREQ);
+    store.rebase_axis(key(), h(2_000_000), held);
+    rec(&mut store, key(), linear(2_500_000, 1.0, 5.0, 6.0));
     assert_eq!(store.final_position(key()), Some(6.0));
 }

--- a/rust/motion-engine/src/motion_history/tests.rs
+++ b/rust/motion-engine/src/motion_history/tests.rs
@@ -244,3 +244,27 @@ fn rebase_to_earlier_clock_accepts_post_rewind_pieces() {
     rec(&mut store, key(), linear(2_500_000, 1.0, 5.0, 6.0));
     assert_eq!(store.final_position(key()), Some(6.0));
 }
+
+#[test]
+fn legacy_clock_shadow_matches_host_lookup() {
+    let mut store = HistoryStore::default();
+    rec(&mut store, key(), linear(0, 1.0, 0.0, 10.0));
+    let mid_clock = FREQ as u64 / 2;
+    let host = store
+        .state_at_host(key(), h(mid_clock), Some(f64::INFINITY))
+        .unwrap();
+    let shadow = store
+        .state_at_clock_legacy(key(), mid_clock, u64::MAX)
+        .expect("legacy lookup resolves inside a recorded piece");
+    assert!((host.position - shadow.position).abs() < 1e-9);
+}
+
+#[test]
+fn legacy_clock_shadow_none_when_empty() {
+    let store = HistoryStore::default();
+    assert!(
+        store
+            .state_at_clock_legacy(key(), 1_000, u64::MAX)
+            .is_none()
+    );
+}

--- a/rust/motion-engine/src/motion_history/tests.rs
+++ b/rust/motion-engine/src/motion_history/tests.rs
@@ -268,3 +268,33 @@ fn legacy_clock_shadow_none_when_empty() {
             .is_none()
     );
 }
+
+#[test]
+fn backward_host_supersedes_stale_tail() {
+    let mut store = HistoryStore::default();
+    store.record(key(), &linear(0, 0.5, 0.0, 10.0), FREQ, 1.0);
+    store.record(key(), &linear(0, 0.5, 50.0, 60.0), FREQ, 0.2);
+    let st = store
+        .state_at_host(key(), 0.4, Some(f64::INFINITY))
+        .unwrap();
+    assert!((st.position - 54.0).abs() < 1e-6);
+    let held = store
+        .state_at_host(key(), 1.2, Some(f64::INFINITY))
+        .unwrap();
+    assert!((held.position - 60.0).abs() < 1e-6);
+}
+
+#[test]
+fn host_clock_round_trip_is_identity() {
+    let router = stub_router_two_mcus();
+    let h = crate::types::mcu_handle_from_raw(1);
+    let clock = 12_345_678_u64;
+    let host = router.clock_to_host_secs(h, clock).expect("synced mcu");
+    let back = router
+        .host_time_to_mcu_clock(h, host)
+        .expect("synced mcu inverse");
+    assert!(
+        (back as i64 - clock as i64).abs() <= 1,
+        "T then T^-1 must return the original clock (got {back}, want {clock})"
+    );
+}


### PR DESCRIPTION
## Problem
On the Trident, `Z_TILT_ADJUST` crashed intermittently ("moonraker can't connect to klipper") — a hard `SIGABRT`, not a Python exception. The motion-engine planner thread panicked in `HistoryStore::record`'s monotonicity assert:

```
thread 'kalico-stream-planner' panicked at motion_history.rs:138
out-of-order piece for AxisKey { mcu_id: 1, axis: 2 }: 447537601286 < 447537603339   (Z, ~11µs)
```

## Root cause
The history ring was keyed by each piece's projected **MCU start tick**, which is host schedule time run through the clock-sync regression. That regression is re-fit between dispatches, so consecutive committed segments could project a tick *earlier* than the previous piece — even though the schedule time itself (`t0 + intra-segment offset`) is monotonic by construction. The fail-loud assert tripped on the backward tick and took the whole host process down.

The same `start_time` also fed the beacon-probe → toolhead-Z correlation, routing that metrology through the stepper clock model unnecessarily.

## Fix — key the history on host schedule time
- **Monotonic by construction.** `start_host = t0 + offset` can't jitter backward from clock-sync re-fit; the crash class is eliminated at the source, not just demoted. A genuine backward host time (a late segment) logs `history_host_out_of_order` and the ring self-heals (pops the superseded tail) instead of going unsorted.
- **Fewer clock models in metrology.** The beacon (`motion_state_at_clock`) and homing (`reconstruct_axis_position`) readers convert their source-MCU clock to host seconds — the pivot they already computed — and look up by host, dropping the second `host→target-MCU` projection. The stepper clock model leaves the probe-correlation path entirely.
- **Wire unchanged.** The MCU tick still drives the wire, guarded by the existing `PieceStartInPast` fault (host) and `Timer too close` shutdown (MCU). The history check was a redundant third, process-fatal authority on a derived structure.
- **Shadow canary.** Every probe/homing lookup also resolves through the legacy stepper-clock domain and compares; divergence beyond tolerance emits `history_shadow_divergence` — restoring the disagreement signal the re-key removes (guards against host↔MCU frame drift).
- **Epoch identity** pinned by a `T`-then-`T⁻¹` round-trip test (record-side and query-side host time share one router epoch).

## Validation
- Bench: `Z_TILT_ADJUST` ran repeatedly, `Retries: 0/10`, converged, **no crash**, moonraker stayed ready. `history_shadow_divergence = 0` across every probe sample (host-keyed lookup matches the legacy stepper-clock lookup). Probe point spread sub-3µm.
- `./scripts/ci.sh quick` green (ruff, rust-test, rust-clippy `-D warnings`, rust-fmt, watchdog-canary); full workspace `cargo nextest` = 2057 passed.

## Notes / deferred
- The backward-tick race is clock-sync-state-dependent and stayed dormant on a fresh-flashed bench; instrumentation (`history_order_jitter`) + the shadow canary remain in place as a standing trap to size the alarm tolerance empirically if it recurs.
- Full `HostSecs`/`McuClock` newtypes deferred (disproportionate `host-rt` churn vs the existing f64-host/u64-clock split + the epoch round-trip).

Design rationale and the adversarial review are in `_bmad-output/planning-artifacts/plan-history-host-time-keying.md`.