### PR TITLE
refactor(motion-engine): make the fit/plan/lower/dispatch chain readable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ and `query-logs` skills.
 
 - **MCU C/Rust boundary — architectural invariant:** [`docs/rewrite/mcu-c-rust-boundary.md`](docs/rewrite/mcu-c-rust-boundary.md). Read this before adding shared state between C and Rust on the MCU, or before reaching for `#[link_section]` on a Rust static. Rules: C owns boot, safety-critical paths, and all shared-memory placement; Rust owns the motion engine; the seam is `extern "C"` + `#[repr(C)]` only.
 
+- **Motion planner entry point:** `StreamState::commit` in `rust/motion-engine/src/stream.rs` is the pipeline's main function — read it first when exploring the planner. It runs `fit -> plan -> lower -> choose_commit_boundary -> post-process -> advance_state` as a flat sequence of named methods immediately below it in the same file; each step's own logic (corner fitting, velocity solve, per-axis lowering, seam/buffer bookkeeping) lives inside that method rather than inlined into `commit` itself. Segment dispatch to the pump (`stream_planner.rs::dispatch_segment`) is the next stage after `commit` returns.
+
 # Git
 
 Never rewrite git history, never amend commits, never force-push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ and `query-logs` skills.
 
 - **MCU C/Rust boundary — architectural invariant:** [`docs/rewrite/mcu-c-rust-boundary.md`](docs/rewrite/mcu-c-rust-boundary.md). Read this before adding shared state between C and Rust on the MCU, or before reaching for `#[link_section]` on a Rust static. Rules: C owns boot, safety-critical paths, and all shared-memory placement; Rust owns the motion engine; the seam is `extern "C"` + `#[repr(C)]` only.
 
-- **Motion planner entry point:** `StreamState::commit` in `rust/motion-engine/src/stream.rs` is the pipeline's main function — read it first when exploring the planner. It runs `fit -> plan -> lower -> choose_commit_boundary -> post-process -> advance_state` as a flat sequence of named methods immediately below it in the same file; each step's own logic (corner fitting, velocity solve, per-axis lowering, seam/buffer bookkeeping) lives inside that method rather than inlined into `commit` itself. Segment dispatch to the pump (`stream_planner.rs::dispatch_segment`) is the next stage after `commit` returns.
+- **Motion planner entry point:** `StreamState::commit` in `rust/motion-engine/src/stream.rs` is the pipeline's main function — read it first when exploring the planner.
 
 # Git
 

--- a/_bmad-output/implementation-artifacts/spec-pipeline-dispatch-readability.md
+++ b/_bmad-output/implementation-artifacts/spec-pipeline-dispatch-readability.md
@@ -1,0 +1,36 @@
+---
+title: 'Relocate segment-dispatch logic out of an opaque cross-file closure'
+type: 'refactor'
+created: '2026-07-01'
+status: 'done'
+route: 'one-shot'
+context: []
+---
+
+## Relocate segment-dispatch logic out of an opaque cross-file closure
+
+## Intent
+
+**Problem:** To follow one committed `ShapedSegment` from `StreamState::commit()` to the pump, a reader had to jump into an opaque `Arc<dyn Fn>` (`DispatchFn`) that was invoked in `stream_planner.rs` but actually defined ~200 lines away in `bridge.rs`, with no named function marking where the real logic lived.
+
+**Approach:** Extracted the closure's body verbatim into a named free function `dispatch_segment(ctx: &SegmentDispatchCtx, seg: &ShapedSegment)` co-located with its only caller in `stream_planner.rs`; `bridge.rs` now just builds the `SegmentDispatchCtx` (the same `Arc`-cloned state the closure used to capture) and passes a one-line closure calling it. Pure relocation — no algorithm, signature, channel, or threading changes.
+
+## Suggested Review Order
+
+**Where the logic now lives**
+
+- New named home for the dispatch logic, previously an anonymous closure body in `bridge.rs`.
+  [`stream_planner.rs:415`](../../rust/motion-engine/src/stream_planner.rs#L415)
+
+- The context struct that replaces closure-capture — same `Arc`-cloned fields as before, just named.
+  [`stream_planner.rs:401`](../../rust/motion-engine/src/stream_planner.rs#L401)
+
+**Where it's now constructed**
+
+- `bridge.rs` builds the context once and hands a one-line closure to `stream_planner`, instead of the ~100-line inline closure this replaces.
+  [`bridge.rs:3322`](../../rust/motion-engine/src/bridge.rs#L3322)
+
+**Peripherals**
+
+- `dispatch_committed` (unchanged) — the existing caller `dispatch_segment` is now readable next to.
+  [`stream_planner.rs:517`](../../rust/motion-engine/src/stream_planner.rs#L517)

--- a/rust/motion-engine/src/bridge.rs
+++ b/rust/motion-engine/src/bridge.rs
@@ -20,7 +20,8 @@ use crate::config::{self, PlannerConfig};
 use crate::dispatch::{McuAxisConfig, McuCaps, build_mcu_configs};
 use crate::kinematics::{KinematicsModule, SPATIAL_AXES};
 use crate::stream_planner::{
-    DispatchError, HomeDripParams, NudgeParams, StreamPlannerError, StreamPlannerHandle,
+    DispatchError, HomeDripParams, NudgeParams, SegmentDispatchCtx, StreamPlannerError,
+    StreamPlannerHandle,
 };
 use crate::types::{cq_id_from_raw, mcu_handle_from_raw, stats_to_pydict};
 
@@ -3296,128 +3297,44 @@ impl PyMotionEngine {
             }
         }
 
-        let mcu_configs_for_cb = mcu_configs;
-        let router_for_cb = Arc::clone(&router_arc);
+        let mcu_configs_for_ctx = mcu_configs;
+        let router_for_ctx = Arc::clone(&router_arc);
 
         let anchor_mutex = Arc::clone(&self.dispatch_anchor);
         *anchor_mutex.lock().unwrap_or_else(|p| p.into_inner()) = crate::anchor::Anchor::new();
-        let pump_tx_for_cb = data_tx_init.clone();
-        let drain_disp = self.drain.clone();
-        let counter_for_cb = Arc::clone(&counter);
-        let active_drip_cohort_for_cb = Arc::clone(&self.active_drip_cohort);
-        let motion_history_for_cb = Arc::clone(&self.motion_history);
-        let nominal_freqs_for_cb = Arc::clone(&self.nominal_clock_freqs);
+        let pump_tx_for_ctx = data_tx_init.clone();
+        let drain_for_ctx = self.drain.clone();
+        let counter_for_ctx = Arc::clone(&counter);
+        let active_drip_cohort_for_ctx = Arc::clone(&self.active_drip_cohort);
+        let motion_history_for_ctx = Arc::clone(&self.motion_history);
+        let nominal_freqs_for_ctx = Arc::clone(&self.nominal_clock_freqs);
 
-        let nudge_mcu_configs = mcu_configs_for_cb.clone();
-        let nudge_router = Arc::clone(&router_for_cb);
-        let nudge_pump_tx = pump_tx_for_cb.clone();
-        let nudge_drain = drain_disp.clone();
-        let nudge_counter = Arc::clone(&counter_for_cb);
-        let nudge_active_drip_cohort = Arc::clone(&active_drip_cohort_for_cb);
-        let nudge_motion_history = Arc::clone(&motion_history_for_cb);
-        let nudge_nominal_freqs = Arc::clone(&nominal_freqs_for_cb);
+        let nudge_mcu_configs = mcu_configs_for_ctx.clone();
+        let nudge_router = Arc::clone(&router_for_ctx);
+        let nudge_pump_tx = pump_tx_for_ctx.clone();
+        let nudge_drain = drain_for_ctx.clone();
+        let nudge_counter = Arc::clone(&counter_for_ctx);
+        let nudge_active_drip_cohort = Arc::clone(&active_drip_cohort_for_ctx);
+        let nudge_motion_history = Arc::clone(&motion_history_for_ctx);
+        let nudge_nominal_freqs = Arc::clone(&nominal_freqs_for_ctx);
         let nudge_anchor_arc = Arc::clone(&anchor_mutex);
 
+        let dispatch_ctx = Arc::new(SegmentDispatchCtx {
+            router: router_for_ctx,
+            anchor: anchor_mutex,
+            mcu_configs: mcu_configs_for_ctx,
+            pump_tx: pump_tx_for_ctx,
+            drain: drain_for_ctx,
+            counter: counter_for_ctx,
+            active_drip_cohort: active_drip_cohort_for_ctx,
+            motion_history: motion_history_for_ctx,
+            nominal_freqs: nominal_freqs_for_ctx,
+        });
         let dispatch: Arc<
             dyn Fn(&trajectory::ShapedSegment) -> Result<(), DispatchError> + Send + Sync,
         > = Arc::new(
             move |seg: &trajectory::ShapedSegment| -> Result<(), DispatchError> {
-                tracing::debug!(
-                    subsystem = "engine",
-                    event = "dispatch_entered",
-                    seg_t_start = seg.t_start,
-                    seg_t_end = seg.t_end,
-                    "[engine-trace] dispatch entered"
-                );
-
-                let host_now = {
-                    let r = router_for_cb.lock().unwrap_or_else(|p| p.into_inner());
-                    r.host_now_secs()
-                };
-
-                let (t0, fresh) = anchor_mutex
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .anchor_segment(seg.t_start, seg.t_end, host_now);
-
-                if fresh {
-                    let r = router_for_cb.lock().unwrap_or_else(|p| p.into_inner());
-                    for cfg in mcu_configs_for_cb.iter() {
-                        let h = crate::types::mcu_handle_from_raw(cfg.mcu_id);
-                        r.log_seg0_lead(h, t0 + seg.t_start, t0);
-                    }
-                }
-
-                let project = |mcu_id: u32, host_secs: f64| -> u64 {
-                    let r = router_for_cb.lock().unwrap_or_else(|p| p.into_inner());
-                    r.host_time_to_mcu_clock(crate::types::mcu_handle_from_raw(mcu_id), host_secs)
-                        .unwrap_or(0)
-                };
-
-                let active_cohort: Option<u64> = *active_drip_cohort_for_cb
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner());
-
-                let max_piece_secs = if active_cohort.is_some() {
-                    Some(0.025_f64)
-                } else {
-                    None::<f64>
-                };
-                let lead_secs = if active_cohort.is_some() {
-                    crate::pump::DRIP_WINDOW_SECS
-                } else {
-                    crate::pump::MAX_LEAD_SECS
-                };
-
-                let msgs = crate::enqueue::enqueue_segment(
-                    seg,
-                    &mcu_configs_for_cb,
-                    t0,
-                    fresh,
-                    host_now,
-                    lead_secs,
-                    project,
-                    max_piece_secs,
-                );
-
-                let nominal_freqs = nominal_freqs_for_cb
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .clone();
-                if fresh {
-                    motion_history_for_cb
-                        .lock()
-                        .unwrap_or_else(|p| p.into_inner())
-                        .drop_pieces_on_reanchor();
-                }
-                for m in msgs {
-                    let nominal_freq = *nominal_freqs
-                        .get(&m.key.mcu_id)
-                        .ok_or(DispatchError::MissingNominalFreq(m.key.mcu_id))?;
-                    {
-                        let mut store = motion_history_for_cb
-                            .lock()
-                            .unwrap_or_else(|p| p.into_inner());
-                        for (piece, host_t) in &m.pieces {
-                            store.record(m.key, piece, nominal_freq, *host_t);
-                        }
-                    }
-                    drain_disp.add_sent(m.key.mcu_id, m.key.axis, m.pieces.len() as u32);
-                    pump_tx_for_cb
-                        .send(m)
-                        .map_err(|_| DispatchError::PumpGone)?;
-                }
-
-                tracing::info!(
-                    subsystem = "motion",
-                    event = "pipe_pump_in",
-                    line = seg.source_line,
-                    t_us = crate::timing::mono_us(),
-                    "[pipe] handed to pump"
-                );
-
-                counter_for_cb.fetch_add(1, Ordering::Relaxed);
-                Ok(())
+                crate::stream_planner::dispatch_segment(&dispatch_ctx, seg)
             },
         );
 

--- a/rust/motion-engine/src/stream.rs
+++ b/rust/motion-engine/src/stream.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 use geometry::path::lowering::PositionProfile;
 use geometry::path::{Line, Segment};
 use geometry::{
-    ChainFitConfig, FitError, GeometryError, Move, VelocityConfig, VelocityError, VelocityLimits,
-    fit_chain_with_head_restore, plan_velocity_warm_start,
+    ChainFitConfig, FitError, FitOutcome, GeometryError, Move, VelocityConfig, VelocityError,
+    VelocityLimits, VelocityProfile, fit_chain_with_head_restore, plan_velocity_warm_start,
 };
 use nurbs::bezier::{BezierPiece, bezier_pieces_to_nurbs, extract_bezier_pieces};
 use trajectory::{AxisChainSet, ChainStage, CompiledChain, ShapedSegment, ShapedSignal};
@@ -136,6 +136,99 @@ pub enum PostProcessError {
     MissingLookahead { axis: usize, t: f64 },
     #[error("axis {axis}: shaped sample is non-finite at t={t}")]
     NonFiniteSample { axis: usize, t: f64 },
+}
+
+/// Identity + tracing for one `commit()` call. Carries the batch sequence
+/// number and the buffer's line range through `fit`/`plan`/`lower`/
+/// `choose_commit_boundary` so each stage's `tracing` span stays keyed the
+/// same way it was before those stages were split out of `commit()`.
+#[derive(Clone, Copy)]
+struct CommitBatch {
+    seq: u64,
+    line_lo: u32,
+    line_hi: u32,
+}
+
+impl CommitBatch {
+    fn new(moves: &[Move]) -> Self {
+        Self {
+            seq: crate::timing::next_batch_seq(),
+            line_lo: moves.first().map_or(0, |m| m.source.start_line),
+            line_hi: moves.last().map_or(0, |m| m.source.start_line),
+        }
+    }
+
+    fn trace_fit(&self, n_in: usize, n_out: usize, elapsed: std::time::Duration) {
+        tracing::info!(
+            subsystem = "motion",
+            event = "pipe_fit",
+            batch = self.seq,
+            line_lo = self.line_lo,
+            line_hi = self.line_hi,
+            n_in,
+            n_out,
+            fit_us = elapsed.as_micros(),
+            t_us = crate::timing::mono_us(),
+            "[pipe] fit"
+        );
+    }
+
+    fn trace_plan(&self, elapsed: std::time::Duration) {
+        tracing::info!(
+            subsystem = "motion",
+            event = "pipe_plan",
+            batch = self.seq,
+            line_lo = self.line_lo,
+            line_hi = self.line_hi,
+            plan_us = elapsed.as_micros(),
+            t_us = crate::timing::mono_us(),
+            "[pipe] plan"
+        );
+    }
+
+    fn trace_lower(&self, n: usize, elapsed: std::time::Duration) {
+        tracing::info!(
+            subsystem = "motion",
+            event = "pipe_lower",
+            batch = self.seq,
+            line_lo = self.line_lo,
+            line_hi = self.line_hi,
+            n,
+            lower_us = elapsed.as_micros(),
+            t_us = crate::timing::mono_us(),
+            "[pipe] lower"
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn trace_commit_decision(
+        &self,
+        force: bool,
+        n: usize,
+        unblended: usize,
+        commit_count: usize,
+        total_t: f64,
+        barrier: usize,
+        v_barrier: f64,
+        entry_v: f64,
+        t_committed: f64,
+    ) {
+        tracing::info!(
+            subsystem = "motion",
+            event = "commit_decision",
+            batch = self.seq,
+            force,
+            n,
+            unblended,
+            commit_count,
+            total_t,
+            barrier,
+            v_barrier,
+            entry_v,
+            t_committed,
+            "[commit-decision]"
+        );
+    }
 }
 
 /// Streaming look-ahead planner over the new geometry pipeline. Buffers
@@ -327,41 +420,71 @@ impl StreamState {
         }
 
         let moves: Vec<Move> = self.buffer.iter().cloned().collect();
-        let batch = crate::timing::next_batch_seq();
-        let line_lo = moves.first().map_or(0, |m| m.source.start_line);
-        let line_hi = moves.last().map_or(0, |m| m.source.start_line);
+        let batch = CommitBatch::new(&moves);
 
+        let outcome = self.fit(&moves, batch)?;
+        let profile = self.plan(&outcome, batch)?;
+        let (segs, seam_xyz) = self.lower(&outcome, &profile, batch)?;
+
+        let commit_count =
+            self.choose_commit_boundary(force, &outcome, &profile, &seam_xyz, &segs, batch);
+        if commit_count == 0 {
+            return Ok(Vec::new());
+        }
+        let commit_count = self.post_commit_count(commit_count, force, &segs);
+        if commit_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let committed = apply_axis_chains(
+            &self.post_history,
+            &segs,
+            commit_count,
+            force,
+            &self.axis_chains.chains,
+        )?;
+
+        self.advance_state(&outcome, &profile, &committed, commit_count)?;
+        self.post_history
+            .extend(segs.into_iter().take(commit_count));
+        self.trim_post_history();
+
+        Ok(committed)
+    }
+
+    /// Fit the buffered raw moves into G2-continuous geometry (biclothoid
+    /// corner blends). Purely geometric — never reasons about velocity.
+    fn fit(&self, moves: &[Move], batch: CommitBatch) -> Result<FitOutcome, StreamError> {
         let fit_clock = Instant::now();
         let outcome =
-            fit_chain_with_head_restore(&moves, self.config.chain, self.committed_head_len)?;
-        let fit_us = fit_clock.elapsed().as_micros();
-        tracing::info!(
-            subsystem = "motion",
-            event = "pipe_fit",
-            batch,
-            line_lo,
-            line_hi,
-            n_in = moves.len(),
-            n_out = outcome.moves.len(),
-            fit_us,
-            t_us = crate::timing::mono_us(),
-            "[pipe] fit"
-        );
+            fit_chain_with_head_restore(moves, self.config.chain, self.committed_head_len)?;
+        batch.trace_fit(moves.len(), outcome.moves.len(), fit_clock.elapsed());
+        Ok(outcome)
+    }
 
+    /// Plan a jerk-limited S-curve speed profile over the fitted geometry,
+    /// warm-started from the velocity already committed at the last seam.
+    fn plan(
+        &self,
+        outcome: &FitOutcome,
+        batch: CommitBatch,
+    ) -> Result<VelocityProfile, StreamError> {
         let plan_clock = Instant::now();
-        let profile = plan_velocity_warm_start(&outcome, self.config.velocity, self.entry_v)?;
-        let plan_us = plan_clock.elapsed().as_micros();
-        tracing::info!(
-            subsystem = "motion",
-            event = "pipe_plan",
-            batch,
-            line_lo,
-            line_hi,
-            plan_us,
-            t_us = crate::timing::mono_us(),
-            "[pipe] plan"
-        );
+        let profile = plan_velocity_warm_start(outcome, self.config.velocity, self.entry_v)?;
+        batch.trace_plan(plan_clock.elapsed());
+        Ok(profile)
+    }
 
+    /// Lower each fitted move + its velocity profile into a dispatchable
+    /// `ShapedSegment`, advancing a local odometer/clock as it goes. Returns
+    /// the segments alongside each seam's position (needed to judge whether a
+    /// commit boundary there is head-trim-feasible).
+    fn lower(
+        &self,
+        outcome: &FitOutcome,
+        profile: &VelocityProfile,
+        batch: CommitBatch,
+    ) -> Result<(Vec<ShapedSegment>, Vec<[f64; 3]>), StreamError> {
         let n = outcome.moves.len();
         let mut pos = self.odometer.clone();
         let mut t = self.t_committed;
@@ -383,20 +506,23 @@ impl StreamState {
             advance_odometer(&mut pos, gm);
             segs.push(seg);
         }
-        let lower_us = lower_clock.elapsed().as_micros();
-        tracing::info!(
-            subsystem = "motion",
-            event = "pipe_lower",
-            batch,
-            line_lo,
-            line_hi,
-            n,
-            lower_us,
-            t_us = crate::timing::mono_us(),
-            "[pipe] lower"
-        );
-        let total_t = t - self.t_committed;
+        batch.trace_lower(n, lower_clock.elapsed());
+        Ok((segs, seam_xyz))
+    }
 
+    /// Pick the furthest-forward clean (zero-curvature) seam that's still
+    /// head-trim-feasible and inside the finality barrier — the boundary up
+    /// to which this batch commits. `force` commits everything.
+    fn choose_commit_boundary(
+        &mut self,
+        force: bool,
+        outcome: &FitOutcome,
+        profile: &VelocityProfile,
+        seam_xyz: &[[f64; 3]],
+        segs: &[ShapedSegment],
+        batch: CommitBatch,
+    ) -> usize {
+        let n = outcome.moves.len();
         let commit_count = if force {
             n
         } else {
@@ -427,40 +553,36 @@ impl StreamState {
             profile.barrier
         );
         self.last_v_barrier = profile.v_barrier;
-
-        tracing::info!(
-            subsystem = "motion",
-            event = "commit_decision",
-            batch,
+        let total_t = segs.last().map_or(0.0, |s| s.t_end) - self.t_committed;
+        batch.trace_commit_decision(
             force,
             n,
-            unblended = outcome.report.unblended.len(),
+            outcome.report.unblended.len(),
             commit_count,
             total_t,
-            barrier = profile.barrier,
-            v_barrier = profile.v_barrier,
-            entry_v = self.entry_v,
-            t_committed = self.t_committed,
-            "[commit-decision]"
+            profile.barrier,
+            profile.v_barrier,
+            self.entry_v,
+            self.t_committed,
         );
+        commit_count
+    }
 
-        if commit_count == 0 {
-            return Ok(Vec::new());
-        }
-
-        let commit_count = self.post_commit_count(commit_count, force, &segs);
-
-        if commit_count == 0 {
-            return Ok(Vec::new());
-        }
-
-        let committed = apply_axis_chains(
-            &self.post_history,
-            &segs,
-            commit_count,
-            force,
-            &self.axis_chains.chains,
-        )?;
+    /// Advance the odometer/clock/entry-velocity to the new commit boundary,
+    /// then retire committed moves from the buffer — trimming the front to
+    /// the seam and carrying the trimmed length into the next fit's
+    /// blend-budget restore (`committed_head_len`) so the trailing corner
+    /// re-fits to the curvature it had before the head was committed (else a
+    /// shorter front yields a sharper apex and a corner cap below the
+    /// already-committed entry velocity — an `OverCommitted` abort).
+    fn advance_state(
+        &mut self,
+        outcome: &FitOutcome,
+        profile: &VelocityProfile,
+        committed: &[ShapedSegment],
+        commit_count: usize,
+    ) -> Result<(), StreamError> {
+        let n = outcome.moves.len();
 
         let mut seam_pos = self.odometer.clone();
         for gm in outcome.moves.iter().take(commit_count) {
@@ -477,44 +599,36 @@ impl StreamState {
         if commit_count == n {
             self.buffer.clear();
             self.committed_head_len = 0.0;
-        } else {
-            let keep_line = outcome.moves[commit_count].source.start_line;
-            while self
-                .buffer
-                .front()
-                .is_some_and(|m| m.source.start_line < keep_line)
-            {
-                self.buffer.pop_front();
-            }
-            // `keep_line` retires moves wholly before the seam, but a move can be
-            // fully committed yet still carry the seam's source line (a collinear
-            // split or coalesced run emits one move as several pieces). Drop any
-            // front whose geometry has already reached the committed odometer so the
-            // trim below never sees a degenerate (zero-length) remainder.
-            while self.front_reached_odometer() {
-                self.buffer.pop_front();
-            }
-            // The clean seam can fall at an internal sub-piece boundary of the kept
-            // raw move — a blend exit, or a collinear split that emits one move as
-            // several line pieces — leaving the raw move starting behind the
-            // committed odometer. Trim it to start exactly at the seam so the next
-            // re-fit's first piece is C0 with what was just emitted, and feed the
-            // consumed head length back as the next fit's blend-budget restore so the
-            // trailing corner re-fits to the curvature it had before the head was
-            // committed (else a shorter front yields a sharper apex and a corner cap
-            // below the already-committed entry velocity — an OverCommitted abort).
-            self.committed_head_len = if self.front_starts_behind_odometer() {
-                self.trim_front_to_seam()?
-            } else {
-                0.0
-            };
+            return Ok(());
         }
 
-        self.post_history
-            .extend(segs.into_iter().take(commit_count));
-        self.trim_post_history();
-
-        Ok(committed)
+        let keep_line = outcome.moves[commit_count].source.start_line;
+        while self
+            .buffer
+            .front()
+            .is_some_and(|m| m.source.start_line < keep_line)
+        {
+            self.buffer.pop_front();
+        }
+        // `keep_line` retires moves wholly before the seam, but a move can be
+        // fully committed yet still carry the seam's source line (a collinear
+        // split or coalesced run emits one move as several pieces). Drop any
+        // front whose geometry has already reached the committed odometer so the
+        // trim below never sees a degenerate (zero-length) remainder.
+        while self.front_reached_odometer() {
+            self.buffer.pop_front();
+        }
+        // The clean seam can fall at an internal sub-piece boundary of the kept
+        // raw move — a blend exit, or a collinear split that emits one move as
+        // several line pieces — leaving the raw move starting behind the
+        // committed odometer. Trim it to start exactly at the seam so the next
+        // re-fit's first piece is C0 with what was just emitted.
+        self.committed_head_len = if self.front_starts_behind_odometer() {
+            self.trim_front_to_seam()?
+        } else {
+            0.0
+        };
+        Ok(())
     }
 
     /// Materialize the deferred brake-to-rest on a producer-stall watermark.

--- a/rust/motion-engine/src/stream_planner.rs
+++ b/rust/motion-engine/src/stream_planner.rs
@@ -1,6 +1,6 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -393,6 +393,125 @@ fn fatal(msg: &str) -> ! {
     eprintln!("kalico stream planner fatal: {msg}");
     std::thread::sleep(Duration::from_millis(100));
     std::process::abort();
+}
+
+/// State a committed `ShapedSegment` needs to reach the pump: per-MCU clock
+/// anchoring/projection, the axis-lane split, and the motion-history/drain
+/// bookkeeping that split feeds.
+pub(crate) struct SegmentDispatchCtx {
+    pub(crate) router: Arc<Mutex<host_rt::passthrough_queue::PassthroughRouter>>,
+    pub(crate) anchor: Arc<Mutex<crate::anchor::Anchor>>,
+    pub(crate) mcu_configs: Vec<crate::dispatch::McuAxisConfig>,
+    pub(crate) pump_tx: Sender<crate::pump::EnqueueMsg>,
+    pub(crate) drain: Arc<crate::drain::DrainSync>,
+    pub(crate) counter: Arc<AtomicU64>,
+    pub(crate) active_drip_cohort: Arc<Mutex<Option<u64>>>,
+    pub(crate) motion_history: Arc<Mutex<crate::motion_history::HistoryStore>>,
+    pub(crate) nominal_freqs: Arc<Mutex<HashMap<u32, u32>>>,
+}
+
+/// Anchor a committed segment to the MCU clock, split it into per-axis
+/// pieces, and hand each piece to the pump.
+pub(crate) fn dispatch_segment(
+    ctx: &SegmentDispatchCtx,
+    seg: &ShapedSegment,
+) -> Result<(), DispatchError> {
+    tracing::debug!(
+        subsystem = "engine",
+        event = "dispatch_entered",
+        seg_t_start = seg.t_start,
+        seg_t_end = seg.t_end,
+        "[engine-trace] dispatch entered"
+    );
+
+    let host_now = {
+        let r = ctx.router.lock().unwrap_or_else(|p| p.into_inner());
+        r.host_now_secs()
+    };
+
+    let (t0, fresh) = ctx
+        .anchor
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .anchor_segment(seg.t_start, seg.t_end, host_now);
+
+    if fresh {
+        let r = ctx.router.lock().unwrap_or_else(|p| p.into_inner());
+        for cfg in ctx.mcu_configs.iter() {
+            let h = crate::types::mcu_handle_from_raw(cfg.mcu_id);
+            r.log_seg0_lead(h, t0 + seg.t_start, t0);
+        }
+    }
+
+    let project = |mcu_id: u32, host_secs: f64| -> u64 {
+        let r = ctx.router.lock().unwrap_or_else(|p| p.into_inner());
+        r.host_time_to_mcu_clock(crate::types::mcu_handle_from_raw(mcu_id), host_secs)
+            .unwrap_or(0)
+    };
+
+    let active_cohort: Option<u64> = *ctx
+        .active_drip_cohort
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
+    let max_piece_secs = if active_cohort.is_some() {
+        Some(0.025_f64)
+    } else {
+        None::<f64>
+    };
+    let lead_secs = if active_cohort.is_some() {
+        crate::pump::DRIP_WINDOW_SECS
+    } else {
+        crate::pump::MAX_LEAD_SECS
+    };
+
+    let msgs = crate::enqueue::enqueue_segment(
+        seg,
+        &ctx.mcu_configs,
+        t0,
+        fresh,
+        host_now,
+        lead_secs,
+        project,
+        max_piece_secs,
+    );
+
+    let nominal_freqs = ctx
+        .nominal_freqs
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone();
+    if fresh {
+        ctx.motion_history
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .drop_pieces_on_reanchor();
+    }
+    for m in msgs {
+        let nominal_freq = *nominal_freqs
+            .get(&m.key.mcu_id)
+            .ok_or(DispatchError::MissingNominalFreq(m.key.mcu_id))?;
+        {
+            let mut store = ctx.motion_history.lock().unwrap_or_else(|p| p.into_inner());
+            for (piece, host_t) in &m.pieces {
+                store.record(m.key, piece, nominal_freq, *host_t);
+            }
+        }
+        ctx.drain
+            .add_sent(m.key.mcu_id, m.key.axis, m.pieces.len() as u32);
+        ctx.pump_tx.send(m).map_err(|_| DispatchError::PumpGone)?;
+    }
+
+    tracing::info!(
+        subsystem = "motion",
+        event = "pipe_pump_in",
+        line = seg.source_line,
+        t_us = crate::timing::mono_us(),
+        "[pipe] handed to pump"
+    );
+
+    ctx.counter.fetch_add(1, Ordering::Relaxed);
+    Ok(())
 }
 
 fn dispatch_committed(


### PR DESCRIPTION
## Summary
- Relocate the segment-dispatch logic (clock anchoring, per-axis kinematics split, pump handoff) out of an opaque `Arc<dyn Fn>` closure defined in `bridge.rs` into a named `dispatch_segment` function co-located with its caller in `stream_planner.rs`.
- Flatten `StreamState::commit()` in `stream.rs` from one ~190-line function interleaving fit/plan/lower/post-process with buffer/seam/odometer bookkeeping into a flat `fit -> plan -> lower -> choose_commit_boundary -> post-process -> advance_state` sequence, with each step as its own named method.

Both changes are pure relocation/extraction — no algorithm, signature, channel, or threading changes. `head_len_restore`/`OverCommitted` behavior is untouched; that remains a separate, deferred fix.

## Test plan
- [x] `cargo build -p motion-engine`
- [x] `cargo nextest run -p motion-engine` — 377 passed, 1 skipped (unchanged from baseline)
- [x] `cargo clippy -p motion-engine --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Adversarial review of the dispatch relocation (lock ordering, ownership/clone timing, cross-closure evaluation order) — no behavior-affecting defects found; minor hygiene findings patched (dropped unused `Clone` derive, removed unenforced-invariant doc comments, renamed stale `_for_cb` variables)